### PR TITLE
Populate exercises with journey vocabulary

### DIFF
--- a/generators/js/serializer.py
+++ b/generators/js/serializer.py
@@ -31,6 +31,8 @@ class PhaseSerializer:
             "const STORAGE_PREFIX = 'liraJourney';\n",
             "const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;\n",
             "const quizStateCache = {};\n\n",
+            "window.phaseData = phaseVocabularies;\n",
+            "window.phaseKeys = Object.keys(phaseVocabularies);\n\n",
         ]
         return "".join(parts)
 
@@ -40,15 +42,32 @@ class PhaseSerializer:
             phase_id = phase.get("id")
             if not phase_id:
                 continue
+            vocabulary_entries = [self._serialize_vocabulary_entry(word) for word in phase.get("vocabulary", [])]
             phases[phase_id] = {
                 "title": phase.get("title", ""),
                 "description": phase.get("description", ""),
+                "vocabulary": vocabulary_entries,
                 "words": [self._serialize_word(word) for word in phase.get("vocabulary", [])],
                 "quizzes": [self._serialize_quiz(quiz) for quiz in phase.get("quizzes", [])],
                 "quizAttempts": {},
                 "sentenceParts": self._sentence_constructors(phase),
             }
         return phases
+
+    @staticmethod
+    def _serialize_vocabulary_entry(word: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "german": word.get("german", ""),
+            "russian": word.get("russian", ""),
+            "sentence": word.get("sentence", ""),
+            "sentence_translation": word.get("sentence_translation", ""),
+            "russian_hint": word.get("russian_hint", ""),
+            "transcription": word.get("transcription", ""),
+            "themes": _ensure_list(word.get("themes")),
+            "sentence_parts": _ensure_list(word.get("sentence_parts")),
+            "synonyms": _ensure_list(word.get("synonyms")),
+            "visual_hint": word.get("visual_hint", ""),
+        }
 
     @staticmethod
     def _serialize_word(word: Dict[str, Any]) -> Dict[str, Any]:

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["терпеть", "брак", "слабость", "молчание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["терпеть", "брак", "молчание", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["молчание", "терпеть", "уступать", "брак"], "correct_index": 3}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["мягкий", "молчание", "слабость", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["молчание", "слабость", "пассивный", "мягкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["мягкий", "уступать", "пассивный", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["колебаться", "уступать", "пассивный", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «mild»?", "choices": ["терпеть", "мягкий", "уступать", "колебаться"], "correct_index": 1}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["совесть", "подвергать сомнению", "беспокойство", "сомнение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["беспокойство", "сомнение", "совесть", "подвергать сомнению"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["беспокойство", "сомнение", "неуверенный", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["сомнение", "тревожить", "размышлять", "подвергать сомнению"], "correct_index": 3}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "неуверенный", "сомнение", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["сомнение", "совесть", "неуверенный", "подвергать сомнению"], "correct_index": 2}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["беспокойство", "размышлять", "подвергать сомнению", "сомнение"], "correct_index": 1}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["пробуждаться", "осознание", "понимать", "ужас"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["осознание", "ужас", "пробуждаться", "понимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["ясно видеть", "пугаться", "превращение", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["превращение", "просыпаться", "пробуждаться", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["просыпаться", "пугаться", "ужас", "понимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["просыпаться", "ужас", "превращение", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["ясно видеть", "понимать", "просыпаться", "ужас"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["пробуждаться", "превращение", "пугаться", "понимать"], "correct_index": 1}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "противостоять", "мужество", "сопротивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["противостоять", "спор", "мужество", "сопротивление"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["спор", "сопротивление", "противостоять", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["мужество", "защищаться", "противостоять", "обвинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["сопротивление", "противостоять", "обвинять", "защищаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["восставать", "спор", "защищаться", "мужество"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["противостоять", "защищаться", "обвинять", "восставать"], "correct_index": 3}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "решение", "мораль", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "справедливость", "выбирать", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["добродетель", "благородный", "мораль", "решение"], "correct_index": 3}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["благородный", "решение", "справедливость", "выбирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "решение", "добродетель", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["благородный", "принцип", "выбирать", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «edel»?", "choices": ["справедливость", "благородный", "выбирать", "принцип"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["добродетель", "мораль", "принцип", "решение"], "correct_index": 0}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["доброта", "борьба", "наказывать", "право"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["борьба", "право", "наказывать", "доброта"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["судить", "наказывать", "доброта", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["вмешиваться", "право", "борьба", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «richten»?", "choices": ["наказывать", "вмешиваться", "право", "судить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["доброта", "борьба", "защищать", "право"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["защищать", "вмешиваться", "доброта", "право"], "correct_index": 1}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "мудрость", "направлять", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["направлять", "мудрость", "правление", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["новое начало", "направлять", "примирять", "правление"], "correct_index": 0}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["строить", "направлять", "новое начало", "обновлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["обновлять", "правление", "мир", "строить"], "correct_index": 3}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["мудрость", "мир", "обновлять", "новое начало"], "correct_index": 2}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["правление", "направлять", "строить", "примирять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["примирять", "обновлять", "мир", "направлять"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["слабость", "брак", "терпеть", "молчание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "слабость", "молчание", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["слабость", "пассивный", "колебаться", "брак"], "correct_index": 3}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["пассивный", "колебаться", "слабость", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "терпеть", "слабость", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["пассивный", "колебаться", "уступать", "терпеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["колебаться", "брак", "мягкий", "пассивный"], "correct_index": 0}, {"question": "Что означает немецкое слово «mild»?", "choices": ["колебаться", "брак", "пассивный", "мягкий"], "correct_index": 3}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["сомнение", "беспокойство", "совесть", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["сомнение", "совесть", "беспокойство", "подвергать сомнению"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["подвергать сомнению", "неуверенный", "беспокойство", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["сомнение", "неуверенный", "беспокойство", "подвергать сомнению"], "correct_index": 3}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["сомнение", "тревожить", "размышлять", "подвергать сомнению"], "correct_index": 1}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["неуверенный", "совесть", "подвергать сомнению", "тревожить"], "correct_index": 0}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["размышлять", "совесть", "неуверенный", "беспокойство"], "correct_index": 0}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "ужас", "понимать", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["пробуждаться", "понимать", "ужас", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["пробуждаться", "пугаться", "ясно видеть", "ужас"], "correct_index": 0}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["ужас", "пугаться", "понимать", "ясно видеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["ужас", "пугаться", "просыпаться", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["осознание", "ясно видеть", "просыпаться", "пугаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["превращение", "ясно видеть", "понимать", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["ясно видеть", "просыпаться", "превращение", "понимать"], "correct_index": 2}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "противостоять", "мужество", "сопротивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["спор", "сопротивление", "мужество", "противостоять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["противостоять", "сопротивление", "спор", "защищаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["спор", "обвинять", "противостоять", "защищаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["противостоять", "обвинять", "восставать", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["мужество", "сопротивление", "обвинять", "защищаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["обвинять", "восставать", "мужество", "спор"], "correct_index": 1}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["решение", "справедливость", "выбирать", "мораль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "выбирать", "решение", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "праведный", "выбирать", "добродетель"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["принцип", "выбирать", "благородный", "праведный"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["добродетель", "праведный", "выбирать", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["мораль", "принцип", "выбирать", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «edel»?", "choices": ["благородный", "добродетель", "праведный", "мораль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["выбирать", "добродетель", "праведный", "принцип"], "correct_index": 1}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["доброта", "право", "наказывать", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["доброта", "наказывать", "право", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["вмешиваться", "право", "защищать", "доброта"], "correct_index": 3}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["доброта", "наказывать", "борьба", "вмешиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["судить", "право", "доброта", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["право", "наказывать", "защищать", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["борьба", "вмешиваться", "защищать", "право"], "correct_index": 1}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["новое начало", "направлять", "мудрость", "правление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["правление", "новое начало", "направлять", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["мир", "примирять", "новое начало", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["обновлять", "мир", "направлять", "примирять"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "направлять", "обновлять", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["строить", "мудрость", "направлять", "обновлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["мудрость", "примирять", "обновлять", "направлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["новое начало", "направлять", "мудрость", "мир"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -666,11 +666,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
                             
@@ -678,17 +678,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -698,11 +698,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
@@ -714,9 +714,9 @@
                         <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
@@ -726,31 +726,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -764,27 +764,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,29 +797,13 @@
             <div class="quiz-phase-container" data-phase="first_doubts">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                             
@@ -829,17 +813,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -847,6 +847,22 @@
                     
                     <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
@@ -861,49 +877,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,47 +916,15 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
                             
@@ -964,17 +932,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -984,27 +984,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
                             
@@ -1012,31 +996,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
@@ -1071,13 +1071,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1087,13 +1087,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1103,25 +1103,41 @@
                         <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
@@ -1131,33 +1147,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,15 +1170,31 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
@@ -1186,13 +1202,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
                             
@@ -1202,59 +1250,11 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
                             
@@ -1266,33 +1266,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «edel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,47 +1305,15 @@
             <div class="quiz-phase-container" data-phase="justice_seeker">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
@@ -1353,33 +1321,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «richten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1389,13 +1389,13 @@
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1405,11 +1405,11 @@
                         <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">право</button>
                             
@@ -1424,47 +1424,15 @@
             <div class="quiz-phase-container" data-phase="new_ruler">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
                             
@@ -1472,63 +1440,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мир</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                             
@@ -1536,17 +1488,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1568,6 +1568,177 @@
     "passive_duke": {
         "title": "Пассивный герцог",
         "description": "Акт I: Молчаливый муж Гонерильи",
+        "vocabulary": [
+            {
+                "german": "das Schweigen",
+                "russian": "молчание",
+                "sentence": "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron. Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В золотом зале Олбани молча сидит рядом с троном Гонерильи. Моё дыхание рисует слово «молчание» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дас ШВАЙ-ген]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Im goldenen Saal sitzt Albany schweigend neben Gonerils Thron.",
+                    "Mein Atem zeichnet das Wort „das Schweigen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "молчание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Schwäche",
+                "russian": "слабость",
+                "sentence": "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken. Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед ссорящимися сёстрами Олбани складывает руки за спиной. Я держу слово «слабость» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ШВЕ-хе]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Vor den streitenden Schwestern faltet Albany die Hände hinter dem Rücken.",
+                    "Ich halte das Wort „die Schwäche“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "слабость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ehe",
+                "russian": "брак",
+                "sentence": "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken. Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "У окна зала приёмов Олбани наблюдает за плывущими облаками. Я вывожу слово «брак» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди Э-е]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Am Fenster der Audienzhalle betrachtet Albany die vorbeiziehenden Wolken.",
+                    "Ich zeichne das Wort „die Ehe“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "брак"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "dulden",
+                "russian": "терпеть",
+                "sentence": "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig. Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Среди рассеянных советников Олбани покорно кивает всему. Я черчу слово «терпеть» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ДУЛЬ-ден]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerstreuten Ratsmitgliedern nickt Albany zu allem bereitwillig.",
+                    "Ich zeichne das Wort „dulden“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "терпеть",
+                    "erdulden — тоже «терпеть»",
+                    "ertragen — тоже «терпеть»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "passiv",
+                "russian": "пассивный",
+                "sentence": "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite. Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen.",
+                "sentence_translation": "В конце стола Олбани аккуратно откладывает приборы. Как тихая молитва слово «пассивный» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[па-СИФ]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Am Ende der Tafel legt Albany das Besteck ordentlich beiseite.",
+                    "Wie ein stilles Gebet legt sich das Wort „passiv“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "пассивный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "nachgeben",
+                "russian": "уступать",
+                "sentence": "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos. Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus.",
+                "sentence_translation": "Рядом с торжествующей улыбкой Гонерильи Олбани остаётся неподвижным. Я глубоко вдыхаю и выпускаю только слово «уступать».",
+                "russian_hint": "",
+                "transcription": "[НАХ-ге-бен]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Neben Gonerils triumphierendem Lächeln bleibt Albany reglos.",
+                    "Ich atme tief ein und lasse nur das Wort „nachgeben“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "уступать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zögern",
+                "russian": "колебаться",
+                "sentence": "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener. Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На балконе Олбани безмолвно слушает жалобы слуг. Холодный свет заставляет слово «колебаться» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ЦЁ-герн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon lauscht Albany stumm den Beschwerden der Diener.",
+                    "Das kalte Licht lässt das Wort „zögern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "колебаться",
+                    "медлить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "mild",
+                "russian": "мягкий",
+                "sentence": "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen. Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В тени колонн Олбани позволяет спору пройти мимо себя. Моё дыхание рисует слово «мягкий» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[МИЛЬД]",
+                "themes": [
+                    "Ehe",
+                    "Schweigen",
+                    "Schwäche"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Säulen lässt Albany den Streit an sich vorbeiziehen.",
+                    "Mein Atem zeichnet das Wort „mild“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "мягкий"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "das Schweigen",
@@ -1781,9 +1952,9 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "терпеть",
-                    "брак",
                     "слабость",
+                    "брак",
+                    "терпеть",
                     "молчание"
                 ],
                 "correctIndex": 3
@@ -1791,19 +1962,19 @@
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
-                    "терпеть",
                     "брак",
+                    "слабость",
                     "молчание",
-                    "слабость"
+                    "терпеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
-                    "молчание",
-                    "терпеть",
-                    "уступать",
+                    "слабость",
+                    "пассивный",
+                    "колебаться",
                     "брак"
                 ],
                 "correctIndex": 3
@@ -1811,8 +1982,8 @@
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
-                    "мягкий",
-                    "молчание",
+                    "пассивный",
+                    "колебаться",
                     "слабость",
                     "терпеть"
                 ],
@@ -1821,42 +1992,42 @@
             {
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
-                    "молчание",
-                    "слабость",
                     "пассивный",
-                    "мягкий"
+                    "терпеть",
+                    "слабость",
+                    "молчание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
-                    "мягкий",
-                    "уступать",
                     "пассивный",
+                    "колебаться",
+                    "уступать",
                     "терпеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
                     "колебаться",
-                    "уступать",
-                    "пассивный",
-                    "терпеть"
+                    "брак",
+                    "мягкий",
+                    "пассивный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
-                    "терпеть",
-                    "мягкий",
-                    "уступать",
-                    "колебаться"
+                    "колебаться",
+                    "брак",
+                    "пассивный",
+                    "мягкий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -1946,6 +2117,156 @@
     "first_doubts": {
         "title": "Первые сомнения",
         "description": "Акт II: Начинает сомневаться",
+        "vocabulary": [
+            {
+                "german": "der Zweifel",
+                "russian": "сомнение",
+                "sentence": "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen. Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen.",
+                "sentence_translation": "В ночной галерее Олбани рассматривает тускнеющий семейный герб. Как тихая молитва слово «сомнение» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер ЦВАЙ-фель]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "In der nächtlichen Galerie betrachtet Albany das verblassende Familienwappen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Zweifel“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "сомнение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Gewissen",
+                "russian": "совесть",
+                "sentence": "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels. Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten.",
+                "sentence_translation": "Перед зеркалом Олбани впервые замечает тень сомнения. Твёрдым голосом я клянусь себе: слово «совесть» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[дас ге-ВИ-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem Spiegel entdeckt Albany zum ersten Mal den Schatten des Zweifels.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Gewissen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "совесть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Unbehagen",
+                "russian": "беспокойство",
+                "sentence": "Neben gestapelten Tributschriften blättert Albany nervös. Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Рядом с кипами податных свитков Олбани нервно перелистывает страницы. Эхо слова «беспокойство» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[дас УН-бе-ха-ген]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "Neben gestapelten Tributschriften blättert Albany nervös.",
+                    "Das Echo des Wortes „das Unbehagen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "беспокойство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hinterfragen",
+                "russian": "подвергать сомнению",
+                "sentence": "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen. Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten.",
+                "sentence_translation": "Во тёмном дворе Олбани украдкой наблюдает жестокость стражи. Твёрдым голосом я клянусь себе: слово «подвергать сомнению» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ХИН-тер-фра-ген]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Hof beobachtet Albany heimlich die Grausamkeit der Wachen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „hinterfragen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "подвергать",
+                    "сомнению"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beunruhigen",
+                "russian": "тревожить",
+                "sentence": "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch. Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Среди пустых банкетных столов Олбани тянется к наполовину полному кубку. Холодный свет заставляет слово «тревожить» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[бе-УН-ру-и-ген]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "Zwischen verlassenen Banketttischen greift Albany nach einem halb vollen Kelch.",
+                    "Das kalte Licht lässt das Wort „beunruhigen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "тревожить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unsicher",
+                "russian": "неуверенный",
+                "sentence": "Auf dem Flur belauscht Albany ein Gespräch über Lear. Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten.",
+                "sentence_translation": "В коридоре Олбани подслушивает разговор о Лире. Твёрдым голосом я клянусь себе: слово «неуверенный» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[УН-зи-хер]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "Auf dem Flur belauscht Albany ein Gespräch über Lear.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „unsicher“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "неуверенный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "grübeln",
+                "russian": "размышлять",
+                "sentence": "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen. Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В опочивальне Олбани беспокойно скручивает карты королевства. Эхо слова «размышлять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ГРЮ-бельн]",
+                "themes": [
+                    "Gewissen",
+                    "Unbehagen",
+                    "Zweifel"
+                ],
+                "sentence_parts": [
+                    "Im Schlafgemach rollt Albany die Karten des Reiches unruhig zusammen.",
+                    "Das Echo des Wortes „grübeln“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "размышлять",
+                    "nachdenken — тоже «размышлять»",
+                    "sinnen — тоже «размышлять»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Zweifel",
@@ -2133,39 +2454,39 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "совесть",
-                    "подвергать сомнению",
+                    "сомнение",
                     "беспокойство",
-                    "сомнение"
+                    "совесть",
+                    "подвергать сомнению"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "беспокойство",
                     "сомнение",
                     "совесть",
+                    "беспокойство",
                     "подвергать сомнению"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "беспокойство",
-                    "сомнение",
+                    "подвергать сомнению",
                     "неуверенный",
-                    "совесть"
+                    "беспокойство",
+                    "размышлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
                     "сомнение",
-                    "тревожить",
-                    "размышлять",
+                    "неуверенный",
+                    "беспокойство",
                     "подвергать сомнению"
                 ],
                 "correctIndex": 3
@@ -2173,32 +2494,32 @@
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
-                    "тревожить",
-                    "неуверенный",
                     "сомнение",
+                    "тревожить",
+                    "размышлять",
                     "подвергать сомнению"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "сомнение",
-                    "совесть",
                     "неуверенный",
-                    "подвергать сомнению"
+                    "совесть",
+                    "подвергать сомнению",
+                    "тревожить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
-                    "беспокойство",
                     "размышлять",
-                    "подвергать сомнению",
-                    "сомнение"
+                    "совесть",
+                    "неуверенный",
+                    "беспокойство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2278,6 +2599,175 @@
     "awakening": {
         "title": "Пробуждение",
         "description": "Акт III: Осознаёт зло жены",
+        "vocabulary": [
+            {
+                "german": "die Erkenntnis",
+                "russian": "осознание",
+                "sentence": "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht. Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед разбитым зеркалом Олбани понимает собственное бессилие. Моё дыхание рисует слово «осознание» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ер-КЕНТ-нис]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor einem zerschlagenen Spiegel erkennt Albany die eigene Ohnmacht.",
+                    "Mein Atem zeichnet das Wort „die Erkenntnis“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "осознание",
+                    "познание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Entsetzen",
+                "russian": "ужас",
+                "sentence": "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert. Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На пыльном плацу Олбани впервые обнажает меч. Я черчу слово «ужас» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дас энт-ЗЕ-цен]",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
+                "sentence_parts": [
+                    "Auf dem staubigen Kampfplatz zieht Albany zum ersten Mal das Schwert.",
+                    "Ich zeichne das Wort „das Entsetzen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "ужас",
+                    "das Grauen — тоже «ужас»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erwachen",
+                "russian": "пробуждаться",
+                "sentence": "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril. Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Среди взбунтовавшихся слуг Олбани поднимает голос против Гонерильи. Я стискиваю слово «пробуждаться» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ер-ВА-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen aufgebrachten Dienern erhebt Albany die Stimme gegen Goneril.",
+                    "Ich presse das Wort „erwachen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "пробуждаться",
+                    "просыпаться",
+                    "aufwachen — тоже «просыпаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begreifen",
+                "russian": "понимать",
+                "sentence": "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird. Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У окна Олбани видит, как Лира гонят в бурю. Я держу слово «понимать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[бе-ГРАЙ-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Fenster beobachtet Albany Lear, der in den Sturm getrieben wird.",
+                    "Ich halte das Wort „begreifen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "понимать",
+                    "verstehen — тоже «понимать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erschrecken",
+                "russian": "пугаться",
+                "sentence": "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand. Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На дворе Олбани протянутой рукой останавливает жестокую казнь. Холодный свет заставляет слово «пугаться» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ер-ШРЕК-кен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hof stoppt Albany eine grausame Strafe mit ausgestreckter Hand.",
+                    "Das kalte Licht lässt das Wort „erschrecken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "пугать",
+                    "пугаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufwachen",
+                "russian": "просыпаться",
+                "sentence": "Im Kriegssaal zerreißt Albany einen falschen Befehl. Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig.",
+                "sentence_translation": "В военном зале Олбани разрывает ложный приказ. Каждой клеткой тела я обещаю: слово «просыпаться» останется живым.",
+                "russian_hint": "",
+                "transcription": "[АУФ-ва-хен]",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
+                "sentence_parts": [
+                    "Im Kriegssaal zerreißt Albany einen falschen Befehl.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „aufwachen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "просыпаться",
+                    "erwachen — тоже «просыпаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "klar sehen",
+                "russian": "ясно видеть",
+                "sentence": "Neben Kent tauscht Albany einen verständnisvollen Blick. Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten.",
+                "sentence_translation": "Рядом с Кентом Олбани обменивается понимающим взглядом. Твёрдым голосом я клянусь себе: слово «ясно видеть» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[КЛАР ЗЕ-ен]",
+                "themes": [
+                    "Entsetzen",
+                    "Erkenntnis",
+                    "Erwachen"
+                ],
+                "sentence_parts": [
+                    "Neben Kent tauscht Albany einen verständnisvollen Blick.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „klar sehen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "ясно",
+                    "видеть",
+                    "sehen — тоже «видеть»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verwandlung",
+                "russian": "превращение",
+                "sentence": "An der Grenze des Herzogtums schwört Albany dem Unrecht ab. Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На границе герцогства Олбани отрекается от несправедливости. Я вывожу слово «превращение» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ВАНД-лунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "An der Grenze des Herzogtums schwört Albany dem Unrecht ab.",
+                    "Ich zeichne das Wort „die Verwandlung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "превращение"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Erkenntnis",
@@ -2489,82 +2979,82 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "пробуждаться",
                     "осознание",
+                    "ужас",
                     "понимать",
-                    "ужас"
+                    "пробуждаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
-                    "осознание",
-                    "ужас",
                     "пробуждаться",
-                    "понимать"
+                    "понимать",
+                    "ужас",
+                    "осознание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
-                    "ясно видеть",
+                    "пробуждаться",
                     "пугаться",
-                    "превращение",
-                    "пробуждаться"
+                    "ясно видеть",
+                    "ужас"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
-                    "превращение",
-                    "просыпаться",
-                    "пробуждаться",
-                    "понимать"
+                    "ужас",
+                    "пугаться",
+                    "понимать",
+                    "ясно видеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
-                    "просыпаться",
-                    "пугаться",
                     "ужас",
-                    "понимать"
+                    "пугаться",
+                    "просыпаться",
+                    "пробуждаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufwachen»?",
                 "choices": [
+                    "осознание",
+                    "ясно видеть",
                     "просыпаться",
-                    "ужас",
-                    "превращение",
-                    "пробуждаться"
+                    "пугаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «klar sehen»?",
                 "choices": [
+                    "превращение",
                     "ясно видеть",
                     "понимать",
-                    "просыпаться",
-                    "ужас"
+                    "пугаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
-                    "пробуждаться",
+                    "ясно видеть",
+                    "просыпаться",
                     "превращение",
-                    "пугаться",
                     "понимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2654,6 +3144,156 @@
     "confrontation": {
         "title": "Противостояние",
         "description": "Акт IV: Спорит с Гонерильей",
+        "vocabulary": [
+            {
+                "german": "der Streit",
+                "russian": "спор",
+                "sentence": "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir.",
+                "sentence_translation": "В военном лагере Олбани становится перед Гонерильей среди шатров. Буря за окнами усиливает клятву: слово «спор» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дер ШТРАЙТ]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Im Kriegslager stellt sich Albany Goneril mitten zwischen die Zelte.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Streit“ gehört mir."
+                ],
+                "synonyms": [
+                    "спор"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Mut",
+                "russian": "мужество",
+                "sentence": "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen.",
+                "sentence_translation": "Перед собравшимися офицерами Олбани бросает перчатку на стол. Я шепчу стражам судьбы: слово «мужество» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[дер МУТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den versammelten Offizieren wirft Albany den Handschuh auf den Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Mut“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "мужество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Widerstand",
+                "russian": "сопротивление",
+                "sentence": "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden. Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У повозки с оружием Олбани преграждает путь беглянке. Моё дыхание рисует слово «сопротивление» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ВИ-дер-штанд]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Am Wagen voller Waffen blockiert Albany den Weg der Flüchtenden.",
+                    "Mein Atem zeichnet das Wort „der Widerstand“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "сопротивление"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "konfrontieren",
+                "russian": "противостоять",
+                "sentence": "Zwischen wehenden Bannern nennt Albany laut den Verrat. Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под развевающимися знамёнами Олбани громко называет предательство. Я черчу слово «противостоять» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[кон-фрон-ТИ-рен]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Zwischen wehenden Bannern nennt Albany laut den Verrat.",
+                    "Ich zeichne das Wort „konfrontieren“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "противостоять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "anklagen",
+                "russian": "обвинять",
+                "sentence": "Auf dem Felsen bei Dover fordert Albany Edmund heraus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig.",
+                "sentence_translation": "На скале у Дувра Олбани вызывает Эдмунда. Каждой клеткой тела я обещаю: слово «обвинять» останется живым.",
+                "russian_hint": "",
+                "transcription": "[АН-кла-ген]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Auf dem Felsen bei Dover fordert Albany Edmund heraus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „anklagen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "обвинять",
+                    "beschuldigen — тоже «обвинять»",
+                    "verklagen — тоже «обвинять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sich wehren",
+                "russian": "защищаться",
+                "sentence": "Vor der Armee verliest Albany Gonerils geheime Briefe. Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед войском Олбани зачитывает тайные письма Гонерильи. Моё дыхание рисует слово «защищаться» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[зих ВЕ-рен]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Vor der Armee verliest Albany Gonerils geheime Briefe.",
+                    "Mein Atem zeichnet das Wort „sich wehren“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "защищаться",
+                    "wehren — тоже «защищаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufbegehren",
+                "russian": "восставать",
+                "sentence": "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen.",
+                "sentence_translation": "При ярком дневном свете Олбани указывает на предателей без дрожи. Я шепчу стражам судьбы: слово «восставать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[АУФ-бе-ге-рен]",
+                "themes": [
+                    "Mut",
+                    "Streit",
+                    "Widerstand"
+                ],
+                "sentence_parts": [
+                    "Im hellen Tageslicht zeigt Albany auf die Verräter, ohne zu zittern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufbegehren“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "восставать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Streit",
@@ -2852,62 +3492,62 @@
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "противостоять",
                     "спор",
+                    "сопротивление",
                     "мужество",
-                    "сопротивление"
+                    "противостоять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
-                    "спор",
-                    "сопротивление",
                     "противостоять",
-                    "обвинять"
+                    "сопротивление",
+                    "спор",
+                    "защищаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
-                    "мужество",
-                    "защищаться",
+                    "спор",
+                    "обвинять",
                     "противостоять",
-                    "обвинять"
+                    "защищаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "сопротивление",
                     "противостоять",
                     "обвинять",
-                    "защищаться"
+                    "восставать",
+                    "мужество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
-                    "восставать",
-                    "спор",
-                    "защищаться",
-                    "мужество"
+                    "мужество",
+                    "сопротивление",
+                    "обвинять",
+                    "защищаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "противостоять",
-                    "защищаться",
                     "обвинять",
-                    "восставать"
+                    "восставать",
+                    "мужество",
+                    "спор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2987,6 +3627,173 @@
     "moral_stand": {
         "title": "Моральный выбор",
         "description": "Акт IV: Встаёт на сторону добра",
+        "vocabulary": [
+            {
+                "german": "die Moral",
+                "russian": "мораль",
+                "sentence": "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand. Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В шатре союзников Олбани проводит линию на песке. Моё дыхание рисует слово «мораль» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди мо-РАЛЬ]",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
+                "sentence_parts": [
+                    "Im Feldzelt der Verbündeten zeichnet Albany eine Linie in den Sand.",
+                    "Mein Atem zeichnet das Wort „die Moral“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "мораль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gerechtigkeit",
+                "russian": "справедливость",
+                "sentence": "Zwischen verletzten Soldaten spricht Albany von Gnade. Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Среди раненых солдат Олбани говорит о милосердии. Моё дыхание рисует слово «справедливость» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ге-РЕХ-тиг-кайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen verletzten Soldaten spricht Albany von Gnade.",
+                    "Mein Atem zeichnet das Wort „die Gerechtigkeit“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "справедливость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Entscheidung",
+                "russian": "решение",
+                "sentence": "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn. Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Над картой сражения Олбани выдвигает вперёд фигуры праведников. Я вывожу слово «решение» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди энт-ШАЙ-дунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Schlachtplan stellt Albany die Figuren der Gerechten nach vorn.",
+                    "Ich zeichne das Wort „die Entscheidung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "решение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "wählen",
+                "russian": "выбирать",
+                "sentence": "Im Rat der Feldherren widerspricht Albany einer grausamen Idee. Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus.",
+                "sentence_translation": "На совете полководцев Олбани возражает жестокой задумке. Я глубоко вдыхаю и выпускаю только слово «выбирать».",
+                "russian_hint": "",
+                "transcription": "[ВЕ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Rat der Feldherren widerspricht Albany einer grausamen Idee.",
+                    "Ich atme tief ein und lasse nur das Wort „wählen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "выбирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "rechtschaffen",
+                "russian": "праведный",
+                "sentence": "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Перед знаменем правды Олбани поднимает голос для клятвы. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[РЕХТ-ша-фен]",
+                "themes": [
+                    "Adel",
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral",
+                    "dienen",
+                    "vertrauen"
+                ],
+                "sentence_parts": [
+                    "Vor dem Banner der Wahrheit hebt Albany die Stimme zu einem Eid.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "праведный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Prinzip",
+                "russian": "принцип",
+                "sentence": "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet. Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen.",
+                "sentence_translation": "На холме над полем битвы Олбани произносит торжественную молитву. Как тихая молитва слово «принцип» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дас прин-ЦИП]",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hügel über dem Schlachtfeld hält Albany ein feierliches Gebet.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Prinzip“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "принцип"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "edel",
+                "russian": "благородный",
+                "sentence": "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden. Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern.",
+                "sentence_translation": "В утреннем солнце Олбани смывает кровь с меча и клянётся миром. Даже если мир распадается, слово «благородный» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[Э-дель]",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
+                "sentence_parts": [
+                    "In der Morgensonne wäscht Albany das Blut vom Schwert und schwört Frieden.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „edel“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "благородный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Tugend",
+                "russian": "добродетель",
+                "sentence": "Bei den Feldärzten verspricht Albany Schutz den Verwundeten. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen.",
+                "sentence_translation": "У полевых лекарей Олбани обещает защиту раненым. Я шепчу стражам судьбы: слово «добродетель» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ТУ-генд]",
+                "themes": [
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral"
+                ],
+                "sentence_parts": [
+                    "Bei den Feldärzten verspricht Albany Schutz den Verwundeten.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Tugend“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "добродетель"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Moral",
@@ -3204,57 +4011,57 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "выбирать",
                     "решение",
-                    "мораль",
-                    "справедливость"
+                    "справедливость",
+                    "выбирать",
+                    "мораль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "мораль",
-                    "справедливость",
+                    "выбирать",
+                    "решение",
+                    "справедливость"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Entscheidung»?",
+                "choices": [
+                    "решение",
+                    "праведный",
+                    "выбирать",
+                    "добродетель"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «wählen»?",
+                "choices": [
+                    "принцип",
+                    "выбирать",
+                    "благородный",
+                    "праведный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «rechtschaffen»?",
+                "choices": [
+                    "добродетель",
+                    "праведный",
                     "выбирать",
                     "решение"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Entscheidung»?",
-                "choices": [
-                    "добродетель",
-                    "благородный",
-                    "мораль",
-                    "решение"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «wählen»?",
-                "choices": [
-                    "благородный",
-                    "решение",
-                    "справедливость",
-                    "выбирать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «rechtschaffen»?",
-                "choices": [
-                    "праведный",
-                    "решение",
-                    "добродетель",
-                    "справедливость"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
-                    "благородный",
+                    "мораль",
                     "принцип",
                     "выбирать",
                     "решение"
@@ -3264,22 +4071,22 @@
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
-                    "справедливость",
                     "благородный",
-                    "выбирать",
-                    "принцип"
+                    "добродетель",
+                    "праведный",
+                    "мораль"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
+                    "выбирать",
                     "добродетель",
-                    "мораль",
-                    "принцип",
-                    "решение"
+                    "праведный",
+                    "принцип"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3369,6 +4176,152 @@
     "justice_seeker": {
         "title": "Поиск справедливости",
         "description": "Акт V: Борется за правду",
+        "vocabulary": [
+            {
+                "german": "der Kampf",
+                "russian": "борьба",
+                "sentence": "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl. Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На трибунале Олбани ставит простой деревянный стул как судейский. Я вывожу слово «борьба» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[дер КАМПФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Tribunal errichtet Albany einen einfachen Holzstuhl als Richterstuhl.",
+                    "Ich zeichne das Wort „der Kampf“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "бой",
+                    "борьба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Recht",
+                "russian": "право",
+                "sentence": "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir.",
+                "sentence_translation": "Перед уцелевшими солдатами Олбани читает имена виновных. Буря за окнами усиливает клятву: слово «право» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дас РЕХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den überlebenden Soldaten verliest Albany die Namen der Schuldigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Recht“ gehört mir."
+                ],
+                "synonyms": [
+                    "право"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Güte",
+                "russian": "доброта",
+                "sentence": "In der Kapelle legt Albany die Hand auf die Bibel, bevor er urteilt. Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В капелле Олбани кладёт руку на Библию, прежде чем судить. Эхо слова «доброта» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ГЮ-те]",
+                "themes": [
+                    "Güte",
+                    "Kampf",
+                    "Recht"
+                ],
+                "sentence_parts": [
+                    "In der Kapelle legt Albany die Hand auf die Bibel,",
+                    "bevor er urteilt.",
+                    "Das Echo des Wortes „die Güte“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "доброта"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "strafen",
+                "russian": "наказывать",
+                "sentence": "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen. Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "У ворот Дувра Олбани встречает возвращающихся с распахнутыми руками. Я черчу слово «наказывать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ШТРА-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Tor von Dover begrüßt Albany die Rückkehrer mit offenen Armen.",
+                    "Ich zeichne das Wort „strafen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "наказывать",
+                    "bestrafen — тоже «наказывать»",
+                    "züchtigen — тоже «наказывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "richten",
+                "russian": "судить",
+                "sentence": "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden. Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В походном лагере Олбани собирает свидетельства выживших. Я вывожу слово «судить» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[РИХ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Feldlager sammelt Albany Zeugnisse der Überlebenden.",
+                    "Ich zeichne das Wort „richten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "судить",
+                    "urteilen — тоже «судить»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beschützen",
+                "russian": "защищать",
+                "sentence": "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit. Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Среди смолкших барабанов Олбани зачитывает приказ о справедливости. Я черчу слово «защищать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[бе-ШЮ-цен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstummten Trommeln verliest Albany den Befehl zur Gerechtigkeit.",
+                    "Ich zeichne das Wort „beschützen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "защищать",
+                    "schützen — тоже «защищать»",
+                    "verteidigen — тоже «защищать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "eingreifen",
+                "russian": "вмешиваться",
+                "sentence": "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern. Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В тени разрушенного замка Олбани клянётся обновить королевство. Я черчу слово «вмешиваться» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[АЙН-грай-фен]",
+                "themes": [
+                    "Güte",
+                    "Kampf",
+                    "Recht"
+                ],
+                "sentence_parts": [
+                    "Im Schatten des zerstörten Schlosses schwört Albany das Reich zu erneuern.",
+                    "Ich zeichne das Wort „eingreifen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "вмешиваться"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Kampf",
@@ -3558,68 +4511,68 @@
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "доброта",
-                    "борьба",
+                    "право",
                     "наказывать",
-                    "право"
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
-                    "борьба",
-                    "право",
-                    "наказывать",
-                    "доброта"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Güte»?",
-                "choices": [
-                    "судить",
-                    "наказывать",
                     "доброта",
+                    "наказывать",
+                    "право",
                     "борьба"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «strafen»?",
+                "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
                     "вмешиваться",
                     "право",
-                    "борьба",
-                    "наказывать"
+                    "защищать",
+                    "доброта"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «strafen»?",
+                "choices": [
+                    "доброта",
+                    "наказывать",
+                    "борьба",
+                    "вмешиваться"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
-                    "наказывать",
-                    "вмешиваться",
+                    "судить",
                     "право",
-                    "судить"
+                    "доброта",
+                    "защищать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "доброта",
-                    "борьба",
+                    "право",
+                    "наказывать",
                     "защищать",
-                    "право"
+                    "борьба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "защищать",
+                    "борьба",
                     "вмешиваться",
-                    "доброта",
+                    "защищать",
                     "право"
                 ],
                 "correctIndex": 1
@@ -3703,6 +4656,187 @@
     "new_ruler": {
         "title": "Новый правитель",
         "description": "Акт V: Становится мудрым лидером",
+        "vocabulary": [
+            {
+                "german": "die Herrschaft",
+                "russian": "правление",
+                "sentence": "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen.",
+                "sentence_translation": "В зале, полном раненых, Олбани раздаёт мягкие слова и приказы одновременно. Я шепчу стражам судьбы: слово «правление» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ХЕР-шафт]",
+                "themes": [
+                    "Herrschaft",
+                    "Macht",
+                    "Neuanfang",
+                    "Weisheit",
+                    "befehlen",
+                    "herrschen"
+                ],
+                "sentence_parts": [
+                    "Im Saal voller Verwundeter verteilt Albany sanfte Worte und Befehle zugleich.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Herrschaft“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "правление",
+                    "господство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Weisheit",
+                "russian": "мудрость",
+                "sentence": "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf. Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На временном троне Олбани вновь поднимает королевство. Эхо слова «мудрость» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ВАЙС-хайт]",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Auf dem behelfsmäßigen Thron richtet Albany das Reich wieder auf.",
+                    "Das Echo des Wortes „die Weisheit“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "мудрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Neuanfang",
+                "russian": "новое начало",
+                "sentence": "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph. Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Среди засохших венков Олбани носит новую корону без торжества. Я обнимаю слово «новое начало», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер НОЙ-ан-фанг]",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Zwischen vertrockneten Kränzen trägt Albany die neue Krone ohne Triumph.",
+                    "Ich umarme das Wort „der Neuanfang“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "новое",
+                    "начало"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "lenken",
+                "russian": "направлять",
+                "sentence": "Vor dem Volk verspricht Albany Heilung für das verwundete Land. Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Перед народом Олбани обещает исцеление раненой земле. Эхо слова «направлять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ЛЕН-кен]",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Vor dem Volk verspricht Albany Heilung für das verwundete Land.",
+                    "Das Echo des Wortes „lenken“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "направлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufbauen",
+                "russian": "строить",
+                "sentence": "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor. Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На ступенях храма Олбани чтит павших. Я держу слово «строить» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[АУФ-бау-ен]",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Auf den Stufen des Tempels hebt Albany die Gefallenen in Ehren hervor.",
+                    "Ich halte das Wort „aufbauen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "строить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erneuern",
+                "russian": "обновлять",
+                "sentence": "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir.",
+                "sentence_translation": "Под развевающимися флагами Олбани велит бить колоколам надежды. Буря за окнами усиливает клятву: слово «обновлять» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ер-НОЙ-ерн]",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Flaggen lässt Albany die Glocken der Hoffnung schlagen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erneuern“ gehört mir."
+                ],
+                "synonyms": [
+                    "обновлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "versöhnen",
+                "russian": "примирять",
+                "sentence": "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet. Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern.",
+                "sentence_translation": "На совете выживших Олбани выслушивает каждого, прежде чем решать. Даже если мир распадается, слово «примирять» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[фер-ЗЁ-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Rat der Überlebenden hört Albany jedem zu, bevor er entscheidet.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „versöhnen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "примирять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Friede",
+                "russian": "мир",
+                "sentence": "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen. Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "У берега Дувра Олбани отправляет в море новые корабли для защиты. Я черчу слово «мир» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер ФРИ-де]",
+                "themes": [
+                    "Herrschaft",
+                    "Neuanfang",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "An der Küste von Dover lässt Albany neue Schiffe zum Schutz auslaufen.",
+                    "Ich zeichne das Wort „der Friede“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "мир",
+                    "die Welt — тоже «мир»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Herrschaft",
@@ -3930,82 +5064,82 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "правление",
-                    "мудрость",
+                    "новое начало",
                     "направлять",
-                    "новое начало"
+                    "мудрость",
+                    "правление"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "направлять",
-                    "мудрость",
                     "правление",
-                    "новое начало"
+                    "новое начало",
+                    "направлять",
+                    "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "новое начало",
-                    "направлять",
+                    "мир",
                     "примирять",
-                    "правление"
+                    "новое начало",
+                    "мудрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
-                    "строить",
+                    "обновлять",
+                    "мир",
                     "направлять",
-                    "новое начало",
-                    "обновлять"
+                    "примирять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
+                    "строить",
+                    "направлять",
                     "обновлять",
-                    "правление",
-                    "мир",
-                    "строить"
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "мудрость",
-                    "мир",
-                    "обновлять",
-                    "новое начало"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «versöhnen»?",
-                "choices": [
-                    "правление",
-                    "направлять",
                     "строить",
-                    "примирять"
+                    "мудрость",
+                    "направлять",
+                    "обновлять"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «der Friede»?",
+                "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
+                    "мудрость",
                     "примирять",
                     "обновлять",
-                    "мир",
                     "направлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Friede»?",
+                "choices": [
+                    "новое начало",
+                    "направлять",
+                    "мудрость",
+                    "мир"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4098,6 +5232,9 @@ const characterId = "albany";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["власть", "церемония", "провозглашать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "правда", "провозглашать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["правда", "торжественный", "провозглашать", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["долг", "власть", "повиноваться", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["долг", "правда", "церемония", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["церемония", "долг", "торжественный", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["долг", "торжественный", "власть", "провозглашать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["провозглашать", "власть", "долг", "верность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["наказание", "изгонять", "гнев", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "покидать", "наказание", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "гнев", "надежда", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "покидать", "приданое", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["чужой", "приданое", "надежда", "принимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["надежда", "приданое", "изгонять", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["гнев", "наказание", "чужой", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["покидать", "гнев", "принимать", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["одиночество", "страх", "известие", "забота"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["забота", "одиночество", "известие", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "защищать", "страдать", "забота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["известие", "тоска", "страх", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "одиночество", "защищать", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["тоска", "защищать", "известие", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["известие", "тоска", "защищать", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["страдать", "одиночество", "молиться", "забота"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "битва", "спасать", "возвращаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "битва", "спасать", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «retten»?", "choices": ["побеждать", "спасать", "армия", "храбрый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["возвращаться", "справедливость", "армия", "битва"], "correct_index": 3}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["справедливость", "армия", "храбрый", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["борьба", "возвращаться", "справедливость", "побеждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["справедливость", "побеждать", "битва", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["борьба", "спасать", "армия", "храбрый"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "слёзы", "узнавать", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "обнимать", "прощать", "слёзы"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощать", "исцелять", "нежный", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["слёзы", "исцелять", "узнавать", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["обнимать", "исцелять", "узнавать", "нежный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "прощать", "исцелять", "слёзы"], "correct_index": 0}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["прощение", "слёзы", "узнавать", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["прощение", "нежный", "обнимать", "прощать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["достоинство", "утешать", "пленный", "тюрьма"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["тюрьма", "утешать", "достоинство", "пленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["утешать", "судьба", "пленный", "достоинство"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["достоинство", "отважный", "смирение", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "смирение", "достоинство", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["утешать", "достоинство", "смирение", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["утешать", "тюрьма", "пленный", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["отважный", "достоинство", "тюрьма", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["жертва", "умирать", "душа", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["душа", "умирать", "смерть", "жертва"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["умирать", "спасение", "вечный", "жертва"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["душа", "конец", "прощание", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "спасение", "смерть", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "конец", "смерть", "душа"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "вечный", "смерть", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["умирать", "жертва", "прощание", "спасение"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "власть", "провозглашать", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["провозглашать", "власть", "правда", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["церемония", "верность", "торжественный", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "долг", "повиноваться", "торжественный"], "correct_index": 0}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["правда", "повиноваться", "торжественный", "церемония"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["провозглашать", "власть", "правда", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["повиноваться", "торжественный", "верность", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["долг", "верность", "правда", "власть"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "наказание", "гнев", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "наказание", "покидать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "надежда", "чужой", "принимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "наказание", "надежда", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["покидать", "приданое", "чужой", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "гнев", "наказание", "чужой"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["приданое", "покидать", "изгонять", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["надежда", "покидать", "гнев", "чужой"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["одиночество", "известие", "страх", "забота"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "известие", "одиночество", "забота"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "забота", "защищать", "одиночество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["тоска", "защищать", "молиться", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "страх", "известие", "одиночество"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["известие", "страх", "тоска", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["одиночество", "страдать", "молиться", "тоска"], "correct_index": 3}, {"question": "Что означает немецкое слово «beten»?", "choices": ["защищать", "страдать", "молиться", "известие"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["битва", "возвращаться", "борьба", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "битва", "спасать", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["возвращаться", "битва", "храбрый", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["справедливость", "битва", "побеждать", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["возвращаться", "спасать", "храбрый", "армия"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["храбрый", "армия", "битва", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["храбрый", "побеждать", "спасать", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["борьба", "армия", "храбрый", "спасать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["обнимать", "прощать", "слёзы", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "слёзы", "обнимать", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["нежный", "прощать", "обнимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["нежный", "узнавать", "прощение", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["узнавать", "исцелять", "нежный", "прощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["исцелять", "раскаяние", "нежный", "прощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["нежный", "слёзы", "раскаяние", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["прощение", "раскаяние", "исцелять", "прощать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "тюрьма", "достоинство", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "пленный", "утешать", "тюрьма"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["судьба", "достоинство", "пленный", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "отважный", "пленный", "достоинство"], "correct_index": 0}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["судьба", "отважный", "достоинство", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["утешать", "смирение", "тюрьма", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["пленный", "отважный", "тюрьма", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["смирение", "судьба", "тюрьма", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "душа", "смерть", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["душа", "смерть", "жертва", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["прощание", "жертва", "спасение", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["спасение", "смерть", "душа", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "конец", "смерть", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "жертва", "прощание", "спасение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["спасение", "вечный", "конец", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["прощание", "смерть", "спасение", "вечный"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,45 +662,13 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
@@ -710,49 +678,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,29 +762,29 @@
                         <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,13 +797,13 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -813,15 +813,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -829,77 +829,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
                             
@@ -909,17 +845,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,9 +938,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
@@ -948,17 +948,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,27 +970,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1002,23 +1002,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
@@ -1028,17 +1012,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1048,13 +1048,13 @@
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,65 +1067,65 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1135,29 +1135,29 @@
                         <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1167,29 +1167,29 @@
                         <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,65 +1202,65 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1270,45 +1270,45 @@
                         <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1320,9 +1320,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
@@ -1337,15 +1337,31 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
                             
@@ -1353,29 +1369,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
                             
@@ -1385,49 +1401,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1437,11 +1437,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
@@ -1453,9 +1453,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
@@ -1472,47 +1472,63 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
@@ -1520,33 +1536,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1558,11 +1558,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1572,11 +1572,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
@@ -1584,17 +1584,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1616,6 +1616,173 @@
     "throne": {
         "title": "Тронный зал",
         "description": "Акт I: Честная любовь",
+        "vocabulary": [
+            {
+                "german": "die Wahrheit",
+                "russian": "правда",
+                "sentence": "Die Wahrheit über den Vorfall wurde gestern bekannt.",
+                "sentence_translation": "Правда о происшествии стала известна вчера.",
+                "russian_hint": "",
+                "transcription": "[ди ВАР-хайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Wahrheit über den Vorfall",
+                    "wurde gestern bekannt."
+                ],
+                "synonyms": [
+                    "правда"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Zeremonie",
+                "russian": "церемония",
+                "sentence": "Die feierliche Zeremonie der Krönung beginnt um Mittag.",
+                "sentence_translation": "Торжественная церемония коронации начинается в полдень.",
+                "russian_hint": "",
+                "transcription": "[ди це-ре-мо-НИ]",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Die feierliche Zeremonie der Krönung",
+                    "beginnt um Mittag."
+                ],
+                "synonyms": [
+                    "церемония"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verkünden",
+                "russian": "провозглашать",
+                "sentence": "Der Präsident wird morgen seine Entscheidung verkünden.",
+                "sentence_translation": "Президент завтра провозгласит своё решение.",
+                "russian_hint": "",
+                "transcription": "[фер-КЮН-ден]",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Der Präsident wird morgen",
+                    "seine Entscheidung verkünden."
+                ],
+                "synonyms": [
+                    "провозглашать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Macht",
+                "russian": "власть",
+                "sentence": "Die Macht des neuen Gesetzes ist sehr begrenzt.",
+                "sentence_translation": "Власть нового закона очень ограничена.",
+                "russian_hint": "",
+                "transcription": "[ди МАХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Macht des neuen Gesetzes",
+                    "ist sehr begrenzt."
+                ],
+                "synonyms": [
+                    "власть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gehorchen",
+                "russian": "повиноваться",
+                "sentence": "Kinder sollten ihren Eltern gehorchen und respektieren.",
+                "sentence_translation": "Дети должны повиноваться родителям и уважать их.",
+                "russian_hint": "",
+                "transcription": "[ге-ХОР-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Kinder sollten ihren Eltern",
+                    "gehorchen und respektieren."
+                ],
+                "synonyms": [
+                    "повиноваться",
+                    "подчиняться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Pflicht",
+                "russian": "долг",
+                "sentence": "Es ist meine Pflicht, pünktlich zur Arbeit zu kommen.",
+                "sentence_translation": "Мой долг - приходить на работу вовремя.",
+                "russian_hint": "",
+                "transcription": "[ди ПФЛИХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Es ist meine Pflicht,",
+                    "pünktlich zur Arbeit zu kommen."
+                ],
+                "synonyms": [
+                    "долг"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "feierlich",
+                "russian": "торжественный",
+                "sentence": "Der feierliche Empfang fand im großen Saal statt.",
+                "sentence_translation": "Торжественный приём проходил в большом зале.",
+                "russian_hint": "",
+                "transcription": "[ФАЙ-ер-лих]",
+                "themes": [
+                    "Ehrlichkeit",
+                    "Liebe",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Der feierliche Empfang",
+                    "fand im großen Saal statt."
+                ],
+                "synonyms": [
+                    "торжественный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Treue",
+                "russian": "верность",
+                "sentence": "Die Treue zu seinen Freunden ist bewundernswert.",
+                "sentence_translation": "Верность своим друзьям достойна восхищения.",
+                "russian_hint": "",
+                "transcription": "[ди ТРОЙ-е]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Treue zu seinen Freunden",
+                    "ist bewundernswert."
+                ],
+                "synonyms": [
+                    "верность"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Wahrheit",
@@ -1840,82 +2007,82 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "власть",
-                    "церемония",
-                    "провозглашать",
-                    "правда"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Zeremonie»?",
-                "choices": [
-                    "церемония",
                     "правда",
+                    "власть",
                     "провозглашать",
-                    "власть"
+                    "церемония"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verkünden»?",
+                "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "правда",
-                    "торжественный",
                     "провозглашать",
-                    "церемония"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Macht»?",
-                "choices": [
-                    "долг",
                     "власть",
-                    "повиноваться",
-                    "верность"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «gehorchen»?",
-                "choices": [
-                    "долг",
                     "правда",
-                    "церемония",
-                    "повиноваться"
+                    "церемония"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Pflicht»?",
+                "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
                     "церемония",
-                    "долг",
+                    "верность",
                     "торжественный",
-                    "верность"
+                    "провозглашать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Macht»?",
+                "choices": [
+                    "власть",
+                    "долг",
+                    "повиноваться",
+                    "торжественный"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «gehorchen»?",
+                "choices": [
+                    "правда",
+                    "повиноваться",
+                    "торжественный",
+                    "церемония"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Pflicht»?",
+                "choices": [
+                    "провозглашать",
+                    "власть",
+                    "правда",
+                    "долг"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
-                    "долг",
+                    "повиноваться",
                     "торжественный",
-                    "власть",
-                    "провозглашать"
+                    "верность",
+                    "власть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "провозглашать",
-                    "власть",
                     "долг",
-                    "верность"
+                    "верность",
+                    "правда",
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2005,6 +2172,171 @@
     "goneril": {
         "title": "Изгнание",
         "description": "Акт I: Отъезд во Францию",
+        "vocabulary": [
+            {
+                "german": "verstoßen",
+                "russian": "изгонять",
+                "sentence": "Die Familie hat ihn wegen seines Verhaltens verstoßen.",
+                "sentence_translation": "Семья изгнала его за его поведение.",
+                "russian_hint": "",
+                "transcription": "[фер-ШТО-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Familie hat ihn",
+                    "wegen seines Verhaltens verstoßen."
+                ],
+                "synonyms": [
+                    "изгонять",
+                    "verbannen — тоже «изгонять»",
+                    "vertreiben — тоже «изгонять»",
+                    "отвергать",
+                    "abweisen — тоже «отвергать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verlassen",
+                "russian": "покидать",
+                "sentence": "Wir müssen das Gebäude sofort verlassen.",
+                "sentence_translation": "Мы должны немедленно покинуть здание.",
+                "russian_hint": "",
+                "transcription": "[фер-ЛА-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Wir müssen das Gebäude",
+                    "sofort verlassen."
+                ],
+                "synonyms": [
+                    "покидать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Zorn",
+                "russian": "гнев",
+                "sentence": "Der Zorn des Chefs war deutlich zu spüren.",
+                "sentence_translation": "Гнев начальника был явно ощутим.",
+                "russian_hint": "",
+                "transcription": "[дер ЦОРН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der Zorn des Chefs",
+                    "war deutlich zu spüren."
+                ],
+                "synonyms": [
+                    "гнев"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Strafe",
+                "russian": "наказание",
+                "sentence": "Die Strafe für dieses Vergehen beträgt tausend Euro.",
+                "sentence_translation": "Наказание за это нарушение составляет тысячу евро.",
+                "russian_hint": "",
+                "transcription": "[ди ШТРА-фе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Strafe für dieses Vergehen",
+                    "beträgt tausend Euro."
+                ],
+                "synonyms": [
+                    "кара",
+                    "наказание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "fremd",
+                "russian": "чужой",
+                "sentence": "In der neuen Stadt fühlte ich mich völlig fremd.",
+                "sentence_translation": "В новом городе я чувствовал себя совершенно чужим.",
+                "russian_hint": "",
+                "transcription": "[ФРЕМД]",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "In der neuen Stadt",
+                    "fühlte ich mich völlig fremd."
+                ],
+                "synonyms": [
+                    "чужой"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Mitgift",
+                "russian": "приданое",
+                "sentence": "Die Mitgift der Braut war sehr großzügig.",
+                "sentence_translation": "Приданое невесты было очень щедрым.",
+                "russian_hint": "",
+                "transcription": "[ди МИТ-гифт]",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Die Mitgift der Braut",
+                    "war sehr großzügig."
+                ],
+                "synonyms": [
+                    "приданое"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufnehmen",
+                "russian": "принимать",
+                "sentence": "Das Krankenhaus kann heute keine neuen Patienten aufnehmen.",
+                "sentence_translation": "Больница сегодня не может принимать новых пациентов.",
+                "russian_hint": "",
+                "transcription": "[АУФ-не-мен]",
+                "themes": [
+                    "Frankreich",
+                    "verlassen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Das Krankenhaus kann heute",
+                    "keine neuen Patienten aufnehmen."
+                ],
+                "synonyms": [
+                    "принимать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hoffnung",
+                "russian": "надежда",
+                "sentence": "Die Hoffnung auf bessere Zeiten stirbt zuletzt.",
+                "sentence_translation": "Надежда на лучшие времена умирает последней.",
+                "russian_hint": "",
+                "transcription": "[ди ХОФ-нунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Hoffnung auf bessere Zeiten",
+                    "stirbt zuletzt."
+                ],
+                "synonyms": [
+                    "надежда"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verstoßen",
@@ -2225,69 +2557,69 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "наказание",
                     "изгонять",
+                    "наказание",
                     "гнев",
                     "покидать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
                     "гнев",
-                    "покидать",
                     "наказание",
+                    "покидать",
                     "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "чужой",
                     "гнев",
                     "надежда",
-                    "наказание"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Strafe»?",
-                "choices": [
-                    "наказание",
-                    "покидать",
-                    "приданое",
-                    "гнев"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «fremd»?",
-                "choices": [
                     "чужой",
-                    "приданое",
-                    "надежда",
                     "принимать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Mitgift»?",
+                "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "надежда",
-                    "приданое",
                     "изгонять",
-                    "покидать"
+                    "наказание",
+                    "надежда",
+                    "гнев"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «aufnehmen»?",
+                "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
+                    "покидать",
+                    "приданое",
+                    "чужой",
+                    "изгонять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Mitgift»?",
+                "choices": [
+                    "приданое",
                     "гнев",
                     "наказание",
-                    "чужой",
+                    "чужой"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «aufnehmen»?",
+                "choices": [
+                    "приданое",
+                    "покидать",
+                    "изгонять",
                     "принимать"
                 ],
                 "correctIndex": 3
@@ -2295,12 +2627,12 @@
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
+                    "надежда",
                     "покидать",
                     "гнев",
-                    "принимать",
-                    "надежда"
+                    "чужой"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2390,6 +2722,169 @@
     "regan": {
         "title": "Во Франции",
         "description": "Акт II-III: Беспокойство за отца",
+        "vocabulary": [
+            {
+                "german": "die Sorge",
+                "russian": "забота",
+                "sentence": "Die Sorge um ihre kranke Mutter belastet sie sehr.",
+                "sentence_translation": "Забота о больной матери очень её тяготит.",
+                "russian_hint": "",
+                "transcription": "[ди ЗОР-ге]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Sorge um ihre kranke Mutter",
+                    "belastet sie sehr."
+                ],
+                "synonyms": [
+                    "забота"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Einsamkeit",
+                "russian": "одиночество",
+                "sentence": "Die Einsamkeit in der großen Stadt ist manchmal unerträglich.",
+                "sentence_translation": "Одиночество в большом городе иногда невыносимо.",
+                "russian_hint": "",
+                "transcription": "[ди АЙН-зам-кайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Einsamkeit in der großen Stadt",
+                    "ist manchmal unerträglich."
+                ],
+                "synonyms": [
+                    "одиночество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Nachricht",
+                "russian": "известие",
+                "sentence": "Die Nachricht von seinem Erfolg erreichte uns gestern.",
+                "sentence_translation": "Известие о его успехе дошло до нас вчера.",
+                "russian_hint": "",
+                "transcription": "[ди НАХ-рихт]",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
+                "sentence_parts": [
+                    "Die Nachricht von seinem Erfolg",
+                    "erreichte uns gestern."
+                ],
+                "synonyms": [
+                    "известие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Angst",
+                "russian": "страх",
+                "sentence": "Die Angst vor der Prüfung ließ ihn nicht schlafen.",
+                "sentence_translation": "Страх перед экзаменом не давал ему спать.",
+                "russian_hint": "",
+                "transcription": "[ди АНГСТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Angst vor der Prüfung",
+                    "ließ ihn nicht schlafen."
+                ],
+                "synonyms": [
+                    "страх",
+                    "die Furcht — тоже «страх»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leiden",
+                "russian": "страдать",
+                "sentence": "Viele Menschen leiden unter chronischen Schmerzen.",
+                "sentence_translation": "Многие люди страдают от хронических болей.",
+                "russian_hint": "",
+                "transcription": "[ЛАЙ-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Viele Menschen leiden",
+                    "unter chronischen Schmerzen."
+                ],
+                "synonyms": [
+                    "страдать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beschützen",
+                "russian": "защищать",
+                "sentence": "Eltern wollen ihre Kinder vor Gefahren beschützen.",
+                "sentence_translation": "Родители хотят защитить своих детей от опасностей.",
+                "russian_hint": "",
+                "transcription": "[бе-ШЮ-цен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Eltern wollen ihre Kinder",
+                    "vor Gefahren beschützen."
+                ],
+                "synonyms": [
+                    "защищать",
+                    "schützen — тоже «защищать»",
+                    "verteidigen — тоже «защищать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Sehnsucht",
+                "russian": "тоска",
+                "sentence": "Die Sehnsucht nach der Heimat wurde immer stärker.",
+                "sentence_translation": "Тоска по родине становилась всё сильнее.",
+                "russian_hint": "",
+                "transcription": "[ди ЗЕН-зухт]",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
+                "sentence_parts": [
+                    "Die Sehnsucht nach der Heimat",
+                    "wurde immer stärker."
+                ],
+                "synonyms": [
+                    "тоска"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beten",
+                "russian": "молиться",
+                "sentence": "Viele Menschen beten jeden Tag vor dem Essen.",
+                "sentence_translation": "Многие люди молятся каждый день перед едой.",
+                "russian_hint": "",
+                "transcription": "[БЕ-тен]",
+                "themes": [
+                    "beten",
+                    "sorgen",
+                    "warten"
+                ],
+                "sentence_parts": [
+                    "Viele Menschen beten",
+                    "jeden Tag vor dem Essen."
+                ],
+                "synonyms": [
+                    "молиться"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Sorge",
@@ -2607,8 +3102,8 @@
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
                     "одиночество",
-                    "страх",
                     "известие",
+                    "страх",
                     "забота"
                 ],
                 "correctIndex": 3
@@ -2616,70 +3111,70 @@
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "забота",
-                    "одиночество",
+                    "страх",
                     "известие",
-                    "страх"
+                    "одиночество",
+                    "забота"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
                     "известие",
+                    "забота",
                     "защищать",
-                    "страдать",
-                    "забота"
+                    "одиночество"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
-                    "известие",
                     "тоска",
-                    "страх",
-                    "страдать"
+                    "защищать",
+                    "молиться",
+                    "страх"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
                     "страдать",
-                    "одиночество",
-                    "защищать",
-                    "страх"
+                    "страх",
+                    "известие",
+                    "одиночество"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "тоска",
-                    "защищать",
                     "известие",
-                    "одиночество"
+                    "страх",
+                    "тоска",
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
-                    "известие",
-                    "тоска",
-                    "защищать",
-                    "страх"
+                    "одиночество",
+                    "страдать",
+                    "молиться",
+                    "тоска"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
+                    "защищать",
                     "страдать",
-                    "одиночество",
                     "молиться",
-                    "забота"
+                    "известие"
                 ],
                 "correctIndex": 2
             }
@@ -2771,6 +3266,167 @@
     "storm": {
         "title": "Возвращение",
         "description": "Акт IV: Возвращение с армией",
+        "vocabulary": [
+            {
+                "german": "zurückkehren",
+                "russian": "возвращаться",
+                "sentence": "Nach zehn Jahren möchte er in seine Heimatstadt zurückkehren.",
+                "sentence_translation": "Через десять лет он хочет вернуться в родной город.",
+                "russian_hint": "",
+                "transcription": "[цу-РЮК-ке-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Nach zehn Jahren möchte er",
+                    "in seine Heimatstadt zurückkehren."
+                ],
+                "synonyms": [
+                    "возвращаться",
+                    "umkehren — тоже «возвращаться»",
+                    "wiederkehren — тоже «возвращаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Kampf",
+                "russian": "борьба",
+                "sentence": "Der Kampf gegen die Krankheit dauerte mehrere Jahre.",
+                "sentence_translation": "Борьба с болезнью длилась несколько лет.",
+                "russian_hint": "",
+                "transcription": "[дер КАМПФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der Kampf gegen die Krankheit",
+                    "dauerte mehrere Jahre."
+                ],
+                "synonyms": [
+                    "бой",
+                    "борьба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "retten",
+                "russian": "спасать",
+                "sentence": "Die Feuerwehr konnte alle Menschen aus dem brennenden Haus retten.",
+                "sentence_translation": "Пожарные смогли спасти всех людей из горящего дома.",
+                "russian_hint": "",
+                "transcription": "[РЕ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Feuerwehr konnte alle Menschen",
+                    "aus dem brennenden Haus retten."
+                ],
+                "synonyms": [
+                    "спасать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Schlacht",
+                "russian": "битва",
+                "sentence": "Die Schlacht bei Waterloo war historisch bedeutsam.",
+                "sentence_translation": "Битва при Ватерлоо была исторически значимой.",
+                "russian_hint": "",
+                "transcription": "[ди ШЛАХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Schlacht bei Waterloo",
+                    "war historisch bedeutsam."
+                ],
+                "synonyms": [
+                    "битва"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "mutig",
+                "russian": "храбрый",
+                "sentence": "Der mutige Junge sprang ins Wasser, um das Kind zu retten.",
+                "sentence_translation": "Храбрый мальчик прыгнул в воду, чтобы спасти ребёнка.",
+                "russian_hint": "",
+                "transcription": "[МУ-тиг]",
+                "themes": [
+                    "kämpfen",
+                    "retten",
+                    "zurückkehren"
+                ],
+                "sentence_parts": [
+                    "Der mutige Junge sprang ins Wasser,",
+                    "um das Kind zu retten."
+                ],
+                "synonyms": [
+                    "храбрый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gerechtigkeit",
+                "russian": "справедливость",
+                "sentence": "Die Gerechtigkeit sollte für alle Menschen gleich sein.",
+                "sentence_translation": "Справедливость должна быть одинаковой для всех людей.",
+                "russian_hint": "",
+                "transcription": "[ди ге-РЕХ-тиг-кайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Gerechtigkeit sollte",
+                    "für alle Menschen gleich sein."
+                ],
+                "synonyms": [
+                    "справедливость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "siegen",
+                "russian": "побеждать",
+                "sentence": "Unsere Mannschaft wird im Finale sicher siegen.",
+                "sentence_translation": "Наша команда точно победит в финале.",
+                "russian_hint": "",
+                "transcription": "[ЗИ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unsere Mannschaft wird",
+                    "im Finale sicher siegen."
+                ],
+                "synonyms": [
+                    "побеждать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Armee",
+                "russian": "армия",
+                "sentence": "Die Armee marschierte durch das Tal zur Stadt.",
+                "sentence_translation": "Армия шла через долину к городу.",
+                "russian_hint": "",
+                "transcription": "[ди ар-МЭ]",
+                "themes": [
+                    "kämpfen",
+                    "retten",
+                    "zurückkehren"
+                ],
+                "sentence_parts": [
+                    "Die Armee marschierte",
+                    "durch das Tal zur Stadt."
+                ],
+                "synonyms": [
+                    "армия"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "zurückkehren",
@@ -2986,70 +3642,70 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "борьба",
                     "битва",
-                    "спасать",
-                    "возвращаться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Kampf»?",
-                "choices": [
+                    "возвращаться",
                     "борьба",
-                    "битва",
-                    "спасать",
-                    "возвращаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «retten»?",
-                "choices": [
-                    "побеждать",
-                    "спасать",
-                    "армия",
-                    "храбрый"
+                    "спасать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Schlacht»?",
+                "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "возвращаться",
-                    "справедливость",
-                    "армия",
-                    "битва"
+                    "битва",
+                    "спасать",
+                    "борьба"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «mutig»?",
+                "question": "Что означает немецкое слово «retten»?",
+                "choices": [
+                    "возвращаться",
+                    "битва",
+                    "храбрый",
+                    "спасать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
                     "справедливость",
-                    "армия",
+                    "битва",
+                    "побеждать",
+                    "спасать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «mutig»?",
+                "choices": [
+                    "возвращаться",
+                    "спасать",
                     "храбрый",
-                    "борьба"
+                    "армия"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "борьба",
-                    "возвращаться",
-                    "справедливость",
-                    "побеждать"
+                    "храбрый",
+                    "армия",
+                    "битва",
+                    "справедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "справедливость",
+                    "храбрый",
                     "побеждать",
-                    "битва",
-                    "борьба"
+                    "спасать",
+                    "справедливость"
                 ],
                 "correctIndex": 1
             },
@@ -3057,11 +3713,11 @@
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
                     "борьба",
-                    "спасать",
                     "армия",
-                    "храбрый"
+                    "храбрый",
+                    "спасать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3151,6 +3807,177 @@
     "hut": {
         "title": "Встреча",
         "description": "Акт IV: Встреча с отцом",
+        "vocabulary": [
+            {
+                "german": "verzeihen",
+                "russian": "прощать",
+                "sentence": "Kannst du mir meinen Fehler bitte verzeihen?",
+                "sentence_translation": "Можешь ли ты простить мне мою ошибку?",
+                "russian_hint": "",
+                "transcription": "[фер-ЦАЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Kannst du mir meinen Fehler",
+                    "bitte verzeihen?"
+                ],
+                "synonyms": [
+                    "прощать",
+                    "vergeben — тоже «прощать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Tränen",
+                "russian": "слёзы",
+                "sentence": "Die Tränen der Freude liefen über ihre Wangen.",
+                "sentence_translation": "Слёзы радости текли по её щекам.",
+                "russian_hint": "",
+                "transcription": "[ди ТРЕ-нен]",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Die Tränen der Freude",
+                    "liefen über ihre Wangen."
+                ],
+                "synonyms": [
+                    "слёзы"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "umarmen",
+                "russian": "обнимать",
+                "sentence": "Die Freunde umarmten sich nach langer Trennung herzlich.",
+                "sentence_translation": "Друзья сердечно обнялись после долгой разлуки.",
+                "russian_hint": "",
+                "transcription": "[ум-АР-мен]",
+                "themes": [
+                    "erkennen",
+                    "heilen",
+                    "sterben",
+                    "umarmen",
+                    "vergeben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Die Freunde umarmten sich",
+                    "nach langer Trennung herzlich."
+                ],
+                "synonyms": [
+                    "обнимать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erkennen",
+                "russian": "узнавать",
+                "sentence": "Ich konnte ihn nach so vielen Jahren kaum erkennen.",
+                "sentence_translation": "Я едва мог узнать его после стольких лет.",
+                "russian_hint": "",
+                "transcription": "[ер-КЕН-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Ich konnte ihn nach so vielen Jahren",
+                    "kaum erkennen."
+                ],
+                "synonyms": [
+                    "познавать",
+                    "узнавать",
+                    "erfahren — тоже «узнавать»",
+                    "wiedererkennen — тоже «узнавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "heilen",
+                "russian": "исцелять",
+                "sentence": "Die Zeit wird alle emotionalen Wunden heilen.",
+                "sentence_translation": "Время исцелит все душевные раны.",
+                "russian_hint": "",
+                "transcription": "[ХАЙ-лен]",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Die Zeit wird",
+                    "alle emotionalen Wunden heilen."
+                ],
+                "synonyms": [
+                    "исцелять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Reue",
+                "russian": "раскаяние",
+                "sentence": "Die Reue über seine Tat quälte ihn jahrelang.",
+                "sentence_translation": "Раскаяние в своём поступке мучило его годами.",
+                "russian_hint": "",
+                "transcription": "[ди РОЙ-е]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Reue über seine Tat",
+                    "quälte ihn jahrelang."
+                ],
+                "synonyms": [
+                    "раскаяние"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sanft",
+                "russian": "нежный",
+                "sentence": "Sie sprach mit sanfter Stimme zu dem verängstigten Kind.",
+                "sentence_translation": "Она говорила нежным голосом с испуганным ребёнком.",
+                "russian_hint": "",
+                "transcription": "[ЗАНФТ]",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Sie sprach mit sanfter Stimme",
+                    "zu dem verängstigten Kind."
+                ],
+                "synonyms": [
+                    "нежный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Vergebung",
+                "russian": "прощение",
+                "sentence": "Die Vergebung der Schuld brachte ihm inneren Frieden.",
+                "sentence_translation": "Прощение вины принесло ему внутренний покой.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ГЕ-бунг]",
+                "themes": [
+                    "heilen",
+                    "umarmen",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Die Vergebung der Schuld",
+                    "brachte ihm inneren Frieden."
+                ],
+                "synonyms": [
+                    "прощение"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verzeihen",
@@ -3372,79 +4199,79 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
+                    "обнимать",
                     "прощать",
                     "слёзы",
-                    "узнавать",
-                    "обнимать"
+                    "узнавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
                     "узнавать",
+                    "слёзы",
                     "обнимать",
-                    "прощать",
-                    "слёзы"
+                    "прощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "прощать",
-                    "исцелять",
                     "нежный",
-                    "обнимать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
-                    "слёзы",
-                    "исцелять",
-                    "узнавать",
-                    "обнимать"
+                    "прощать",
+                    "обнимать",
+                    "узнавать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «erkennen»?",
+                "choices": [
+                    "нежный",
+                    "узнавать",
+                    "прощение",
+                    "прощать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «heilen»?",
                 "choices": [
-                    "обнимать",
-                    "исцелять",
                     "узнавать",
-                    "нежный"
+                    "исцелять",
+                    "нежный",
+                    "прощение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "раскаяние",
-                    "прощать",
                     "исцелять",
-                    "слёзы"
+                    "раскаяние",
+                    "нежный",
+                    "прощение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "прощение",
+                    "нежный",
                     "слёзы",
-                    "узнавать",
-                    "нежный"
+                    "раскаяние",
+                    "обнимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
                     "прощение",
-                    "нежный",
-                    "обнимать",
+                    "раскаяние",
+                    "исцелять",
                     "прощать"
                 ],
                 "correctIndex": 0
@@ -3537,6 +4364,166 @@
     "dover": {
         "title": "Плен",
         "description": "Акт V: Захват в плен",
+        "vocabulary": [
+            {
+                "german": "gefangen",
+                "russian": "пленный",
+                "sentence": "Der Soldat wurde im Krieg gefangen genommen.",
+                "sentence_translation": "Солдат был взят в плен на войне.",
+                "russian_hint": "",
+                "transcription": "[ге-ФАН-ген]",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
+                "sentence_parts": [
+                    "Der Soldat wurde",
+                    "im Krieg gefangen genommen."
+                ],
+                "synonyms": [
+                    "пленный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Gefängnis",
+                "russian": "тюрьма",
+                "sentence": "Der Dieb musste für zwei Jahre ins Gefängnis.",
+                "sentence_translation": "Вор должен был отправиться в тюрьму на два года.",
+                "russian_hint": "",
+                "transcription": "[дас ге-ФЭНГ-нис]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der Dieb musste",
+                    "für zwei Jahre ins Gefängnis."
+                ],
+                "synonyms": [
+                    "тюрьма"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Würde",
+                "russian": "достоинство",
+                "sentence": "Die Würde des Menschen ist unantastbar.",
+                "sentence_translation": "Достоинство человека неприкосновенно.",
+                "russian_hint": "",
+                "transcription": "[ди ВЮР-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Würde des Menschen",
+                    "ist unantastbar."
+                ],
+                "synonyms": [
+                    "достоинство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "trösten",
+                "russian": "утешать",
+                "sentence": "Die Mutter versuchte ihr weinendes Kind zu trösten.",
+                "sentence_translation": "Мать пыталась утешить своего плачущего ребёнка.",
+                "russian_hint": "",
+                "transcription": "[ТРЁС-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Mutter versuchte",
+                    "ihr weinendes Kind zu trösten."
+                ],
+                "synonyms": [
+                    "утешать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "tapfer",
+                "russian": "отважный",
+                "sentence": "Der tapfere Ritter kämpfte gegen den Drachen.",
+                "sentence_translation": "Отважный рыцарь сражался с драконом.",
+                "russian_hint": "",
+                "transcription": "[ТАП-фер]",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
+                "sentence_parts": [
+                    "Der tapfere Ritter",
+                    "kämpfte gegen den Drachen."
+                ],
+                "synonyms": [
+                    "отважный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Demut",
+                "russian": "смирение",
+                "sentence": "Mit Demut nahm er die Kritik an seiner Arbeit an.",
+                "sentence_translation": "Со смирением он принял критику своей работы.",
+                "russian_hint": "",
+                "transcription": "[ди ДЕ-мут]",
+                "themes": [
+                    "Gerechtigkeit",
+                    "Würde",
+                    "gefangen"
+                ],
+                "sentence_parts": [
+                    "Mit Demut nahm er",
+                    "die Kritik an seiner Arbeit an."
+                ],
+                "synonyms": [
+                    "смирение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Schicksal",
+                "russian": "судьба",
+                "sentence": "Das Schicksal hat uns zusammengeführt.",
+                "sentence_translation": "Судьба свела нас вместе.",
+                "russian_hint": "",
+                "transcription": "[дас ШИК-заль]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Das Schicksal",
+                    "hat uns zusammengeführt."
+                ],
+                "synonyms": [
+                    "судьба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ehre",
+                "russian": "честь",
+                "sentence": "Es ist eine große Ehre, diese Auszeichnung zu erhalten.",
+                "sentence_translation": "Большая честь получить эту награду.",
+                "russian_hint": "",
+                "transcription": "[ди Э-ре]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Es ist eine große Ehre,",
+                    "diese Auszeichnung zu erhalten."
+                ],
+                "synonyms": [
+                    "честь"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "gefangen",
@@ -3751,69 +4738,69 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "достоинство",
-                    "утешать",
                     "пленный",
-                    "тюрьма"
+                    "тюрьма",
+                    "достоинство",
+                    "утешать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
-                    "тюрьма",
-                    "утешать",
                     "достоинство",
-                    "пленный"
+                    "пленный",
+                    "утешать",
+                    "тюрьма"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
-                    "утешать",
                     "судьба",
+                    "достоинство",
                     "пленный",
-                    "достоинство"
+                    "смирение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "достоинство",
+                    "утешать",
                     "отважный",
-                    "смирение",
-                    "утешать"
+                    "пленный",
+                    "достоинство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
+                    "судьба",
                     "отважный",
-                    "смирение",
                     "достоинство",
-                    "утешать"
+                    "пленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
                     "утешать",
-                    "достоинство",
                     "смирение",
-                    "судьба"
+                    "тюрьма",
+                    "достоинство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "утешать",
-                    "тюрьма",
                     "пленный",
+                    "отважный",
+                    "тюрьма",
                     "судьба"
                 ],
                 "correctIndex": 3
@@ -3821,8 +4808,8 @@
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "отважный",
-                    "достоинство",
+                    "смирение",
+                    "судьба",
                     "тюрьма",
                     "честь"
                 ],
@@ -3916,6 +4903,177 @@
     "prison": {
         "title": "Финал",
         "description": "Акт V: Трагический конец",
+        "vocabulary": [
+            {
+                "german": "der Tod",
+                "russian": "смерть",
+                "sentence": "Der Tod des alten Mannes kam friedlich im Schlaf.",
+                "sentence_translation": "Смерть старика пришла мирно во сне.",
+                "russian_hint": "",
+                "transcription": "[дер ТОД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der Tod des alten Mannes",
+                    "kam friedlich im Schlaf."
+                ],
+                "synonyms": [
+                    "смерть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sterben",
+                "russian": "умирать",
+                "sentence": "Die Blumen werden ohne Wasser schnell sterben.",
+                "sentence_translation": "Цветы без воды быстро умрут.",
+                "russian_hint": "",
+                "transcription": "[ШТЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Blumen werden",
+                    "ohne Wasser schnell sterben."
+                ],
+                "synonyms": [
+                    "умирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Opfer",
+                "russian": "жертва",
+                "sentence": "Das Opfer des Unfalls wurde ins Krankenhaus gebracht.",
+                "sentence_translation": "Жертва аварии была доставлена в больницу.",
+                "russian_hint": "",
+                "transcription": "[дас ОП-фер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Das Opfer des Unfalls",
+                    "wurde ins Krankenhaus gebracht."
+                ],
+                "synonyms": [
+                    "жертва"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Seele",
+                "russian": "душа",
+                "sentence": "Musik ist Nahrung für die Seele.",
+                "sentence_translation": "Музыка - это пища для души.",
+                "russian_hint": "",
+                "transcription": "[ди ЗЕ-ле]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Musik ist",
+                    "Nahrung für die Seele."
+                ],
+                "synonyms": [
+                    "душа"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Ende",
+                "russian": "конец",
+                "sentence": "Das Ende des Films war sehr überraschend.",
+                "sentence_translation": "Конец фильма был очень неожиданным.",
+                "russian_hint": "",
+                "transcription": "[дас ЕН-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Das Ende des Films",
+                    "war sehr überraschend."
+                ],
+                "synonyms": [
+                    "конец"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ewig",
+                "russian": "вечный",
+                "sentence": "Ihre Liebe schien ewig zu dauern.",
+                "sentence_translation": "Их любовь казалась вечной.",
+                "russian_hint": "",
+                "transcription": "[Э-виг]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Ihre Liebe",
+                    "schien ewig zu dauern."
+                ],
+                "synonyms": [
+                    "вечный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Abschied",
+                "russian": "прощание",
+                "sentence": "Der Abschied am Bahnhof fiel allen sehr schwer.",
+                "sentence_translation": "Прощание на вокзале далось всем очень тяжело.",
+                "russian_hint": "",
+                "transcription": "[дер АБ-шид]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Der Abschied am Bahnhof",
+                    "fiel allen sehr schwer."
+                ],
+                "synonyms": [
+                    "прощание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Erlösung",
+                "russian": "спасение",
+                "sentence": "Die Erlösung von den Schmerzen kam endlich durch die Medizin.",
+                "sentence_translation": "Спасение от боли наконец пришло благодаря лекарству.",
+                "russian_hint": "",
+                "transcription": "[ди ер-ЛЁ-зунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Erlösung von den Schmerzen",
+                    "kam endlich durch die Medizin."
+                ],
+                "synonyms": [
+                    "спасение"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Tod",
@@ -4153,69 +5311,69 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "жертва",
                     "умирать",
                     "душа",
-                    "смерть"
+                    "смерть",
+                    "жертва"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "душа",
-                    "умирать",
                     "смерть",
-                    "жертва"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Opfer»?",
-                "choices": [
-                    "умирать",
-                    "спасение",
-                    "вечный",
-                    "жертва"
+                    "жертва",
+                    "умирать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «das Opfer»?",
+                "choices": [
+                    "прощание",
+                    "жертва",
+                    "спасение",
+                    "умирать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
+                    "спасение",
+                    "смерть",
                     "душа",
-                    "конец",
-                    "прощание",
-                    "вечный"
+                    "жертва"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "умирать",
-                    "спасение",
+                    "конец",
                     "смерть",
-                    "конец"
+                    "вечный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "вечный",
-                    "конец",
-                    "смерть",
-                    "душа"
+                    "жертва",
+                    "прощание",
+                    "спасение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "умирать",
+                    "спасение",
                     "вечный",
-                    "смерть",
+                    "конец",
                     "прощание"
                 ],
                 "correctIndex": 3
@@ -4223,12 +5381,12 @@
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "умирать",
-                    "жертва",
                     "прощание",
-                    "спасение"
+                    "смерть",
+                    "спасение",
+                    "вечный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4321,6 +5479,9 @@ const characterId = "cordelia";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["желать", "жадность", "стремиться", "честолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "честолюбие", "стремиться", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["захватывать", "жадный", "стремиться", "честолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "желать", "честолюбие", "жадность"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["захватывать", "вожделеть", "стремиться", "честолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["жадность", "жадный", "вожделеть", "стремиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "стремиться", "жадный", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["захватывать", "жадный", "стремиться", "жадность"], "correct_index": 0}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "поддерживать", "одобрять", "злоба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["поддерживать", "злоба", "жестокость", "одобрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["подстрекать", "одобрять", "злоба", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "злоба", "одобрять", "суровость"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["суровость", "поддерживать", "злоба", "подстрекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поддерживать", "злоба", "жестокость", "поощрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "суровость", "поддерживать", "поощрять"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["подавлять", "страх", "угнетение", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "тирания", "страх", "угнетение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["брутальный", "страх", "угнетение", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["тирания", "брутальный", "страх", "подавлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["угнетение", "принуждать", "брутальный", "порабощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["брутальный", "принуждать", "произвол", "порабощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["угнетение", "порабощать", "произвол", "брутальный"], "correct_index": 2}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["тирания", "брутальный", "порабощать", "принуждать"], "correct_index": 1}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "наказание", "наказывать", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказывать", "карать", "наказание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["мучить", "карать", "унижать", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["наказывать", "унижать", "карать", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["гнев", "унижать", "наказание", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["наказывать", "карать", "унижать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "наказание", "унижать", "карать"], "correct_index": 0}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "пытать", "кровь", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["кровь", "садизм", "пытка", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["ослеплять", "мука", "кровь", "калечить"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["выкалывать", "кровь", "ослеплять", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["садизм", "пытка", "калечить", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["кровь", "ослеплять", "пытка", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["калечить", "мука", "кровь", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["калечить", "кровь", "пытка", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["боль", "кровоточить", "удивление", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "рана", "кровоточить", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["раненый", "страдать", "боль", "удивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["страдать", "кровоточить", "рана", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["страдать", "боль", "кровоточить", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["ослаблять", "страдать", "кровоточить", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "раненый", "кровоточить", "ослаблять"], "correct_index": 0}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "умирать", "конец", "возмездие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "конец", "смерть", "возмездие"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["хрипеть", "конец", "проклинать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "смерть", "умирать", "возмездие"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["умирать", "хрипеть", "конец", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["хрипеть", "проклинать", "смерть", "кара"], "correct_index": 1}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["проклинать", "кара", "конец", "хрипеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["кара", "издыхать", "конец", "проклинать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "честолюбие", "жадность", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["честолюбие", "желать", "жадность", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «streben»?", "choices": ["желать", "стремиться", "жадность", "властолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "желать", "жадность", "честолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["честолюбие", "жадный", "вожделеть", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["стремиться", "жадный", "властолюбие", "захватывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "жадный", "жадность", "честолюбие"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["желать", "захватывать", "жадный", "вожделеть"], "correct_index": 1}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "жестокость", "злоба", "одобрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["поддерживать", "одобрять", "злоба", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["одобрять", "подстрекать", "жестокость", "поощрять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["злоба", "жестокость", "суровость", "поддерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["подстрекать", "жестокость", "поддерживать", "одобрять"], "correct_index": 0}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["подстрекать", "поддерживать", "поощрять", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "жестокость", "суровость", "одобрять"], "correct_index": 2}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["страх", "подавлять", "угнетение", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["страх", "тирания", "подавлять", "угнетение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "страх", "подавлять", "угнетение"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "угнетение", "страх", "брутальный"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["страх", "порабощать", "подавлять", "произвол"], "correct_index": 1}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["тирания", "принуждать", "подавлять", "угнетение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["страх", "брутальный", "подавлять", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["произвол", "тирания", "брутальный", "угнетение"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "карать", "наказывать", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказание", "гнев", "наказывать", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["гнев", "карать", "унижать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["унижать", "карать", "наказывать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "наказывать", "карать", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "наказывать", "наказание", "мучить"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "карать", "наказание", "мучить"], "correct_index": 3}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "пытать", "кровь", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "садизм", "пытать", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["ослеплять", "кровь", "калечить", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["пытать", "калечить", "кровь", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытка", "калечить", "кровь", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["пытать", "калечить", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["выкалывать", "ослеплять", "пытать", "садизм"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мука", "пытать", "калечить", "выкалывать"], "correct_index": 0}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["кровоточить", "рана", "боль", "удивление"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "рана", "кровоточить", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["удивление", "рана", "ослаблять", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["страдать", "раненый", "ослаблять", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["раненый", "боль", "кровоточить", "ослаблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["удивление", "ослаблять", "рана", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["ослаблять", "рана", "страдать", "удивление"], "correct_index": 2}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "возмездие", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "конец", "возмездие", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["хрипеть", "смерть", "проклинать", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "возмездие", "кара", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["кара", "конец", "проклинать", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["издыхать", "кара", "смерть", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["кара", "возмездие", "хрипеть", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["умирать", "проклинать", "кара", "смерть"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,31 +662,15 @@
             <div class="quiz-phase-container active" data-phase="ambitious_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
@@ -694,17 +678,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «streben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -718,25 +718,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -746,13 +746,13 @@
                         <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -764,27 +764,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,31 +797,15 @@
             <div class="quiz-phase-container" data-phase="cruel_husband">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
@@ -829,11 +813,11 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
@@ -845,45 +829,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
@@ -893,17 +845,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -920,9 +920,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
@@ -936,11 +936,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
@@ -952,45 +952,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1000,45 +1000,45 @@
                         <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,13 +1051,29 @@
             <div class="quiz-phase-container" data-phase="punishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
@@ -1067,15 +1083,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -1083,81 +1115,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1190,59 +1190,59 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
@@ -1250,31 +1250,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
@@ -1282,17 +1266,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,45 +1305,13 @@
             <div class="quiz-phase-container" data-phase="wounded">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
@@ -1353,13 +1321,77 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                             
@@ -1369,49 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1430,17 +1430,17 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                         <div class="quiz-choices">
                             
@@ -1448,23 +1448,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1472,17 +1456,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1492,11 +1492,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
@@ -1504,49 +1504,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1568,6 +1568,176 @@
     "ambitious_duke": {
         "title": "Амбициозный герцог",
         "description": "Акт I: Жаждет власти",
+        "vocabulary": [
+            {
+                "german": "der Ehrgeiz",
+                "russian": "честолюбие",
+                "sentence": "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen. Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В оружейной Корнуолл жадно рассматривает выставленные коронные драгоценности. Эхо слова «честолюбие» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[дер ЭР-гайц]",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
+                "sentence_parts": [
+                    "In der Waffenkammer betrachtet Cornwall gierig die ausgestellten Kronjuwelen.",
+                    "Das Echo des Wortes „der Ehrgeiz“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "честолюбие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gier",
+                "russian": "жадность",
+                "sentence": "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen. Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед картой Англии Корнуолл проводит кинжалом новые границы. Моё дыхание рисует слово «жадность» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ГИР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der Karte Englands fährt Cornwall mit dem Dolch über neue Grenzen.",
+                    "Mein Atem zeichnet das Wort „die Gier“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "жадность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "streben",
+                "russian": "стремиться",
+                "sentence": "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten. Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Среди преклонивших колено вассалов Корнуолл проводит пальцами по тронному креслу. Я стискиваю слово «стремиться» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ШТРЕ-бен]",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
+                "sentence_parts": [
+                    "Zwischen knienden Vasallen lässt Cornwall die Finger über den Thronsessel gleiten.",
+                    "Ich presse das Wort „streben“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "стремиться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verlangen",
+                "russian": "желать",
+                "sentence": "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt. Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У высокого окна Корнуолл вымеряет расстояние до столицы. Моё дыхание рисует слово «желать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-ЛАН-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am hohen Fenster misst Cornwall den Abstand zur Hauptstadt.",
+                    "Mein Atem zeichnet das Wort „verlangen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "желать",
+                    "begehren — тоже «желать»",
+                    "wünschen — тоже «желать»",
+                    "требовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begehren",
+                "russian": "вожделеть",
+                "sentence": "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes. Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen.",
+                "sentence_translation": "У тлеющего камина Корнуолл взвешивает на руке меч. Я шепчу стражам судьбы: слово «вожделеть» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЕ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben dem schwelenden Kamin testet Cornwall das Gewicht eines Schwertes.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „begehren“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "вожделеть",
+                    "желать",
+                    "verlangen — тоже «желать»",
+                    "wünschen — тоже «желать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gierig",
+                "russian": "жадный",
+                "sentence": "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten. Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern.",
+                "sentence_translation": "На турнирной площадке Корнуолл строит всадников поздним вечером. Даже если мир распадается, слово «жадный» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ГИ-риг]",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
+                "sentence_parts": [
+                    "Auf dem Turnierplatz lässt Cornwall seine Reiter zu später Stunde antreten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „gierig“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "жадный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Herrschsucht",
+                "russian": "властолюбие",
+                "sentence": "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse. Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen.",
+                "sentence_translation": "Среди свитков пергамента Корнуолл обдумывает тайные союзы. Как тихая молитва слово «властолюбие» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди ХЕР-зухт]",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
+                "sentence_parts": [
+                    "Zwischen Pergamentrollen überdenkt Cornwall geheime Bündnisse.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Herrschsucht“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "властолюбие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ergreifen",
+                "russian": "захватывать",
+                "sentence": "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers. Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В зеркале аудиенц-зала Корнуолл репетирует улыбку правителя. Я обнимаю слово «захватывать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ер-ГРАЙ-фен]",
+                "themes": [
+                    "Ehrgeiz",
+                    "Gier",
+                    "Macht"
+                ],
+                "sentence_parts": [
+                    "Im Spiegel der Audienzhalle probt Cornwall das Lächeln eines Herrschers.",
+                    "Ich umarme das Wort „ergreifen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "захватывать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Ehrgeiz",
@@ -1782,60 +1952,60 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "желать",
-                    "жадность",
                     "стремиться",
-                    "честолюбие"
+                    "честолюбие",
+                    "жадность",
+                    "желать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "жадность",
                     "честолюбие",
-                    "стремиться",
-                    "желать"
+                    "желать",
+                    "жадность",
+                    "стремиться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
-                    "захватывать",
-                    "жадный",
+                    "желать",
                     "стремиться",
-                    "честолюбие"
+                    "жадность",
+                    "властолюбие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
                     "захватывать",
                     "желать",
-                    "честолюбие",
-                    "жадность"
+                    "жадность",
+                    "честолюбие"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "захватывать",
+                    "честолюбие",
+                    "жадный",
                     "вожделеть",
-                    "стремиться",
-                    "честолюбие"
+                    "жадность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
-                    "жадность",
+                    "стремиться",
                     "жадный",
-                    "вожделеть",
-                    "стремиться"
+                    "властолюбие",
+                    "захватывать"
                 ],
                 "correctIndex": 1
             },
@@ -1843,21 +2013,21 @@
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
                     "властолюбие",
-                    "стремиться",
                     "жадный",
-                    "желать"
+                    "жадность",
+                    "честолюбие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
+                    "желать",
                     "захватывать",
                     "жадный",
-                    "стремиться",
-                    "жадность"
+                    "вожделеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -1947,6 +2117,168 @@
     "cruel_husband": {
         "title": "Жестокий муж",
         "description": "Акт II: Поддерживает жестокость Реганы",
+        "vocabulary": [
+            {
+                "german": "die Grausamkeit",
+                "russian": "жестокость",
+                "sentence": "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott. Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Рядом с ядовитой улыбкой Реганы Корнуолл поднимает кубок насмешки. Я обнимаю слово «жестокость», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди ГРАУ-зам-кайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Neben Regans vergiftetem Lächeln hebt Cornwall den Kelch zum Spott.",
+                    "Ich umarme das Wort „die Grausamkeit“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "жестокость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Bosheit",
+                "russian": "злоба",
+                "sentence": "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs. Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "На галерее замка Корнуолл аплодирует унижениям короля. Я обнимаю слово «злоба», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди БОС-хайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Auf der Galerie des Schlosses applaudiert Cornwall den Demütigungen des Königs.",
+                    "Ich umarme das Wort „die Bosheit“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "злоба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "billigen",
+                "russian": "одобрять",
+                "sentence": "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche. Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Среди запуганных слуг Корнуолл тянется к плётке. Холодный свет заставляет слово «одобрять» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[БИ-ли-ген]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
+                "sentence_parts": [
+                    "Zwischen eingeschüchterten Dienern greift Cornwall nach der Peitsche.",
+                    "Das kalte Licht lässt das Wort „billigen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "одобрять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unterstützen",
+                "russian": "поддерживать",
+                "sentence": "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit. Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В высоком кресле-ленном Корнуолл сидит с холодным довольством. Я черчу слово «поддерживать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ун-тер-ШТЮ-цен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am hohen Lehnsessel sitzt Cornwall mit kalter Zufriedenheit.",
+                    "Ich zeichne das Wort „unterstützen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "поддерживать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "anstacheln",
+                "russian": "подстрекать",
+                "sentence": "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief. Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern.",
+                "sentence_translation": "Перед шкафом со штандартами Корнуолл разрывает вежливое прошение. Даже если мир распадается, слово «подстрекать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[АН-шта-хельн]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
+                "sentence_parts": [
+                    "Vor dem Bannerschrank zerreißt Cornwall einen höflichen Bittbrief.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „anstacheln“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "подстрекать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ermutigen",
+                "russian": "поощрять",
+                "sentence": "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen. Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Под грохот барабанов Корнуолл приказывает стражам подойти ближе. Эхо слова «поощрять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ер-МУ-ти-ген]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit"
+                ],
+                "sentence_parts": [
+                    "Unter stürmischen Trommeln befiehlt Cornwall den Wachen näherzukommen.",
+                    "Das Echo des Wortes „ermutigen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "поощрять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Härte",
+                "russian": "суровость",
+                "sentence": "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen.",
+                "sentence_translation": "В тени пыточной Корнуолл обменивается с Реганой тайными взглядами. Я шепчу стражам судьбы: слово «суровость» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ХЕР-те]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Folterkammer tauscht Cornwall mit Regan heimliche Blicke.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Härte“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "суровость",
+                    "жёсткость"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Grausamkeit",
@@ -2153,72 +2485,72 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
+                    "поддерживать",
                     "жестокость",
-                    "поддерживать",
-                    "одобрять",
-                    "злоба"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "поддерживать",
                     "злоба",
-                    "жестокость",
                     "одобрять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «billigen»?",
+                "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "подстрекать",
+                    "поддерживать",
                     "одобрять",
                     "злоба",
                     "жестокость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «unterstützen»?",
+                "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
-                    "поддерживать",
-                    "злоба",
                     "одобрять",
-                    "суровость"
+                    "подстрекать",
+                    "жестокость",
+                    "поощрять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «anstacheln»?",
+                "question": "Что означает немецкое слово «unterstützen»?",
                 "choices": [
-                    "суровость",
-                    "поддерживать",
                     "злоба",
-                    "подстрекать"
+                    "жестокость",
+                    "суровость",
+                    "поддерживать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «anstacheln»?",
+                "choices": [
+                    "подстрекать",
+                    "жестокость",
+                    "поддерживать",
+                    "одобрять"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «ermutigen»?",
                 "choices": [
+                    "подстрекать",
                     "поддерживать",
-                    "злоба",
-                    "жестокость",
-                    "поощрять"
+                    "поощрять",
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
                     "злоба",
+                    "жестокость",
                     "суровость",
-                    "поддерживать",
-                    "поощрять"
+                    "одобрять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2298,6 +2630,174 @@
     "tyrant": {
         "title": "Тиран",
         "description": "Акт II: Правит железной рукой",
+        "vocabulary": [
+            {
+                "german": "die Tyrannei",
+                "russian": "тирания",
+                "sentence": "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete. Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На замковом дворе Корнуолл раздаёт новые беспощадные указы. Я вывожу слово «тирания» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди тю-ра-НАЙ]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "Auf dem Burghof verteilt Cornwall neue, erbarmungslose Dekrete.",
+                    "Ich zeichne das Wort „die Tyrannei“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "тирания"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Unterdrückung",
+                "russian": "угнетение",
+                "sentence": "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen. Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед связанными пленниками Корнуолл приказывает проверить боевые булавы. Моё дыхание рисует слово «угнетение» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ун-тер-ДРЮ-кунг]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "Vor gefesselten Gefangenen lässt Cornwall die Streitkolben prüfen.",
+                    "Mein Atem zeichnet das Wort „die Unterdrückung“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "угнетение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Furcht",
+                "russian": "страх",
+                "sentence": "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt. Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Среди звенящих цепей Корнуолл идёт тяжёлым шагом. Я держу слово «страх» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ФУРХТ]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "Zwischen klirrenden Ketten schreitet Cornwall mit schwerem Schritt.",
+                    "Ich halte das Wort „die Furcht“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "страх",
+                    "die Angst — тоже «страх»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unterdrücken",
+                "russian": "подавлять",
+                "sentence": "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft. Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У чёрного знамени власти Корнуолл клянётся вечным господством. Моё дыхание рисует слово «подавлять» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ун-тер-ДРЮ-кен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am schwarzen Banner der Macht schwört Cornwall sich ewige Herrschaft.",
+                    "Mein Atem zeichnet das Wort „unterdrücken“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "подавлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "knechten",
+                "russian": "порабощать",
+                "sentence": "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen. Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На судейском помосте Корнуолл опирается на железный посох. Я стискиваю слово «порабощать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[КНЕХ-тен]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "Auf dem Gerichtspodest stützt Cornwall sich auf den Stab aus Eisen.",
+                    "Ich presse das Wort „knechten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "порабощать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zwingen",
+                "russian": "принуждать",
+                "sentence": "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich. Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Под взглядами запуганных дворян Корнуолл присваивает себе право суда. Я вывожу слово «принуждать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ЦВИН-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter den Blicken eingeschüchterter Edelleute reißt Cornwall das Urteil an sich.",
+                    "Ich zeichne das Wort „zwingen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "заставлять",
+                    "принуждать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Willkür",
+                "russian": "произвол",
+                "sentence": "An der Treppe zum Kerker verteilt Cornwall grausame Befehle. Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "У лестницы в темницу Корнуолл раздаёт жестокие приказы. Я обнимаю слово «произвол», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди ВИЛЬ-кюр]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "An der Treppe zum Kerker verteilt Cornwall grausame Befehle.",
+                    "Ich umarme das Wort „die Willkür“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "произвол"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "brutal",
+                "russian": "брутальный",
+                "sentence": "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne. Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "В мрачном тронном зале Корнуолл бьёт кулаком по подлокотнику. Я держу слово «брутальный» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[бру-ТАЛЬ]",
+                "themes": [
+                    "Furcht",
+                    "Tyrannei",
+                    "Unterdrückung"
+                ],
+                "sentence_parts": [
+                    "Im düsteren Thronsaal schlägt Cornwall mit der Faust auf die Armlehne.",
+                    "Ich halte das Wort „brutal“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "брутальный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Tyrannei",
@@ -2510,8 +3010,8 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
-                    "подавлять",
                     "страх",
+                    "подавлять",
                     "угнетение",
                     "тирания"
                 ],
@@ -2520,9 +3020,9 @@
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "подавлять",
-                    "тирания",
                     "страх",
+                    "тирания",
+                    "подавлять",
                     "угнетение"
                 ],
                 "correctIndex": 3
@@ -2530,62 +3030,62 @@
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
-                    "брутальный",
+                    "порабощать",
                     "страх",
-                    "угнетение",
-                    "тирания"
+                    "подавлять",
+                    "угнетение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterdrücken»?",
                 "choices": [
-                    "тирания",
-                    "брутальный",
+                    "подавлять",
+                    "угнетение",
                     "страх",
-                    "подавлять"
+                    "брутальный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
-                    "угнетение",
-                    "принуждать",
-                    "брутальный",
-                    "порабощать"
+                    "страх",
+                    "порабощать",
+                    "подавлять",
+                    "произвол"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
-                    "брутальный",
+                    "тирания",
                     "принуждать",
-                    "произвол",
-                    "порабощать"
+                    "подавлять",
+                    "угнетение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "угнетение",
-                    "порабощать",
-                    "произвол",
-                    "брутальный"
+                    "страх",
+                    "брутальный",
+                    "подавлять",
+                    "произвол"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
+                    "произвол",
                     "тирания",
                     "брутальный",
-                    "порабощать",
-                    "принуждать"
+                    "угнетение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2675,6 +3175,162 @@
     "punishment": {
         "title": "Каратель",
         "description": "Акт II: Наказывает Кента",
+        "vocabulary": [
+            {
+                "german": "die Strafe",
+                "russian": "наказание",
+                "sentence": "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben. Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen.",
+                "sentence_translation": "Перед потрясёнными придворными Корнуолл указывает на пустые колодки. Как тихая молитва слово «наказание» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди ШТРА-фе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den geschockten Höflingen deutet Cornwall auf die leeren Holzkolben.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Strafe“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "кара",
+                    "наказание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Zorn",
+                "russian": "гнев",
+                "sentence": "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen. Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten.",
+                "sentence_translation": "На мокром дворе Корнуолл приказывает заковать непокорного. Твёрдым голосом я клянусь себе: слово «гнев» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[дер ЦОРН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem nassen Hof befiehlt Cornwall die Fesselung des Widerspenstigen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Zorn“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "гнев"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bestrafen",
+                "russian": "карать",
+                "sentence": "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen.",
+                "sentence_translation": "Рядом с насмешливым взглядом Реганы Корнуолл бросает приговор в воздух. Я шепчу стражам судьбы: слово «карать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[бе-ШТРА-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben Regans spöttischem Blick wirft Cornwall das Urteil in die Luft.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bestrafen“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "карать",
+                    "наказывать",
+                    "strafen — тоже «наказывать»",
+                    "züchtigen — тоже «наказывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "züchtigen",
+                "russian": "наказывать",
+                "sentence": "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel. Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У верстака стражи Корнуолл проверяет острые гвозди. Я стискиваю слово «наказывать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ЦЮХ-ти-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn"
+                ],
+                "sentence_parts": [
+                    "Am Werkzeugtisch der Garde prüft Cornwall die scharfen Nägel.",
+                    "Ich presse das Wort „züchtigen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "наказывать",
+                    "bestrafen — тоже «наказывать»",
+                    "strafen — тоже «наказывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "demütigen",
+                "russian": "унижать",
+                "sentence": "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
+                "sentence_translation": "Перед перепуганными слугами Корнуолл улыбается мольбам о пощаде. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[де-МЮ-ти-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Vor den verschreckten Dienern lächelt Cornwall über das Flehen um Gnade.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "унижать",
+                    "erniedrigen — тоже «унижать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erniedrigen",
+                "russian": "унижать",
+                "sentence": "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen. Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern.",
+                "sentence_translation": "Под раскаты грома Корнуолл приказывает поставить жертву под дождь. Даже если мир распадается, слово «унижать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ер-НИД-ри-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Unter Donnerhall befiehlt Cornwall das Opfer in den Regen zu stellen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erniedrigen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "унижать",
+                    "demütigen — тоже «унижать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "quälen",
+                "russian": "мучить",
+                "sentence": "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser. Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На каменном полу Корнуолл оставляет следы крови и воды. Я держу слово «мучить» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[КВЕ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Steinboden hinterlässt Cornwall Spuren von Blut und Wasser.",
+                    "Ich halte das Wort „quälen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "мучить"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Strafe",
@@ -2878,71 +3534,71 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "гнев",
+                    "карать",
+                    "наказывать",
+                    "наказание"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Zorn»?",
+                "choices": [
                     "наказание",
+                    "гнев",
                     "наказывать",
                     "карать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «der Zorn»?",
-                "choices": [
-                    "наказывать",
-                    "карать",
-                    "наказание",
-                    "гнев"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
-                    "мучить",
+                    "гнев",
                     "карать",
                     "унижать",
-                    "унижать"
+                    "мучить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
-                    "наказывать",
                     "унижать",
                     "карать",
-                    "унижать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «demütigen»?",
-                "choices": [
-                    "гнев",
-                    "унижать",
-                    "наказание",
-                    "карать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erniedrigen»?",
-                "choices": [
                     "наказывать",
-                    "карать",
-                    "унижать",
-                    "наказание"
+                    "гнев"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «quälen»?",
+                "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "мучить",
-                    "наказание",
                     "унижать",
-                    "карать"
+                    "наказывать",
+                    "карать",
+                    "гнев"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erniedrigen»?",
+                "choices": [
+                    "унижать",
+                    "наказывать",
+                    "наказание",
+                    "мучить"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «quälen»?",
+                "choices": [
+                    "унижать",
+                    "карать",
+                    "наказание",
+                    "мучить"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3022,6 +3678,188 @@
     "torturer": {
         "title": "Мучитель",
         "description": "Акт III: Ослепляет Глостера",
+        "vocabulary": [
+            {
+                "german": "die Folter",
+                "russian": "пытка",
+                "sentence": "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl. Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten.",
+                "sentence_translation": "В мрачном зале Корнуолл приковывает графа к дубовому креслу. Твёрдым голосом я клянусь себе: слово «пытка» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди ФОЛЬ-тер]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Im düsteren Saal bindet Cornwall den Grafen an den eichenen Stuhl.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Folter“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "пытка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Sadismus",
+                "russian": "садизм",
+                "sentence": "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut. Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под скрип канатов слуги Реганы раздувают огонь, пока Корнуолл наблюдает. Я черчу слово «садизм» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер за-ДИС-мус]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Neben knirschenden Seilen entfachen Regans Diener das Feuer, während Cornwall zuschaut.",
+                    "Ich zeichne das Wort „der Sadismus“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "садизм"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Blut",
+                "russian": "кровь",
+                "sentence": "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen. Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед собравшимся рыцарством Корнуолл велит приготовить кинжалы. Я черчу слово «кровь» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дас БЛУТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der versammelten Ritterschaft lässt Cornwall die Dolche bereitlegen.",
+                    "Ich zeichne das Wort „das Blut“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "кровь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "foltern",
+                "russian": "пытать",
+                "sentence": "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig.",
+                "sentence_translation": "На забрызганном кровью полу Корнуолл выбивает признание из пленника. Каждой клеткой тела я обещаю: слово «пытать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ФОЛЬ-терн]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Am blutbefleckten Boden tritt Cornwall das Geständnis aus dem Gefangenen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „foltern“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "пытать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verstümmeln",
+                "russian": "калечить",
+                "sentence": "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt. Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern.",
+                "sentence_translation": "Среди вскрикивающих слуг Корнуолл остаётся ледяным и неподвижным. Даже если мир распадается, слово «калечить» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[фер-ШТЮМ-мельн]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus"
+                ],
+                "sentence_parts": [
+                    "Zwischen aufschreienden Dienern bleibt Cornwall eiskalt und unbewegt.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verstümmeln“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "калечить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "blenden",
+                "russian": "ослеплять",
+                "sentence": "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende. Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Под ликование Реганы Корнуолл довершает жестокую работу. Моё дыхание рисует слово «ослеплять» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[БЛЕН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter Regans Jubel reißt Cornwall das grausame Werk zu Ende.",
+                    "Mein Atem zeichnet das Wort „blenden“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "ослеплять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ausstechen",
+                "russian": "выкалывать",
+                "sentence": "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentence_translation": "Перед ужаснувшимися придворными Корнуолл стирает кровь с сапога. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
+                "russian_hint": "",
+                "transcription": "[АУС-ште-хен]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Vor den entsetzten Augen des Hofes wischt Cornwall das Blut vom Stiefel.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "выкалывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Qual",
+                "russian": "мука",
+                "sentence": "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür. Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В отзвуках криков Корнуолл поправляет плащ и разворачивается к двери. Я обнимаю слово «мука», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди КВАЛЬ]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Im Nachhall der Schreie richtet Cornwall den Mantel und wendet sich zur Tür.",
+                    "Ich umarme das Wort „die Qual“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "мука",
+                    "мучение"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Folter",
@@ -3269,10 +4107,10 @@
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "кровь",
-                    "садизм",
                     "пытка",
-                    "пытать"
+                    "садизм",
+                    "пытать",
+                    "кровь"
                 ],
                 "correctIndex": 1
             },
@@ -3280,61 +4118,61 @@
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
                     "ослеплять",
-                    "мука",
                     "кровь",
-                    "калечить"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «foltern»?",
-                "choices": [
-                    "выкалывать",
-                    "кровь",
-                    "ослеплять",
-                    "пытать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verstümmeln»?",
-                "choices": [
-                    "садизм",
-                    "пытка",
                     "калечить",
-                    "ослеплять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «blenden»?",
-                "choices": [
-                    "кровь",
-                    "ослеплять",
-                    "пытка",
                     "мука"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «ausstechen»?",
+                "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
+                    "пытать",
                     "калечить",
-                    "мука",
                     "кровь",
+                    "пытка"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verstümmeln»?",
+                "choices": [
+                    "пытка",
+                    "калечить",
+                    "кровь",
+                    "ослеплять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «blenden»?",
+                "choices": [
+                    "пытать",
+                    "калечить",
+                    "ослеплять",
                     "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «ausstechen»?",
+                "choices": [
+                    "выкалывать",
+                    "ослеплять",
+                    "пытать",
+                    "садизм"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
+                    "мука",
+                    "пытать",
                     "калечить",
-                    "кровь",
-                    "пытка",
-                    "мука"
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3424,6 +4262,151 @@
     "wounded": {
         "title": "Раненый",
         "description": "Акт III: Ранен слугой",
+        "vocabulary": [
+            {
+                "german": "die Wunde",
+                "russian": "рана",
+                "sentence": "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde. Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus.",
+                "sentence_translation": "В тёмном коридоре Корнуолл прижимает руку к свежей ране. Я глубоко вдыхаю и выпускаю только слово «рана».",
+                "russian_hint": "",
+                "transcription": "[ди ВУН-де]",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Korridor presst Cornwall die Hand gegen die frische Wunde.",
+                    "Ich atme tief ein und lasse nur das Wort „die Wunde“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "рана"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Schmerz",
+                "russian": "боль",
+                "sentence": "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt. Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На лестнице Корнуолл пошатывается, окрашивая камень кровью. Холодный свет заставляет слово «боль» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер ШМЕРЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der Treppe taumelt Cornwall, während das Blut den Stein färbt.",
+                    "Das kalte Licht lässt das Wort „der Schmerz“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "боль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Überraschung",
+                "russian": "удивление",
+                "sentence": "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer. Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Рядом с испуганным голосом Реганы Корнуолл ищет опоры в перилах. Я вывожу слово «удивление» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди ю-бер-РА-шунг]",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
+                "sentence_parts": [
+                    "Neben Regans erschrockener Stimme sucht Cornwall Halt am Geländer.",
+                    "Ich zeichne das Wort „die Überraschung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "удивление"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bluten",
+                "russian": "кровоточить",
+                "sentence": "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden. Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В конюшне Корнуолл тянется к седлу, но силы уходят. Я обнимаю слово «кровоточить», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[БЛУ-тен]",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
+                "sentence_parts": [
+                    "Im Stall greift Cornwall nach einem Sattel, doch die Kräfte schwinden.",
+                    "Ich umarme das Wort „bluten“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "кровоточить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verwundet",
+                "russian": "раненый",
+                "sentence": "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern.",
+                "sentence_translation": "Перед воротами замка Корнуолл оставляет след из красной пыли. Даже если мир распадается, слово «раненый» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[фер-ВУН-дет]",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
+                "sentence_parts": [
+                    "Vor dem Tor der Burg hinterlässt Cornwall eine Spur aus rotem Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verwundet“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "раненый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schwächen",
+                "russian": "ослаблять",
+                "sentence": "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen. Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen.",
+                "sentence_translation": "На дворе Корнуолл падает среди испуганных стражников. Как тихая молитва слово «ослаблять» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ШВЕ-хен]",
+                "themes": [
+                    "Schmerz",
+                    "Wunde",
+                    "Überraschung"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hof sinkt Cornwall zwischen erschrockenen Wachen zusammen.",
+                    "Wie ein stilles Gebet legt sich das Wort „schwächen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "ослаблять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leiden",
+                "russian": "страдать",
+                "sentence": "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft. Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Под свинцовым небом Корнуолл клянётся в мести из последних сил. Холодный свет заставляет слово «страдать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ЛАЙ-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter dem bleiernen Himmel schwört Cornwall Rache mit letzter Kraft.",
+                    "Das kalte Licht lässt das Wort „leiden“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "страдать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Wunde",
@@ -3615,72 +4598,72 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
-                    "боль",
                     "кровоточить",
-                    "удивление",
-                    "рана"
+                    "рана",
+                    "боль",
+                    "удивление"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "боль",
+                    "удивление",
                     "рана",
                     "кровоточить",
-                    "удивление"
+                    "боль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
-                    "раненый",
-                    "страдать",
-                    "боль",
-                    "удивление"
+                    "удивление",
+                    "рана",
+                    "ослаблять",
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
                     "страдать",
+                    "раненый",
+                    "ослаблять",
+                    "кровоточить"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verwundet»?",
+                "choices": [
+                    "раненый",
+                    "боль",
                     "кровоточить",
+                    "ослаблять"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «schwächen»?",
+                "choices": [
+                    "удивление",
+                    "ослаблять",
                     "рана",
                     "боль"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verwundet»?",
-                "choices": [
-                    "страдать",
-                    "боль",
-                    "кровоточить",
-                    "раненый"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «schwächen»?",
-                "choices": [
-                    "ослаблять",
-                    "страдать",
-                    "кровоточить",
-                    "боль"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "ослаблять",
+                    "рана",
                     "страдать",
-                    "раненый",
-                    "кровоточить",
-                    "ослаблять"
+                    "удивление"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3760,6 +4743,173 @@
     "death": {
         "title": "Смерть тирана",
         "description": "Акт III: Умирает от раны",
+        "vocabulary": [
+            {
+                "german": "der Tod",
+                "russian": "смерть",
+                "sentence": "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На лестнице замка Корнуолл рушится на холодную площадку. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ТОД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Treppenhaus der Burg bricht Cornwall auf das kalte Steinpodest.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "смерть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Vergeltung",
+                "russian": "возмездие",
+                "sentence": "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem. Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Среди разбитого оружия Корнуолл лежит, хватая воздух. Холодный свет заставляет слово «возмездие» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ГЕЛЬ-тунг]",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbrochenen Waffen liegt Cornwall und ringt nach Atem.",
+                    "Das kalte Licht lässt das Wort „die Vergeltung“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "возмездие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Ende",
+                "russian": "конец",
+                "sentence": "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut. Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед ужаснувшимся взглядом Реганы Корнуолл теряет хватку на собственной ране. Я держу слово «конец» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дас ЕН-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor Regans entsetztem Blick verliert Cornwall den Griff um das eigene Blut.",
+                    "Ich halte das Wort „das Ende“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "конец"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sterben",
+                "russian": "умирать",
+                "sentence": "Am Fuß der Treppe murmelt Cornwall die letzten Befehle. Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "У подножия лестницы Корнуолл бормочет последние приказы. Я обнимаю слово «умирать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ШТЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Fuß der Treppe murmelt Cornwall die letzten Befehle.",
+                    "Ich umarme das Wort „sterben“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "умирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verenden",
+                "russian": "издыхать",
+                "sentence": "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen. Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На холодном сундуке со знамёнами Корнуолл тяжело оседает. Моё дыхание рисует слово «издыхать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-ЕН-ден]",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Flaggenkiste sinkt Cornwall schwer zusammen.",
+                    "Mein Atem zeichnet das Wort „verenden“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "издыхать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verfluchen",
+                "russian": "проклинать",
+                "sentence": "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus. Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten.",
+                "sentence_translation": "У разбитых окон Корнуолл выдыхает последний проклятый звук. Твёрдым голосом я клянусь себе: слово «проклинать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[фер-ФЛУ-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben zerborstenen Fenstern haucht Cornwall den letzten Fluch aus.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verfluchen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "проклинать",
+                    "fluchen — тоже «проклинать»",
+                    "verwünschen — тоже «проклинать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "röcheln",
+                "russian": "хрипеть",
+                "sentence": "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch. Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Под проливным дождём жизнь Корнуолл быстро гаснет. Я держу слово «хрипеть» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[РЁ-хельн]",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung"
+                ],
+                "sentence_parts": [
+                    "Unter dem prasselnden Regen verglimmt Cornwalls Leben rasch.",
+                    "Ich halte das Wort „röcheln“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "хрипеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Strafe",
+                "russian": "кара",
+                "sentence": "Im Staub des Hofes starrt Cornwall zum grauen Himmel, bevor die Augen erlöschen. Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus.",
+                "sentence_translation": "В пыли двора Корнуолл смотрит в серое небо, прежде чем глаза угасают. Я глубоко вдыхаю и выпускаю только слово «кара».",
+                "russian_hint": "",
+                "transcription": "[ди ШТРА-фе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Staub des Hofes starrt Cornwall zum grauen Himmel,",
+                    "bevor die Augen erlöschen.",
+                    "Ich atme tief ein und lasse nur das Wort „die Strafe“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "кара",
+                    "наказание"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Tod",
@@ -3991,9 +5141,9 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "смерть",
-                    "умирать",
+                    "возмездие",
                     "конец",
-                    "возмездие"
+                    "умирать"
                 ],
                 "correctIndex": 0
             },
@@ -4002,37 +5152,37 @@
                 "choices": [
                     "умирать",
                     "конец",
-                    "смерть",
-                    "возмездие"
+                    "возмездие",
+                    "смерть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "хрипеть",
-                    "конец",
+                    "смерть",
                     "проклинать",
-                    "смерть"
+                    "конец"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "конец",
-                    "смерть",
                     "умирать",
-                    "возмездие"
+                    "возмездие",
+                    "кара",
+                    "проклинать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "умирать",
-                    "хрипеть",
+                    "кара",
                     "конец",
+                    "проклинать",
                     "издыхать"
                 ],
                 "correctIndex": 3
@@ -4040,32 +5190,32 @@
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "хрипеть",
-                    "проклинать",
-                    "смерть",
-                    "кара"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «röcheln»?",
-                "choices": [
-                    "проклинать",
+                    "издыхать",
                     "кара",
-                    "конец",
-                    "хрипеть"
+                    "смерть",
+                    "проклинать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Strafe»?",
+                "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
                     "кара",
-                    "издыхать",
-                    "конец",
-                    "проклинать"
+                    "возмездие",
+                    "хрипеть",
+                    "конец"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Strafe»?",
+                "choices": [
+                    "умирать",
+                    "проклинать",
+                    "кара",
+                    "смерть"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4159,6 +5309,9 @@ const characterId = "cornwall";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "королевство", "доверять", "наследник"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["доверять", "знать", "королевство", "наследник"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["доверять", "королевство", "граф", "ничего не подозревающий"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["граф", "доверять", "знать", "королевство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "наследник", "законный", "королевство"], "correct_index": 0}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["граф", "законный", "знать", "наследник"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["доверять", "законный", "граф", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["ничего не подозревающий", "граф", "законный", "наследник"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["предательство", "опасность", "бежать", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "предательство", "опасность", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["преследовать", "предательство", "прятаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "обман", "интрига", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["обман", "изгнать", "прятаться", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "опасность", "изгнать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["интрига", "прятаться", "предательство", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["преследовать", "прятаться", "изгнать", "бежать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "безумие", "маскировка", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["маскировка", "голый", "нищий", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["голый", "нищий", "безумный", "маскировка"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["нищета", "маскировка", "голый", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищий", "бормотать", "маскировка", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["безумный", "голый", "нищета", "дрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "безумие", "маскировка", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["нищета", "безумный", "голый", "безумие"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "буря", "страдать", "хижина"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "хижина", "буря", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "молния", "хижина", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["мёрзнуть", "буря", "хижина", "молния"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["сопровождать", "молния", "гром", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "страдать", "защищать", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["мёрзнуть", "гром", "буря", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["мёрзнуть", "хижина", "сопровождать", "молния"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["обманывать", "утёс", "вести", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «führen»?", "choices": ["слепой", "утёс", "вести", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "вести", "утешать", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "утешать", "отчаяние", "вести"], "correct_index": 0}, {"question": "Что означает немецкое слово «retten»?", "choices": ["хитрость", "спасать", "утёс", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["утёс", "слепой", "хитрость", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утёс", "спасать", "утешать", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["утёс", "хитрость", "спасать", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["дуэль", "бой", "разоблачать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["бой", "дуэль", "разоблачать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["брат", "побеждать", "месть", "разоблачать"], "correct_index": 2}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["меч", "месть", "брат", "разоблачать"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["разоблачать", "побеждать", "меч", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["меч", "бой", "справедливость", "разоблачать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "месть", "побеждать", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["брат", "бой", "справедливость", "дуэль"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["будущее", "править", "наследовать", "выживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "будущее", "править", "выживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "будущее", "наследовать", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["новый", "порядок", "ответственность", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "новый", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["править", "будущее", "порядок", "ответственность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["править", "будущее", "ответственность", "порядок"], "correct_index": 2}, {"question": "Что означает немецкое слово «neu»?", "choices": ["порядок", "мудрость", "новый", "ответственность"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "королевство", "наследник", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["знать", "доверять", "королевство", "наследник"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["королевство", "граф", "знать", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["честь", "знать", "доверять", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["законный", "ничего не подозревающий", "знать", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["граф", "королевство", "законный", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "королевство", "доверять", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["граф", "знать", "законный", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "опасность", "предательство", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["преследовать", "предательство", "бежать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["прятаться", "предательство", "опасность", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["обман", "изгнать", "преследовать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["предательство", "опасность", "прятаться", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["бежать", "изгнать", "интрига", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["опасность", "обман", "прятаться", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["опасность", "предательство", "изгнать", "обман"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "голый", "маскировка", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "маскировка", "нищий", "голый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["бормотать", "дрожать", "маскировка", "голый"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["безумный", "голый", "нищий", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["безумие", "голый", "бормотать", "дрожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "бормотать", "нищий", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "нищета", "безумный", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["бормотать", "маскировка", "безумный", "нищий"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["хижина", "мёрзнуть", "страдать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "буря", "мёрзнуть", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["молния", "хижина", "сопровождать", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["сопровождать", "защищать", "гром", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["буря", "сопровождать", "защищать", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["буря", "гром", "страдать", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["защищать", "молния", "буря", "мёрзнуть"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "обманывать", "утёс", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «führen»?", "choices": ["вести", "слепой", "утёс", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["вести", "утешать", "утёс", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["утешать", "слепой", "обманывать", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["хитрость", "спасать", "отчаяние", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["утешать", "хитрость", "отчаяние", "вести"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["хитрость", "утешать", "утёс", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "утешать", "спасать", "слепой"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["месть", "дуэль", "разоблачать", "бой"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["месть", "дуэль", "бой", "разоблачать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "справедливость", "дуэль", "побеждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["разоблачать", "месть", "меч", "бой"], "correct_index": 0}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["справедливость", "бой", "дуэль", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["брат", "бой", "справедливость", "разоблачать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["побеждать", "разоблачать", "месть", "меч"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["разоблачать", "месть", "брат", "меч"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "наследовать", "будущее", "выживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["будущее", "выживать", "править", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["будущее", "ответственность", "порядок", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["выживать", "править", "новый", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["править", "новый", "порядок", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["порядок", "ответственность", "будущее", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["мудрость", "порядок", "ответственность", "выживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «neu»?", "choices": ["новый", "править", "ответственность", "будущее"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -670,9 +670,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -682,9 +682,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                             
@@ -694,47 +694,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
@@ -742,49 +726,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,17 +797,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -817,7 +817,23 @@
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
@@ -829,33 +845,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -865,9 +865,41 @@
                         <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
@@ -877,49 +909,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,13 +932,13 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
@@ -952,9 +952,73 @@
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
@@ -964,47 +1028,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
@@ -1012,49 +1044,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,33 +1067,33 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,59 +1105,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1167,29 +1167,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1206,11 +1206,11 @@
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
@@ -1218,15 +1218,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «führen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -1234,33 +1234,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1274,39 +1274,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -1314,17 +1282,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1337,17 +1337,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1357,61 +1357,61 @@
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,7 +1421,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
@@ -1433,33 +1433,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1476,11 +1476,11 @@
                         <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                             
@@ -1488,63 +1488,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
@@ -1552,17 +1504,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1572,29 +1572,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «neu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1616,6 +1616,172 @@
     "throne": {
         "title": "Благородный сын",
         "description": "Акт I: Законный наследник",
+        "vocabulary": [
+            {
+                "german": "der Adel",
+                "russian": "знать",
+                "sentence": "Edgar steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig.",
+                "sentence_translation": "Эдгар стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «знать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[дер А-дель]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Edgar steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Adel“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "знать",
+                    "kennen — тоже «знать»",
+                    "wissen — тоже «знать»",
+                    "дворянство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Erbe",
+                "russian": "наследник",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch. Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У развернутой карты королевства Эдгар склоняется над тяжёлым столом Лира. Моё дыхание рисует слово «наследник» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ЕР-бе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edgar über Lears schweren Tisch.",
+                    "Mein Atem zeichnet das Wort „der Erbe“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "наследник"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Königreich",
+                "russian": "королевство",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken. Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen.",
+                "sentence_translation": "Перед каменными статуями предков Эдгар сцепляет руки за спиной. Как тихая молитва слово «королевство» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дас КЁ-ниг-райх]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edgar die Hände hinter dem Rücken.",
+                    "Wie ein stilles Gebet legt sich das Wort „das Königreich“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "королевство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vertrauen",
+                "russian": "доверять",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir.",
+                "sentence_translation": "Между шепчущимися придворными Эдгар скользит по холодному мраморному полу. Буря за окнами усиливает клятву: слово «доверять» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[фер-ТРАУ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen flüsternden Höflingen gleitet Edgar über den kalten Marmorboden.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vertrauen“ gehört mir."
+                ],
+                "synonyms": [
+                    "доверять",
+                    "misstrauen — тоже «доверять»",
+                    "trauen — тоже «доверять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ehre",
+                "russian": "честь",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs. Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen.",
+                "sentence_translation": "На краю пурпурного ковра Эдгар ждёт знака от короля. Как тихая молитва слово «честь» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди Э-ре]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand des purpurnen Teppichs wartet Edgar auf ein Zeichen des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ehre“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "честь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "legitim",
+                "russian": "законный",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig.",
+                "sentence_translation": "Под развевающимися штандартами сестёр Эдгар на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «законный» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ле-ги-ТИМ]",
+                "themes": [
+                    "Erbe",
+                    "Sohn",
+                    "edel"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edgar kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „legitim“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "законный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Graf",
+                "russian": "граф",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes. Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "За позолоченной балюстрадой Эдгар наблюдает за напряжёнными лицами двора. Холодный свет заставляет слово «граф» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер ГРАФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edgar das gespannte Antlitz des Hofes.",
+                    "Das kalte Licht lässt das Wort „der Graf“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "граф"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ahnungslos",
+                "russian": "ничего не подозревающий",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme. Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В отблесках открытых жаровен Эдгар медленно поднимает голос. Я стискиваю слово «ничего не подозревающий» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[А-нунгс-лос]",
+                "themes": [
+                    "Erbe",
+                    "Sohn",
+                    "edel"
+                ],
+                "sentence_parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edgar langsam die Stimme.",
+                    "Ich presse das Wort „ahnungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "ничего",
+                    "не",
+                    "misstrauen — тоже «не»",
+                    "подозревающий"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Adel",
@@ -1832,16 +1998,16 @@
                 "choices": [
                     "знать",
                     "королевство",
-                    "доверять",
-                    "наследник"
+                    "наследник",
+                    "доверять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "доверять",
                     "знать",
+                    "доверять",
                     "королевство",
                     "наследник"
                 ],
@@ -1850,62 +2016,62 @@
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "доверять",
                     "королевство",
                     "граф",
-                    "ничего не подозревающий"
+                    "знать",
+                    "честь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "граф",
-                    "доверять",
+                    "честь",
                     "знать",
+                    "доверять",
                     "королевство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "честь",
-                    "наследник",
                     "законный",
-                    "королевство"
+                    "ничего не подозревающий",
+                    "знать",
+                    "честь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «legitim»?",
                 "choices": [
                     "граф",
+                    "королевство",
                     "законный",
-                    "знать",
-                    "наследник"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Graf»?",
-                "choices": [
-                    "доверять",
-                    "законный",
-                    "граф",
-                    "наследник"
+                    "доверять"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «ahnungslos»?",
+                "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "ничего не подозревающий",
                     "граф",
-                    "законный",
-                    "наследник"
+                    "королевство",
+                    "доверять",
+                    "честь"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «ahnungslos»?",
+                "choices": [
+                    "граф",
+                    "знать",
+                    "законный",
+                    "ничего не подозревающий"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -1995,6 +2161,168 @@
     "goneril": {
         "title": "Бегство",
         "description": "Акт II: Предательство Эдмунда",
+        "vocabulary": [
+            {
+                "german": "fliehen",
+                "russian": "бежать",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten. Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern.",
+                "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдгар замирает среди нагруженных ящиков. Даже если мир распадается, слово «бежать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ФЛИ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edgar zwischen gepackten Kisten.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fliehen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "бежать",
+                    "rennen — тоже «бежать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Verrat",
+                "russian": "предательство",
+                "sentence": "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter. Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "На продуваемой ветром лестнице Эдгар смотрит вниз на молчаливый двор. Я обнимаю слово «предательство», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер фер-РАТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der windigen Freitreppe blickt Edgar zum schweigenden Hof hinunter.",
+                    "Ich umarme das Wort „der Verrat“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "предательство",
+                    "измена"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gefahr",
+                "russian": "опасность",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger. Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Среди оставленных слуг Эдгар плотнее запахивает дорожный плащ. Я вывожу слово «опасность» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди ге-ФАР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edgar den Reisemantel enger.",
+                    "Ich zeichne das Wort „die Gefahr“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "опасность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verfolgen",
+                "russian": "преследовать",
+                "sentence": "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne. Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "У тёмного конюшенного ряда Эдгар гладит гриву нервного коня. Я вывожу слово «преследовать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[фер-ФОЛЬ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Pferdestall streicht Edgar einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „verfolgen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "преследовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verstecken",
+                "russian": "прятаться",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor. Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Перед скрипящим подъёмным мостом Эдгар в последний раз касается родной двери. Холодный свет заставляет слово «прятаться» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[фер-ШТЕ-кен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem knarrenden Fallgatter tastet Edgar ein letztes Mal nach dem Haustor.",
+                    "Das kalte Licht lässt das Wort „verstecken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "прятать",
+                    "прятаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Intrige",
+                "russian": "интрига",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand. Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Среди разбросанных свитков Эдгар вертит кольцо на пальце. Моё дыхание рисует слово «интрига» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ин-ТРИ-ге]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edgar den Ring an der Hand.",
+                    "Mein Atem zeichnet das Wort „die Intrige“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "интрига",
+                    "die Affäre — тоже «интрига»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Betrug",
+                "russian": "обман",
+                "sentence": "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen. Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen.",
+                "sentence_translation": "У пустого банкетного стола Эдгар пересчитывает гаснущие свечи. Как тихая молитва слово «обман» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер бе-ТРУГ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am leeren Bankettisch zählt Edgar die verlöschenden Kerzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Betrug“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "обман",
+                    "die Täuschung — тоже «обман»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verbannen",
+                "russian": "изгнать",
+                "sentence": "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus. Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus.",
+                "sentence_translation": "Между молчаливыми стражниками Эдгар выходит на холодный двор. Я глубоко вдыхаю и выпускаю только слово «изгнать».",
+                "russian_hint": "",
+                "transcription": "[фер-БАН-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen schweigenden Wachen geht Edgar auf den kalten Hof hinaus.",
+                    "Ich atme tief ein und lasse nur das Wort „verbannen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "изгнать",
+                    "изгонять",
+                    "verstoßen — тоже «изгонять»",
+                    "vertreiben — тоже «изгонять»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "fliehen",
@@ -2209,80 +2537,80 @@
             {
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
-                    "предательство",
+                    "преследовать",
                     "опасность",
-                    "бежать",
-                    "преследовать"
+                    "предательство",
+                    "бежать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "бежать",
+                    "преследовать",
                     "предательство",
-                    "опасность",
-                    "преследовать"
+                    "бежать",
+                    "опасность"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "преследовать",
-                    "предательство",
                     "прятаться",
-                    "опасность"
+                    "предательство",
+                    "опасность",
+                    "преследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "преследовать",
                     "обман",
-                    "интрига",
-                    "прятаться"
+                    "изгнать",
+                    "преследовать",
+                    "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "обман",
-                    "изгнать",
+                    "предательство",
+                    "опасность",
                     "прятаться",
-                    "предательство"
+                    "обман"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "интрига",
-                    "опасность",
+                    "бежать",
                     "изгнать",
-                    "предательство"
+                    "интрига",
+                    "обман"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "интрига",
+                    "опасность",
+                    "обман",
                     "прятаться",
-                    "предательство",
-                    "обман"
+                    "предательство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
-                    "преследовать",
-                    "прятаться",
+                    "опасность",
+                    "предательство",
                     "изгнать",
-                    "бежать"
+                    "обман"
                 ],
                 "correctIndex": 2
             }
@@ -2374,6 +2702,180 @@
     "regan": {
         "title": "Том из Бедлама",
         "description": "Акт III: Превращение в безумца",
+        "vocabulary": [
+            {
+                "german": "der Wahnsinn",
+                "russian": "безумие",
+                "sentence": "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde. Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten.",
+                "sentence_translation": "В продуваемом ветром боковом крыле Эдгар слушает вой прибрежного ветра. Твёрдым голосом я клянусь себе: слово «безумие» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[дер ВАН-зин]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im zugigen Seitenflügel lauscht Edgar dem Heulen der Küstenwinde.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Wahnsinn“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "безумие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Bettler",
+                "russian": "нищий",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief. Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед дымным камином замка Эдгар складывает измятый лист. Я держу слово «нищий» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер БЕТ-лер]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edgar einen zerknitterten Brief.",
+                    "Ich halte das Wort „der Bettler“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "нищий"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verkleidung",
+                "russian": "маскировка",
+                "sentence": "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab. Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten.",
+                "sentence_translation": "Под выцветшими гобеленами Эдгар беспокойно меряет шагами зал. Твёрдым голосом я клянусь себе: слово «маскировка» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди фер-КЛАЙ-дунг]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "Unter farblosen Wandteppichen schreitet Edgar rastlos auf und ab.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Verkleidung“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "маскировка",
+                    "переодевание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "nackt",
+                "russian": "голый",
+                "sentence": "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof. Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У узкой бойницы Эдгар считает факелы на дворе. Я стискиваю слово «голый» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[НАКТ]",
+                "themes": [
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "nackt",
+                    "toben",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "An der schmalen Fensterluke zählt Edgar die Fackeln auf dem Hof.",
+                    "Ich presse das Wort „nackt“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "голый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "murmeln",
+                "russian": "бормотать",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften. Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Среди дорожных сундуков послов Эдгар ищет свежие вести. Я держу слово «бормотать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[МУР-мельн]",
+                "themes": [
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edgar nach frischen Botschaften.",
+                    "Ich halte das Wort „murmeln“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "бормотать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zittern",
+                "russian": "дрожать",
+                "sentence": "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur. Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В тихой капелле Эдгар преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «дрожать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ЦИ-терн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im stillen Kapellenraum kniet Edgar vor der kalten Steinfigur.",
+                    "Ich presse das Wort „zittern“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "дрожать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Elend",
+                "russian": "нищета",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest. Ich presse das Wort „das Elend“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На балконе, омываемом морскими брызгами, Эдгар крепко держит фонарь. Я стискиваю слово «нищета» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[дас Э-ленд]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edgar die Laterne fest.",
+                    "Ich presse das Wort „das Elend“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "нищета"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "wahnsinnig",
+                "russian": "безумный",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort. Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig.",
+                "sentence_translation": "В тени высоких стен Эдгар пишет лихорадочный ответ. Каждой клеткой тела я обещаю: слово «безумный» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ВАН-зи-ниг]",
+                "themes": [
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edgar eine fiebrige Antwort.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „wahnsinnig“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "безумный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Wahnsinn",
@@ -2601,82 +3103,82 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "голый",
                     "безумие",
+                    "голый",
                     "маскировка",
                     "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
+                    "безумие",
                     "маскировка",
-                    "голый",
                     "нищий",
-                    "безумие"
+                    "голый"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "голый",
-                    "нищий",
-                    "безумный",
-                    "маскировка"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «nackt»?",
-                "choices": [
-                    "нищета",
+                    "бормотать",
+                    "дрожать",
                     "маскировка",
-                    "голый",
-                    "нищий"
+                    "голый"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «murmeln»?",
+                "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
+                    "безумный",
+                    "голый",
                     "нищий",
-                    "бормотать",
-                    "маскировка",
-                    "безумие"
+                    "дрожать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «murmeln»?",
+                "choices": [
+                    "безумие",
+                    "голый",
+                    "бормотать",
+                    "дрожать"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "безумный",
-                    "голый",
-                    "нищета",
-                    "дрожать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Elend»?",
-                "choices": [
-                    "нищета",
-                    "безумие",
-                    "маскировка",
-                    "дрожать"
+                    "дрожать",
+                    "бормотать",
+                    "нищий",
+                    "безумие"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «wahnsinnig»?",
+                "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
+                    "нищий",
                     "нищета",
                     "безумный",
-                    "голый",
                     "безумие"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «wahnsinnig»?",
+                "choices": [
+                    "бормотать",
+                    "маскировка",
+                    "безумный",
+                    "нищий"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2767,6 +3269,180 @@
     "storm": {
         "title": "В буре",
         "description": "Акт III: Встреча с Лиром",
+        "vocabulary": [
+            {
+                "german": "der Sturm",
+                "russian": "буря",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentence_translation": "Посреди хлещущей дождём пустоши Эдгар упирается в ветер. Как тихая молитва слово «буря» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер ШТУРМ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edgar gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "буря"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "frieren",
+                "russian": "мёрзнуть",
+                "sentence": "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig.",
+                "sentence_translation": "Под разорванным знаменем Эдгар прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «мёрзнуть» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ФРИ-рен]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerrissenen Banner schützt Edgar die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „frieren“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "мёрзнуть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leiden",
+                "russian": "страдать",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner. Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus.",
+                "sentence_translation": "У поваленного дерева Эдгар ищет укрытия от грома. Я глубоко вдыхаю и выпускаю только слово «страдать».",
+                "russian_hint": "",
+                "transcription": "[ЛАЙ-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edgar Deckung vor dem Donner.",
+                    "Ich atme tief ein und lasse nur das Wort „leiden“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "страдать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hütte",
+                "russian": "хижина",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm. Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Между пенящимися лужами Эдгар пробирается через грязь. Я обнимаю слово «хижина», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди ХЮ-те]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Sturm",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edgar durch den Schlamm.",
+                    "Ich umarme das Wort „die Hütte“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "хижина"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beschützen",
+                "russian": "защищать",
+                "sentence": "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig.",
+                "sentence_translation": "На фоне вспыхивающего неба Эдгар упрямо поднимает руки. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[бе-ШЮ-цен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor einem zuckenden Himmel hebt Edgar die Arme trotzig an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „beschützen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "защищать",
+                    "schützen — тоже «защищать»",
+                    "verteidigen — тоже «защищать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begleiten",
+                "russian": "сопровождать",
+                "sentence": "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig.",
+                "sentence_translation": "Под промокшим плащом Эдгар прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «сопровождать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЛАЙ-тен]",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Unter dem durchtränkten Umhang presst Edgar den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „begleiten“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "сопровождать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Donner",
+                "russian": "гром",
+                "sentence": "Am kläglichen Feuerrest wärmt Edgar zitternde Finger. Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "У жалких огненных углей Эдгар греет дрожащие пальцы. Я черчу слово «гром» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер ДО-нер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am kläglichen Feuerrest wärmt Edgar zitternde Finger.",
+                    "Ich zeichne das Wort „der Donner“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "гром"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Blitz",
+                "russian": "молния",
+                "sentence": "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen.",
+                "sentence_translation": "Среди воющих псов Эдгар перекрикивает беснующуюся бурю. Я шепчу стражам судьбы: слово «молния» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[дер БЛИЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen heulenden Hunden ruft Edgar gegen den tosenden Sturm an.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Blitz“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "молния"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Sturm",
@@ -3005,81 +3681,81 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "мёрзнуть",
-                    "буря",
+                    "хижина",
                     "страдать",
-                    "хижина"
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "мёрзнуть",
                     "хижина",
-                    "буря",
-                    "страдать"
+                    "мёрзнуть",
+                    "страдать",
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
                     "страдать",
-                    "молния",
-                    "хижина",
-                    "защищать"
+                    "буря",
+                    "мёрзнуть",
+                    "сопровождать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "мёрзнуть",
-                    "буря",
+                    "молния",
                     "хижина",
-                    "молния"
+                    "сопровождать",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
                     "сопровождать",
-                    "молния",
+                    "защищать",
                     "гром",
-                    "защищать"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
+                    "буря",
                     "сопровождать",
-                    "страдать",
                     "защищать",
-                    "гром"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "мёрзнуть",
-                    "гром",
                     "буря",
-                    "страдать"
+                    "гром",
+                    "страдать",
+                    "защищать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "мёрзнуть",
-                    "хижина",
-                    "сопровождать",
-                    "молния"
+                    "защищать",
+                    "молния",
+                    "буря",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3169,6 +3845,178 @@
     "hut": {
         "title": "Проводник слепого",
         "description": "Акт IV: Спасение отца",
+        "vocabulary": [
+            {
+                "german": "blind",
+                "russian": "слепой",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus.",
+                "sentence_translation": "В тёмном шатре полевых лекарей Эдгар сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «слепой».",
+                "russian_hint": "",
+                "transcription": "[БЛИНД]",
+                "themes": [
+                    "Klippe",
+                    "bereuen",
+                    "blind",
+                    "führen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edgar bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „blind“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "слепой"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "führen",
+                "russian": "вести",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus.",
+                "sentence_translation": "Среди помятых доспехов Эдгар гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «вести».",
+                "russian_hint": "",
+                "transcription": "[ФЮ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edgar über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „führen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "вести",
+                    "verhalten — тоже «вести»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Klippe",
+                "russian": "утёс",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf. Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "О низкую балку хижины Эдгар едва не ударяется головой. Я держу слово «утёс» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди КЛИ-пе]",
+                "themes": [
+                    "Klippe",
+                    "blind",
+                    "führen"
+                ],
+                "sentence_parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edgar fast den Kopf.",
+                    "Ich halte das Wort „die Klippe“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "утёс"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "täuschen",
+                "russian": "обманывать",
+                "sentence": "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentence_translation": "Рядом со спящим стражем Эдгар шепчет в тяжёлую ночь. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ТОЙ-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schlafenden Wache flüstert Edgar in die schwere Nacht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+                ],
+                "synonyms": [
+                    "обманывать",
+                    "betrügen — тоже «обманывать»",
+                    "hintergehen — тоже «обманывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "retten",
+                "russian": "спасать",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten.",
+                "sentence_translation": "Перед грубой походной койкой Эдгар разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «спасать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[РЕ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem einfachen Feldbett betrachtet Edgar die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „retten“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "спасать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die List",
+                "russian": "хитрость",
+                "sentence": "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentence_translation": "В запахе влажной соломы Эдгар откладывает плащ в сторону. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ЛИСТ]",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Im Geruch von feuchtem Stroh legt Edgar den Mantel zur Seite.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "хитрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "trösten",
+                "russian": "утешать",
+                "sentence": "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe. Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen.",
+                "sentence_translation": "На шатком деревянном столе Эдгар раскладывает зачитанные письма. Я шепчу стражам судьбы: слово «утешать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ТРЁС-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem wackligen Holztisch ordnet Edgar zerlesene Briefe.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „trösten“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "утешать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verzweiflung",
+                "russian": "отчаяние",
+                "sentence": "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir.",
+                "sentence_translation": "У входа в хижину Эдгар высматривает знакомую тень. Буря за окнами усиливает клятву: слово «отчаяние» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ЦВАЙ-флунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Eingang der Hütte späht Edgar nach einem vertrauten Schatten.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Verzweiflung“ gehört mir."
+                ],
+                "synonyms": [
+                    "отчаяние"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "blind",
@@ -3398,9 +4246,9 @@
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
+                    "вести",
                     "обманывать",
                     "утёс",
-                    "вести",
                     "слепой"
                 ],
                 "correctIndex": 3
@@ -3408,72 +4256,72 @@
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
+                    "вести",
                     "слепой",
                     "утёс",
-                    "вести",
                     "обманывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
-                    "утёс",
                     "вести",
                     "утешать",
-                    "спасать"
+                    "утёс",
+                    "хитрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "обманывать",
                     "утешать",
-                    "отчаяние",
-                    "вести"
+                    "слепой",
+                    "обманывать",
+                    "хитрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
                     "хитрость",
                     "спасать",
-                    "утёс",
-                    "утешать"
+                    "отчаяние",
+                    "обманывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "утёс",
-                    "слепой",
+                    "утешать",
                     "хитрость",
-                    "спасать"
+                    "отчаяние",
+                    "вести"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "утёс",
-                    "спасать",
+                    "хитрость",
                     "утешать",
-                    "обманывать"
+                    "утёс",
+                    "спасать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "утёс",
-                    "хитрость",
+                    "отчаяние",
+                    "утешать",
                     "спасать",
-                    "отчаяние"
+                    "слепой"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3563,6 +4411,167 @@
     "dover": {
         "title": "Дуэль",
         "description": "Акт V: Поединок с Эдмундом",
+        "vocabulary": [
+            {
+                "german": "der Kampf",
+                "russian": "бой",
+                "sentence": "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern.",
+                "sentence_translation": "На белых скалах Дувра Эдгар смотрит в вздыбленный пролив. Даже если мир распадается, слово «бой» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дер КАМПФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf den weißen Klippen von Dover blickt Edgar in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Kampf“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "бой",
+                    "борьба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Duell",
+                "russian": "дуэль",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edgar den Helm. Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus.",
+                "sentence_translation": "Среди хлопающих штандартов Эдгар поправляет шлем. Я глубоко вдыхаю и выпускаю только слово «дуэль».",
+                "russian_hint": "",
+                "transcription": "[дас ду-ЭЛЬ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen flatternden Feldzeichen richtet Edgar den Helm.",
+                    "Ich atme tief ein und lasse nur das Wort „das Duell“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "дуэль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rache",
+                "russian": "месть",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand. Ich presse das Wort „die Rache“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У французского костра Эдгар рисует в песке путь марша. Я стискиваю слово «месть» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди РА-хе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edgar Marschrouten in den Sand.",
+                    "Ich presse das Wort „die Rache“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "месть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "enthüllen",
+                "russian": "разоблачать",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel. Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У перевязанных провиантных ящиков Эдгар проверяет печати. Я держу слово «разоблачать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[энт-ХЮ-лен]",
+                "themes": [
+                    "Bruder",
+                    "Kampf",
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edgar das Siegel.",
+                    "Ich halte das Wort „enthüllen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "разоблачать",
+                    "раскрывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "siegen",
+                "russian": "побеждать",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer. Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед шёлковым шатром полководцев Эдгар слушает глухой шум моря. Моё дыхание рисует слово «побеждать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ЗИ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edgar dem dumpfen Meer.",
+                    "Mein Atem zeichnet das Wort „siegen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "побеждать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gerechtigkeit",
+                "russian": "справедливость",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen.",
+                "sentence_translation": "На песчаном плацу Эдгар отрабатывает выхват меча. Я шепчу стражам судьбы: слово «справедливость» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ге-РЕХ-тиг-кайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem sandigen Trainingsplatz übt Edgar das Ziehen des Schwerts.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Gerechtigkeit“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "справедливость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Schwert",
+                "russian": "меч",
+                "sentence": "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung. Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Под гул барабанов Эдгар поднимает знамя надежды. Я вывожу слово «меч» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[дас ШВЕРТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen pochenden Trommeln hebt Edgar das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „das Schwert“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "меч"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Bruder",
+                "russian": "брат",
+                "sentence": "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen.",
+                "sentence_translation": "В утреннем тумане побережья Эдгар кладёт ладонь на бьющееся сердце. Как тихая молитва слово «брат» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер БРУ-дер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Morgennebel der Küste legt Edgar die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Bruder“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "брат"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Kampf",
@@ -3783,57 +4792,57 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
+                    "месть",
                     "дуэль",
-                    "бой",
                     "разоблачать",
-                    "месть"
+                    "бой"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "бой",
+                    "месть",
                     "дуэль",
-                    "разоблачать",
-                    "месть"
+                    "бой",
+                    "разоблачать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "брат",
-                    "побеждать",
                     "месть",
-                    "разоблачать"
+                    "справедливость",
+                    "дуэль",
+                    "побеждать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "меч",
+                    "разоблачать",
                     "месть",
-                    "брат",
-                    "разоблачать"
+                    "меч",
+                    "бой"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "разоблачать",
-                    "побеждать",
-                    "меч",
-                    "дуэль"
+                    "справедливость",
+                    "бой",
+                    "дуэль",
+                    "побеждать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "меч",
+                    "брат",
                     "бой",
                     "справедливость",
                     "разоблачать"
@@ -3843,22 +4852,22 @@
             {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
-                    "меч",
-                    "месть",
                     "побеждать",
-                    "справедливость"
+                    "разоблачать",
+                    "месть",
+                    "меч"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
+                    "разоблачать",
+                    "месть",
                     "брат",
-                    "бой",
-                    "справедливость",
-                    "дуэль"
+                    "меч"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3949,6 +4958,177 @@
     "prison": {
         "title": "Наследник",
         "description": "Акт V: Новый граф",
+        "vocabulary": [
+            {
+                "german": "überleben",
+                "russian": "выживать",
+                "sentence": "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein. Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "В сыром подземелье Эдгар опирается на сочащийся камень. Я держу слово «выживать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ю-бер-ЛЕ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im feuchten Kerker stützt Edgar sich an den tropfenden Stein.",
+                    "Ich halte das Wort „überleben“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "выживать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erben",
+                "russian": "наследовать",
+                "sentence": "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette. Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten.",
+                "sentence_translation": "Под мутным фонарём Эдгар пересчитывает железные кольца цепи. Твёрдым голосом я клянусь себе: слово «наследовать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ЭР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter der trüben Laterne zählt Edgar die eisernen Ringe der Kette.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „erben“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "наследовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Zukunft",
+                "russian": "будущее",
+                "sentence": "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen. Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У тяжёлой двери Эдгар прислушивается к далёким рыданиям. Эхо слова «будущее» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ЦУ-кунфт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schweren Holztür horcht Edgar auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „die Zukunft“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "будущее"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "regieren",
+                "russian": "править",
+                "sentence": "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus.",
+                "sentence_translation": "На холодной каменной скамье Эдгар плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «править».",
+                "russian_hint": "",
+                "transcription": "[ре-ГИ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Steinbank zieht Edgar den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „regieren“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "править",
+                    "herrschen — тоже «править»",
+                    "управлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Weisheit",
+                "russian": "мудрость",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht. Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Между тенями решёток Эдгар поднимает лицо к свету. Я держу слово «мудрость» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ВАЙС-хайт]",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edgar das Gesicht zum Licht.",
+                    "Ich halte das Wort „die Weisheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "мудрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ordnung",
+                "russian": "порядок",
+                "sentence": "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig.",
+                "sentence_translation": "У ржавого ведра с водой Эдгар на мгновение видит отражение глаз. Каждой клеткой тела я обещаю: слово «порядок» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ОРД-нунг]",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Am rostigen Wassereimer spiegelt Edgar kurz die eigenen Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ordnung“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "порядок"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verantwortung",
+                "russian": "ответственность",
+                "sentence": "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen.",
+                "sentence_translation": "В глухом эхе шагов Эдгар отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «ответственность» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди фер-АНТ-вор-тунг]",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Im dumpfen Hall der Schritte zählt Edgar den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Verantwortung“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "ответственность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "neu",
+                "russian": "новый",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub. Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten.",
+                "sentence_translation": "Перед заколоченным окном Эдгар чертит круги в пыли. Твёрдым голосом я клянусь себе: слово «новый» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[НОЙ]",
+                "themes": [
+                    "Erbe",
+                    "Zukunft",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Vor dem verriegelten Fenster zeichnet Edgar Kreise in den Staub.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „neu“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "новый"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "überleben",
@@ -4171,9 +5351,9 @@
             {
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
-                    "будущее",
                     "править",
                     "наследовать",
+                    "будущее",
                     "выживать"
                 ],
                 "correctIndex": 3
@@ -4181,72 +5361,72 @@
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
                     "будущее",
-                    "править",
-                    "выживать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Zukunft»?",
-                "choices": [
                     "выживать",
-                    "будущее",
-                    "наследовать",
-                    "мудрость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «regieren»?",
-                "choices": [
-                    "новый",
-                    "порядок",
-                    "ответственность",
-                    "править"
+                    "править",
+                    "наследовать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Zukunft»?",
+                "choices": [
+                    "будущее",
+                    "ответственность",
+                    "порядок",
+                    "править"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «regieren»?",
+                "choices": [
+                    "выживать",
+                    "править",
+                    "новый",
+                    "наследовать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "мудрость",
+                    "править",
                     "новый",
-                    "выживать",
+                    "порядок",
+                    "мудрость"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Ordnung»?",
+                "choices": [
+                    "порядок",
+                    "ответственность",
+                    "будущее",
                     "наследовать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Ordnung»?",
-                "choices": [
-                    "править",
-                    "будущее",
-                    "порядок",
-                    "ответственность"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
-                    "править",
-                    "будущее",
+                    "мудрость",
+                    "порядок",
                     "ответственность",
-                    "порядок"
+                    "выживать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «neu»?",
                 "choices": [
-                    "порядок",
-                    "мудрость",
                     "новый",
-                    "ответственность"
+                    "править",
+                    "ответственность",
+                    "будущее"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4339,6 +5519,9 @@ const characterId = "edgar";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "обделённый", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "бастард", "обделённый", "амбиция"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["амбиция", "зависть", "бастард", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["амбиция", "обделённый", "возвышаться", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["внебрачный", "месть", "амбиция", "возвышаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["природа", "возвышаться", "зависть", "амбиция"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["амбиция", "обделённый", "возвышаться", "внебрачный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["месть", "природа", "обделённый", "амбиция"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["интриговать", "план", "обвинять", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "интриговать", "план", "подделывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["подделывать", "обвинять", "манипулировать", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "обман", "обвинять", "лгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "лгать", "интриговать", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "письмо", "манипулировать", "лгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["лгать", "манипулировать", "письмо", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["лгать", "интриговать", "манипулировать", "обман"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["наследовать", "успех", "изгонять", "торжествовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["успех", "изгонять", "наследовать", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "вытеснять", "изгонять", "торжествовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "изгонять", "вытеснять", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["награда", "выигрывать", "вытеснять", "победа"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "победа", "выигрывать", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["успех", "вытеснять", "победа", "выигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["торжествовать", "выигрывать", "победа", "вытеснять"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["объединяться", "союз", "завоёвывать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["завоёвывать", "союз", "объединяться", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["власть", "завоёвывать", "завоевание", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["союз", "завоевание", "господствовать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["завоевание", "завоёвывать", "соблазнять", "господствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["завоёвывать", "альянс", "завоевание", "объединяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["союз", "завоевание", "соблазнять", "господствовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["альянс", "завоёвывать", "завоевание", "объединяться"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["ослеплять", "предавать", "доносить", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["доносить", "ослеплять", "предавать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "беспощадный", "доносить", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["предавать", "выдавать", "ослеплять", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["ослеплять", "выдавать", "пытка", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выдавать", "беспощадный", "доносить", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["предавать", "пытка", "жертвовать", "выдавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жертвовать", "пытка", "жестокость", "беспощадный"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["играть", "завлекать", "любовная связь", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "завлекать", "соперничество", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["жонглировать", "соперничество", "любовная связь", "играть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["жонглировать", "любовная связь", "завлекать", "похоть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["интрига", "похоть", "любовная связь", "жонглировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "любовная связь", "играть", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["любовная связь", "интрига", "жонглировать", "завлекать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "любовная связь", "завлекать", "играть"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "поражение", "дуэль", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["дуэль", "падать", "сожалеть", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["конец", "проигрывать", "поражение", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["проигрывать", "признаваться", "поражение", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["падать", "падение", "дуэль", "признаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["поражение", "конец", "признаваться", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["поражение", "дуэль", "сожалеть", "конец"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "обделённый", "зависть", "бастард"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "обделённый", "амбиция", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["бастард", "амбиция", "природа", "обделённый"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["месть", "бастард", "обделённый", "возвышаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["природа", "амбиция", "месть", "бастард"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["возвышаться", "бастард", "амбиция", "внебрачный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["амбиция", "внебрачный", "месть", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["зависть", "бастард", "амбиция", "природа"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["план", "интриговать", "обвинять", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["план", "обвинять", "интриговать", "подделывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["подделывать", "лгать", "обвинять", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["подделывать", "обман", "манипулировать", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "письмо", "план", "подделывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["обвинять", "обман", "письмо", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["письмо", "манипулировать", "лгать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["манипулировать", "обман", "план", "письмо"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["наследовать", "торжествовать", "изгонять", "успех"], "correct_index": 2}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["успех", "наследовать", "торжествовать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["вытеснять", "изгонять", "выигрывать", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["наследовать", "выигрывать", "победа", "успех"], "correct_index": 3}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["торжествовать", "изгонять", "выигрывать", "победа"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["вытеснять", "награда", "победа", "выигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["изгонять", "вытеснять", "успех", "выигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["изгонять", "успех", "победа", "торжествовать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["завоёвывать", "объединяться", "власть", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "власть", "завоёвывать", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["альянс", "завоёвывать", "соблазнять", "объединяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["завоевание", "соблазнять", "альянс", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["власть", "альянс", "господствовать", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["завоевание", "власть", "соблазнять", "союз"], "correct_index": 0}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["господствовать", "союз", "завоёвывать", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["союз", "господствовать", "альянс", "соблазнять"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["жестокость", "предавать", "ослеплять", "доносить"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["предавать", "жестокость", "ослеплять", "доносить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "предавать", "пытка", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["жертвовать", "доносить", "жестокость", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["пытка", "ослеплять", "выдавать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["беспощадный", "пытка", "предавать", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["выдавать", "предавать", "жертвовать", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["предавать", "беспощадный", "жертвовать", "доносить"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["соперничество", "завлекать", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "соперничество", "любовная связь", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["играть", "любовная связь", "жонглировать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["любовная связь", "завлекать", "соперничество", "жонглировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["соперничество", "жонглировать", "использовать", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "любовная связь", "похоть", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["использовать", "любовная связь", "жонглировать", "похоть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "играть", "жонглировать", "соперничество"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["падать", "дуэль", "поражение", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["сожалеть", "дуэль", "падать", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["конец", "признаваться", "проигрывать", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["признаваться", "дуэль", "падение", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["падать", "проигрывать", "дуэль", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["падать", "падение", "признаваться", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["дуэль", "признаваться", "проигрывать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "признаваться", "поражение", "сожалеть"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -684,41 +684,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
@@ -726,15 +694,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
                             
@@ -742,31 +726,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                             
@@ -774,17 +758,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -801,9 +801,9 @@
                         <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
@@ -813,15 +813,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
                             
@@ -829,33 +829,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -867,39 +867,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                             
@@ -909,17 +893,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,57 +938,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
@@ -996,15 +980,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                             
@@ -1012,17 +1012,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,11 +1032,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
                             
@@ -1048,13 +1048,13 @@
                         <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,33 +1067,33 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1103,11 +1103,43 @@
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
@@ -1115,81 +1147,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1206,29 +1206,29 @@
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1240,41 +1240,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
@@ -1282,17 +1282,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1302,29 +1302,29 @@
                         <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1337,31 +1337,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
                             
@@ -1369,49 +1353,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1425,7 +1425,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
@@ -1437,13 +1437,13 @@
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1455,11 +1455,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1480,7 +1480,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1488,65 +1504,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1560,41 +1560,41 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1616,6 +1616,171 @@
     "throne": {
         "title": "Незаконнорождённый",
         "description": "Акт I: Зависть бастарда",
+        "vocabulary": [
+            {
+                "german": "der Bastard",
+                "russian": "бастард",
+                "sentence": "Edmund steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Эдмунд стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «бастард» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер БАС-тард]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Edmund steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „der Bastard“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "бастард"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Neid",
+                "russian": "зависть",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch. Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "У развернутой карты королевства Эдмунд склоняется над тяжёлым столом Лира. Я обнимаю слово «зависть», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер НАЙД]",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
+                "sentence_parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Edmund über Lears schweren Tisch.",
+                    "Ich umarme das Wort „der Neid“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "зависть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ambition",
+                "russian": "амбиция",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken. Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Перед каменными статуями предков Эдмунд сцепляет руки за спиной. Эхо слова «амбиция» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ам-би-ЦИ-он]",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
+                "sentence_parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Edmund die Hände hinter dem Rücken.",
+                    "Das Echo des Wortes „die Ambition“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "амбиция"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "benachteiligt",
+                "russian": "обделённый",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden. Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Между шепчущимися придворными Эдмунд скользит по холодному мраморному полу. Я черчу слово «обделённый» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[бе-НАХ-тай-лигт]",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
+                "sentence_parts": [
+                    "Zwischen flüsternden Höflingen gleitet Edmund über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „benachteiligt“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "обделённый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rache",
+                "russian": "месть",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs. Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На краю пурпурного ковра Эдмунд ждёт знака от короля. Моё дыхание рисует слово «месть» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди РА-хе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand des purpurnen Teppichs wartet Edmund auf ein Zeichen des Königs.",
+                    "Mein Atem zeichnet das Wort „die Rache“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "месть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufsteigen",
+                "russian": "возвышаться",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick. Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Под развевающимися штандартами сестёр Эдмунд на миг опускает взгляд. Я вывожу слово «возвышаться» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[АУФ-штай-ген]",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Edmund kurz den Blick.",
+                    "Ich zeichne das Wort „aufsteigen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "возвышаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unehelich",
+                "russian": "внебрачный",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir.",
+                "sentence_translation": "За позолоченной балюстрадой Эдмунд наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «внебрачный» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[УН-э-е-лих]",
+                "themes": [
+                    "Ambition",
+                    "Bastard",
+                    "Neid"
+                ],
+                "sentence_parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Edmund das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unehelich“ gehört mir."
+                ],
+                "synonyms": [
+                    "внебрачный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Natur",
+                "russian": "природа",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen.",
+                "sentence_translation": "В отблесках открытых жаровен Эдмунд медленно поднимает голос. Я шепчу стражам судьбы: слово «природа» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди на-ТУР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Edmund langsam die Stimme.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Natur“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "природа",
+                    "die Wildnis — тоже «природа»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Bastard",
@@ -1841,71 +2006,71 @@
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
                     "зависть",
-                    "бастард",
                     "обделённый",
-                    "амбиция"
+                    "амбиция",
+                    "бастард"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "амбиция",
-                    "зависть",
                     "бастард",
-                    "месть"
+                    "амбиция",
+                    "природа",
+                    "обделённый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
-                    "амбиция",
+                    "месть",
+                    "бастард",
                     "обделённый",
-                    "возвышаться",
-                    "бастард"
+                    "возвышаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "внебрачный",
-                    "месть",
+                    "природа",
                     "амбиция",
-                    "возвышаться"
+                    "месть",
+                    "бастард"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "природа",
                     "возвышаться",
-                    "зависть",
-                    "амбиция"
+                    "бастард",
+                    "амбиция",
+                    "внебрачный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
                     "амбиция",
-                    "обделённый",
-                    "возвышаться",
-                    "внебрачный"
+                    "внебрачный",
+                    "месть",
+                    "бастард"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
-                    "месть",
-                    "природа",
-                    "обделённый",
-                    "амбиция"
+                    "зависть",
+                    "бастард",
+                    "амбиция",
+                    "природа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -1995,6 +2160,183 @@
     "goneril": {
         "title": "Интрига с письмом",
         "description": "Акт I: Обман отца",
+        "vocabulary": [
+            {
+                "german": "fälschen",
+                "russian": "подделывать",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten. Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten.",
+                "sentence_translation": "В гулком проёме ворот замка Гонерильи Эдмунд замирает среди нагруженных ящиков. Твёрдым голосом я клянусь себе: слово «подделывать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ФЕЛЬ-шен]",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Edmund zwischen gepackten Kisten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „fälschen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "подделывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "intrigieren",
+                "russian": "интриговать",
+                "sentence": "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter. Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На продуваемой ветром лестнице Эдмунд смотрит вниз на молчаливый двор. Я вывожу слово «интриговать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ин-три-ГИ-рен]",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Auf der windigen Freitreppe blickt Edmund zum schweigenden Hof hinunter.",
+                    "Ich zeichne das Wort „intrigieren“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "интриговать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beschuldigen",
+                "russian": "обвинять",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger. Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen.",
+                "sentence_translation": "Среди оставленных слуг Эдмунд плотнее запахивает дорожный плащ. Я шепчу стражам судьбы: слово «обвинять» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[бе-ШУЛЬ-ди-ген]",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Edmund den Reisemantel enger.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „beschuldigen“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "обвинять",
+                    "anklagen — тоже «обвинять»",
+                    "verklagen — тоже «обвинять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Plan",
+                "russian": "план",
+                "sentence": "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne. Ich presse das Wort „der Plan“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У тёмного конюшенного ряда Эдмунд гладит гриву нервного коня. Я стискиваю слово «план» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[дер ПЛАН]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Pferdestall streicht Edmund einem nervösen Tier über die Mähne.",
+                    "Ich presse das Wort „der Plan“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "план"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "manipulieren",
+                "russian": "манипулировать",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor. Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten.",
+                "sentence_translation": "Перед скрипящим подъёмным мостом Эдмунд в последний раз касается родной двери. Твёрдым голосом я клянусь себе: слово «манипулировать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ма-ни-пу-ЛИ-рен]",
+                "themes": [
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Vor dem knarrenden Fallgatter tastet Edmund ein letztes Mal nach dem Haustor.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „manipulieren“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "манипулировать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Brief",
+                "russian": "письмо",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand. Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Среди разбросанных свитков Эдмунд вертит кольцо на пальце. Я обнимаю слово «письмо», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер БРИФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Edmund den Ring an der Hand.",
+                    "Ich umarme das Wort „der Brief“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "письмо"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "lügen",
+                "russian": "лгать",
+                "sentence": "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig.",
+                "sentence_translation": "У пустого банкетного стола Эдмунд пересчитывает гаснущие свечи. Каждой клеткой тела я обещаю: слово «лгать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ЛЮ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am leeren Bankettisch zählt Edmund die verlöschenden Kerzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „lügen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "лгать",
+                    "belügen — тоже «лгать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Täuschung",
+                "russian": "обман",
+                "sentence": "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus. Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Между молчаливыми стражниками Эдмунд выходит на холодный двор. Эхо слова «обман» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ТОЙ-шунг]",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Zwischen schweigenden Wachen geht Edmund auf den kalten Hof hinaus.",
+                    "Das Echo des Wortes „die Täuschung“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "обман",
+                    "der Betrug — тоже «обман»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "fälschen",
@@ -2217,8 +2559,8 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
-                    "интриговать",
                     "план",
+                    "интриговать",
                     "обвинять",
                     "подделывать"
                 ],
@@ -2227,72 +2569,72 @@
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
+                    "план",
                     "обвинять",
                     "интриговать",
-                    "план",
                     "подделывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
                     "подделывать",
+                    "лгать",
                     "обвинять",
-                    "манипулировать",
-                    "письмо"
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "план",
+                    "подделывать",
                     "обман",
-                    "обвинять",
-                    "лгать"
+                    "манипулировать",
+                    "план"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «manipulieren»?",
                 "choices": [
                     "манипулировать",
-                    "лгать",
-                    "интриговать",
-                    "письмо"
+                    "письмо",
+                    "план",
+                    "подделывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
+                    "обвинять",
                     "обман",
                     "письмо",
-                    "манипулировать",
-                    "лгать"
+                    "план"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
-                    "лгать",
-                    "манипулировать",
                     "письмо",
-                    "план"
+                    "манипулировать",
+                    "лгать",
+                    "обман"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "лгать",
-                    "интриговать",
                     "манипулировать",
-                    "обман"
+                    "обман",
+                    "план",
+                    "письмо"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2383,6 +2725,173 @@
     "regan": {
         "title": "Изгнание Эдгара",
         "description": "Акт II: Победа интриги",
+        "vocabulary": [
+            {
+                "german": "vertreiben",
+                "russian": "изгонять",
+                "sentence": "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde. Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В продуваемом ветром боковом крыле Эдмунд слушает вой прибрежного ветра. Эхо слова «изгонять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[фер-ТРАЙ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im zugigen Seitenflügel lauscht Edmund dem Heulen der Küstenwinde.",
+                    "Das Echo des Wortes „vertreiben“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "изгонять",
+                    "verbannen — тоже «изгонять»",
+                    "verstoßen — тоже «изгонять»",
+                    "прогонять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "triumphieren",
+                "russian": "торжествовать",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief. Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед дымным камином замка Эдмунд складывает измятый лист. Я держу слово «торжествовать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[три-ум-ФИ-рен]",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Edmund einen zerknitterten Brief.",
+                    "Ich halte das Wort „triumphieren“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "торжествовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erben",
+                "russian": "наследовать",
+                "sentence": "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab. Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под выцветшими гобеленами Эдмунд беспокойно меряет шагами зал. Я черчу слово «наследовать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ЭР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter farblosen Wandteppichen schreitet Edmund rastlos auf und ab.",
+                    "Ich zeichne das Wort „erben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "наследовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Erfolg",
+                "russian": "успех",
+                "sentence": "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof. Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen.",
+                "sentence_translation": "У узкой бойницы Эдмунд считает факелы на дворе. Как тихая молитва слово «успех» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер эр-ФОЛЬГ]",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "An der schmalen Fensterluke zählt Edmund die Fackeln auf dem Hof.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Erfolg“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "успех"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gewinnen",
+                "russian": "выигрывать",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften. Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Среди дорожных сундуков послов Эдмунд ищет свежие вести. Я обнимаю слово «выигрывать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ге-ВИН-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Edmund nach frischen Botschaften.",
+                    "Ich umarme das Wort „gewinnen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "выигрывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Belohnung",
+                "russian": "награда",
+                "sentence": "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur. Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В тихой капелле Эдмунд преклоняет колени перед холодной каменной фигурой. Я вывожу слово «награда» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди бе-ЛО-нунг]",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Im stillen Kapellenraum kniet Edmund vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „die Belohnung“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "награда"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verdrängen",
+                "russian": "вытеснять",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest. Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На балконе, омываемом морскими брызгами, Эдмунд крепко держит фонарь. Холодный свет заставляет слово «вытеснять» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[фер-ДРЕН-ген]",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Edmund die Laterne fest.",
+                    "Das kalte Licht lässt das Wort „verdrängen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "вытеснять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Sieg",
+                "russian": "победа",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort. Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В тени высоких стен Эдмунд пишет лихорадочный ответ. Я вывожу слово «победа» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[дер ЗИГ]",
+                "themes": [
+                    "erben",
+                    "triumphieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Edmund eine fiebrige Antwort.",
+                    "Ich zeichne das Wort „der Sieg“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "победа"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "vertreiben",
@@ -2598,9 +3107,9 @@
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
                     "наследовать",
-                    "успех",
+                    "торжествовать",
                     "изгонять",
-                    "торжествовать"
+                    "успех"
                 ],
                 "correctIndex": 2
             },
@@ -2608,58 +3117,58 @@
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
                     "успех",
-                    "изгонять",
                     "наследовать",
-                    "торжествовать"
+                    "торжествовать",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
                     "вытеснять",
                     "изгонять",
-                    "торжествовать"
+                    "выигрывать",
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
-                    "успех",
-                    "изгонять",
-                    "вытеснять",
-                    "наследовать"
+                    "наследовать",
+                    "выигрывать",
+                    "победа",
+                    "успех"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "награда",
+                    "торжествовать",
+                    "изгонять",
                     "выигрывать",
-                    "вытеснять",
                     "победа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
+                    "вытеснять",
                     "награда",
                     "победа",
-                    "выигрывать",
-                    "успех"
+                    "выигрывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verdrängen»?",
                 "choices": [
-                    "успех",
+                    "изгонять",
                     "вытеснять",
-                    "победа",
+                    "успех",
                     "выигрывать"
                 ],
                 "correctIndex": 1
@@ -2667,10 +3176,10 @@
             {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
-                    "торжествовать",
-                    "выигрывать",
+                    "изгонять",
+                    "успех",
                     "победа",
-                    "вытеснять"
+                    "торжествовать"
                 ],
                 "correctIndex": 2
             }
@@ -2762,6 +3271,179 @@
     "storm": {
         "title": "Союз с сёстрами",
         "description": "Акт III: Альянс со злом",
+        "vocabulary": [
+            {
+                "german": "verbünden",
+                "russian": "объединяться",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir.",
+                "sentence_translation": "Посреди хлещущей дождём пустоши Эдмунд упирается в ветер. Буря за окнами усиливает клятву: слово «объединяться» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[фер-БЮН-ден]",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
+                "sentence_parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Edmund gegen den Wind.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbünden“ gehört mir."
+                ],
+                "synonyms": [
+                    "объединяться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Macht",
+                "russian": "власть",
+                "sentence": "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Под разорванным знаменем Эдмунд прикрывает глаза от молний. Я обнимаю слово «власть», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди МАХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerrissenen Banner schützt Edmund die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "власть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erobern",
+                "russian": "завоёвывать",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner. Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "У поваленного дерева Эдмунд ищет укрытия от грома. Холодный свет заставляет слово «завоёвывать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[эр-О-берн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Edmund Deckung vor dem Donner.",
+                    "Das kalte Licht lässt das Wort „erobern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "завоёвывать",
+                    "завоевывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Bündnis",
+                "russian": "союз",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm. Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Между пенящимися лужами Эдмунд пробирается через грязь. Холодный свет заставляет слово «союз» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дас БЮНД-нис]",
+                "themes": [
+                    "Bündnis",
+                    "Macht",
+                    "erobern",
+                    "planen",
+                    "teilen",
+                    "verbünden"
+                ],
+                "sentence_parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Edmund durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „das Bündnis“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "союз"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verführen",
+                "russian": "соблазнять",
+                "sentence": "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an. Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "На фоне вспыхивающего неба Эдмунд упрямо поднимает руки. Я обнимаю слово «соблазнять», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[фер-ФЮ-рен]",
+                "themes": [
+                    "Macht",
+                    "Witwe",
+                    "begehren",
+                    "erobern",
+                    "verbünden",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Vor einem zuckenden Himmel hebt Edmund die Arme trotzig an.",
+                    "Ich umarme das Wort „verführen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "соблазнять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Eroberung",
+                "russian": "завоевание",
+                "sentence": "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte. Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Под промокшим плащом Эдмунд прижимает дыхание к груди, спасаясь от холода. Я держу слово «завоевание» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди эр-О-бе-рунг]",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
+                "sentence_parts": [
+                    "Unter dem durchtränkten Umhang presst Edmund den Atem gegen die Kälte.",
+                    "Ich halte das Wort „die Eroberung“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "завоевание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beherrschen",
+                "russian": "господствовать",
+                "sentence": "Am kläglichen Feuerrest wärmt Edmund zitternde Finger. Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У жалких огненных углей Эдмунд греет дрожащие пальцы. Я стискиваю слово «господствовать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[бе-ХЕР-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am kläglichen Feuerrest wärmt Edmund zitternde Finger.",
+                    "Ich presse das Wort „beherrschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "владеть",
+                    "господствовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Allianz",
+                "russian": "альянс",
+                "sentence": "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an. Ich presse das Wort „die Allianz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Среди воющих псов Эдмунд перекрикивает беснующуюся бурю. Я стискиваю слово «альянс» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди а-ли-АНЦС]",
+                "themes": [
+                    "Macht",
+                    "erobern",
+                    "verbünden"
+                ],
+                "sentence_parts": [
+                    "Zwischen heulenden Hunden ruft Edmund gegen den tosenden Sturm an.",
+                    "Ich presse das Wort „die Allianz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "альянс"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verbünden",
@@ -2986,82 +3668,82 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "объединяться",
-                    "союз",
                     "завоёвывать",
-                    "власть"
+                    "объединяться",
+                    "власть",
+                    "союз"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "завоёвывать",
-                    "союз",
                     "объединяться",
-                    "власть"
+                    "власть",
+                    "завоёвывать",
+                    "союз"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "власть",
+                    "альянс",
                     "завоёвывать",
-                    "завоевание",
-                    "соблазнять"
+                    "соблазнять",
+                    "объединяться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "союз",
                     "завоевание",
-                    "господствовать",
-                    "власть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verführen»?",
-                "choices": [
-                    "завоевание",
-                    "завоёвывать",
                     "соблазнять",
-                    "господствовать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Eroberung»?",
-                "choices": [
-                    "завоёвывать",
                     "альянс",
-                    "завоевание",
-                    "объединяться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «beherrschen»?",
-                "choices": [
-                    "союз",
-                    "завоевание",
-                    "соблазнять",
-                    "господствовать"
+                    "союз"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Allianz»?",
+                "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
+                    "власть",
                     "альянс",
-                    "завоёвывать",
+                    "господствовать",
+                    "соблазнять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Eroberung»?",
+                "choices": [
                     "завоевание",
-                    "объединяться"
+                    "власть",
+                    "соблазнять",
+                    "союз"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «beherrschen»?",
+                "choices": [
+                    "господствовать",
+                    "союз",
+                    "завоёвывать",
+                    "соблазнять"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Allianz»?",
+                "choices": [
+                    "союз",
+                    "господствовать",
+                    "альянс",
+                    "соблазнять"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3152,6 +3834,195 @@
     "hut": {
         "title": "Предательство отца",
         "description": "Акт III-IV: Ослепление Глостера",
+        "vocabulary": [
+            {
+                "german": "verraten",
+                "russian": "предавать",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze. Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В тёмном шатре полевых лекарей Эдмунд сидит у мерцающей свечи. Моё дыхание рисует слово «предавать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-РА-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Edmund bei der flackernden Kerze.",
+                    "Mein Atem zeichnet das Wort „verraten“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "предавать",
+                    "выдавать",
+                    "ausliefern — тоже «выдавать»",
+                    "verheiraten — тоже «выдавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "blenden",
+                "russian": "ослеплять",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentence_translation": "Среди помятых доспехов Эдмунд гладит старый герб. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[БЛЕН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Edmund über ein altes Wappen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "ослеплять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Grausamkeit",
+                "russian": "жестокость",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir.",
+                "sentence_translation": "О низкую балку хижины Эдмунд едва не ударяется головой. Буря за окнами усиливает клятву: слово «жестокость» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди ГРАУ-зам-кайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Edmund fast den Kopf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Grausamkeit“ gehört mir."
+                ],
+                "synonyms": [
+                    "жестокость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "denunzieren",
+                "russian": "доносить",
+                "sentence": "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht. Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Рядом со спящим стражем Эдмунд шепчет в тяжёлую ночь. Я стискиваю слово «доносить» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[де-нун-ЦИ-рен]",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Neben der schlafenden Wache flüstert Edmund in die schwere Nacht.",
+                    "Ich presse das Wort „denunzieren“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "доносить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ausliefern",
+                "russian": "выдавать",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten.",
+                "sentence_translation": "Перед грубой походной койкой Эдмунд разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «выдавать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[АУС-ли-ферн]",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Vor dem einfachen Feldbett betrachtet Edmund die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ausliefern“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "выдавать",
+                    "verheiraten — тоже «выдавать»",
+                    "verraten — тоже «выдавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Folter",
+                "russian": "пытка",
+                "sentence": "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig.",
+                "sentence_translation": "В запахе влажной соломы Эдмунд откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «пытка» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ФОЛЬ-тер]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Im Geruch von feuchtem Stroh legt Edmund den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Folter“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "пытка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "opfern",
+                "russian": "жертвовать",
+                "sentence": "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe. Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На шатком деревянном столе Эдмунд раскладывает зачитанные письма. Холодный свет заставляет слово «жертвовать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ОП-ферн]",
+                "themes": [
+                    "Grausamkeit",
+                    "blenden",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Auf dem wackligen Holztisch ordnet Edmund zerlesene Briefe.",
+                    "Das kalte Licht lässt das Wort „opfern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "жертвовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erbarmungslos",
+                "russian": "беспощадный",
+                "sentence": "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У входа в хижину Эдмунд высматривает знакомую тень. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[эр-БАР-мунгс-лос]",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Am Eingang der Hütte späht Edmund nach einem vertrauten Schatten.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "беспощадный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verraten",
@@ -3395,82 +4266,82 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "ослеплять",
+                    "жестокость",
                     "предавать",
-                    "доносить",
-                    "жестокость"
+                    "ослеплять",
+                    "доносить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "доносить",
-                    "ослеплять",
                     "предавать",
-                    "жестокость"
+                    "жестокость",
+                    "ослеплять",
+                    "доносить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
                     "жестокость",
-                    "беспощадный",
-                    "доносить",
-                    "предавать"
+                    "предавать",
+                    "пытка",
+                    "беспощадный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «denunzieren»?",
                 "choices": [
-                    "предавать",
-                    "выдавать",
-                    "ослеплять",
-                    "доносить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "ослеплять",
-                    "выдавать",
-                    "пытка",
-                    "жестокость"
+                    "жертвовать",
+                    "доносить",
+                    "жестокость",
+                    "беспощадный"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "пытка",
+                    "ослеплять",
+                    "выдавать",
+                    "жестокость"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "выдавать",
                     "беспощадный",
-                    "доносить",
-                    "пытка"
+                    "пытка",
+                    "предавать",
+                    "ослеплять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
+                    "выдавать",
                     "предавать",
-                    "пытка",
                     "жертвовать",
-                    "выдавать"
+                    "пытка"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
+                    "предавать",
+                    "беспощадный",
                     "жертвовать",
-                    "пытка",
-                    "жестокость",
-                    "беспощадный"
+                    "доносить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3560,6 +4431,183 @@
     "dover": {
         "title": "Любовный треугольник",
         "description": "Акт IV-V: Между двух сестёр",
+        "vocabulary": [
+            {
+                "german": "die Liebschaft",
+                "russian": "любовная связь",
+                "sentence": "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir.",
+                "sentence_translation": "На белых скалах Дувра Эдмунд смотрит в вздыбленный пролив. Буря за окнами усиливает клятву: слово «любовная связь» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди ЛИБ-шафт]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
+                "sentence_parts": [
+                    "Auf den weißen Klippen von Dover blickt Edmund in den aufgewühlten Kanal.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Liebschaft“ gehört mir."
+                ],
+                "synonyms": [
+                    "любовная",
+                    "связь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rivalität",
+                "russian": "соперничество",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Edmund den Helm. Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Среди хлопающих штандартов Эдмунд поправляет шлем. Я держу слово «соперничество» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ри-ва-ли-ТЕТ]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "bedrohen",
+                    "hassen",
+                    "spielen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Zwischen flatternden Feldzeichen richtet Edmund den Helm.",
+                    "Ich halte das Wort „die Rivalität“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "соперничество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "spielen",
+                "russian": "играть",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir.",
+                "sentence_translation": "У французского костра Эдмунд рисует в песке путь марша. Буря за окнами усиливает клятву: слово «играть» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ШПИ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Edmund Marschrouten in den Sand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „spielen“ gehört mir."
+                ],
+                "synonyms": [
+                    "играть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verlocken",
+                "russian": "завлекать",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen.",
+                "sentence_translation": "У перевязанных провиантных ящиков Эдмунд проверяет печати. Я шепчу стражам судьбы: слово «завлекать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[фер-ЛО-кен]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
+                "sentence_parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Edmund das Siegel.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verlocken“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "завлекать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Lust",
+                "russian": "похоть",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer. Ich presse das Wort „die Lust“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Перед шёлковым шатром полководцев Эдмунд слушает глухой шум моря. Я стискиваю слово «похоть» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ЛУСТ]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "Witwe",
+                    "begehren",
+                    "spielen",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Edmund dem dumpfen Meer.",
+                    "Ich presse das Wort „die Lust“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "похоть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ausnutzen",
+                "russian": "использовать",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts. Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus.",
+                "sentence_translation": "На песчаном плацу Эдмунд отрабатывает выхват меча. Я глубоко вдыхаю и выпускаю только слово «использовать».",
+                "russian_hint": "",
+                "transcription": "[АУС-нут-цен]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
+                "sentence_parts": [
+                    "Auf dem sandigen Trainingsplatz übt Edmund das Ziehen des Schwerts.",
+                    "Ich atme tief ein und lasse nur das Wort „ausnutzen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "использовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "jonglieren",
+                "russian": "жонглировать",
+                "sentence": "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung. Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Под гул барабанов Эдмунд поднимает знамя надежды. Холодный свет заставляет слово «жонглировать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[жон-ГЛИ-рен]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
+                "sentence_parts": [
+                    "Zwischen pochenden Trommeln hebt Edmund das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „jonglieren“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "жонглировать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Affäre",
+                "russian": "интрига",
+                "sentence": "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen.",
+                "sentence_translation": "В утреннем тумане побережья Эдмунд кладёт ладонь на бьющееся сердце. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди а-ФЕ-ре]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "spielen"
+                ],
+                "sentence_parts": [
+                    "Am Morgennebel der Küste legt Edmund die Hand auf das pochende Herz.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Affäre“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "интрига",
+                    "die Intrige — тоже «интрига»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Liebschaft",
@@ -3782,59 +4830,59 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "играть",
+                    "соперничество",
                     "завлекать",
-                    "любовная связь",
-                    "соперничество"
+                    "играть",
+                    "любовная связь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
                     "играть",
-                    "завлекать",
                     "соперничество",
-                    "любовная связь"
+                    "любовная связь",
+                    "завлекать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
-                    "жонглировать",
-                    "соперничество",
+                    "играть",
                     "любовная связь",
-                    "играть"
+                    "жонглировать",
+                    "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
-                    "жонглировать",
                     "любовная связь",
                     "завлекать",
-                    "похоть"
+                    "соперничество",
+                    "жонглировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "интрига",
-                    "похоть",
-                    "любовная связь",
-                    "жонглировать"
+                    "соперничество",
+                    "жонглировать",
+                    "использовать",
+                    "похоть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
                     "использовать",
                     "любовная связь",
-                    "играть",
+                    "похоть",
                     "соперничество"
                 ],
                 "correctIndex": 0
@@ -3842,10 +4890,10 @@
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
+                    "использовать",
                     "любовная связь",
-                    "интрига",
                     "жонглировать",
-                    "завлекать"
+                    "похоть"
                 ],
                 "correctIndex": 2
             },
@@ -3853,9 +4901,9 @@
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
                     "интрига",
-                    "любовная связь",
-                    "завлекать",
-                    "играть"
+                    "играть",
+                    "жонглировать",
+                    "соперничество"
                 ],
                 "correctIndex": 0
             }
@@ -3948,6 +4996,170 @@
     "prison": {
         "title": "Дуэль и смерть",
         "description": "Акт V: Поражение и раскаяние",
+        "vocabulary": [
+            {
+                "german": "das Duell",
+                "russian": "дуэль",
+                "sentence": "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir.",
+                "sentence_translation": "В сыром подземелье Эдмунд опирается на сочащийся камень. Буря за окнами усиливает клятву: слово «дуэль» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дас ду-ЭЛЬ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im feuchten Kerker stützt Edmund sich an den tropfenden Stein.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „das Duell“ gehört mir."
+                ],
+                "synonyms": [
+                    "дуэль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "fallen",
+                "russian": "падать",
+                "sentence": "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette. Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под мутным фонарём Эдмунд пересчитывает железные кольца цепи. Я черчу слово «падать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ФАЛ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter der trüben Laterne zählt Edmund die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „fallen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "падать",
+                    "stürzen — тоже «падать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bereuen",
+                "russian": "сожалеть",
+                "sentence": "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen. Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У тяжёлой двери Эдмунд прислушивается к далёким рыданиям. Эхо слова «сожалеть» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[бе-РОЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schweren Holztür horcht Edmund auf entferntes Schluchzen.",
+                    "Das Echo des Wortes „bereuen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "сожалеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Niederlage",
+                "russian": "поражение",
+                "sentence": "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern. Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На холодной каменной скамье Эдмунд плотнее кутается в плащ. Я черчу слово «поражение» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди НИ-дер-ла-ге]",
+                "themes": [
+                    "Duell",
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "bereuen",
+                    "fallen"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Steinbank zieht Edmund den Mantel enger um die Schultern.",
+                    "Ich zeichne das Wort „die Niederlage“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "поражение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verlieren",
+                "russian": "проигрывать",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht. Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten.",
+                "sentence_translation": "Между тенями решёток Эдмунд поднимает лицо к свету. Твёрдым голосом я клянусь себе: слово «проигрывать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[фер-ЛИ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Edmund das Gesicht zum Licht.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verlieren“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "проигрывать",
+                    "unterliegen — тоже «проигрывать»",
+                    "терять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Untergang",
+                "russian": "падение",
+                "sentence": "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen. Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У ржавого ведра с водой Эдмунд на мгновение видит отражение глаз. Я держу слово «падение» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер УН-тер-ганг]",
+                "themes": [
+                    "Duell",
+                    "bereuen",
+                    "fallen"
+                ],
+                "sentence_parts": [
+                    "Am rostigen Wassereimer spiegelt Edmund kurz die eigenen Augen.",
+                    "Ich halte das Wort „der Untergang“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "падение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gestehen",
+                "russian": "признаваться",
+                "sentence": "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen. Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В глухом эхе шагов Эдмунд отсчитывает ритм часовых. Эхо слова «признаваться» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ге-ШТЕ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dumpfen Hall der Schritte zählt Edmund den Rhythmus der Wachen.",
+                    "Das Echo des Wortes „gestehen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "признаваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Ende",
+                "russian": "конец",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub. Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus.",
+                "sentence_translation": "Перед заколоченным окном Эдмунд чертит круги в пыли. Я глубоко вдыхаю и выпускаю только слово «конец».",
+                "russian_hint": "",
+                "transcription": "[дас ЭН-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem verriegelten Fenster zeichnet Edmund Kreise in den Staub.",
+                    "Ich atme tief ein und lasse nur das Wort „das Ende“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "конец"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "das Duell",
@@ -4170,80 +5382,80 @@
                 "choices": [
                     "падать",
                     "дуэль",
-                    "сожалеть",
-                    "поражение"
+                    "поражение",
+                    "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "падать",
-                    "поражение",
+                    "сожалеть",
                     "дуэль",
-                    "сожалеть"
+                    "падать",
+                    "поражение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "дуэль",
-                    "падать",
-                    "сожалеть",
-                    "падение"
+                    "конец",
+                    "признаваться",
+                    "проигрывать",
+                    "сожалеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "конец",
-                    "проигрывать",
-                    "поражение",
-                    "падение"
+                    "признаваться",
+                    "дуэль",
+                    "падение",
+                    "поражение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
+                    "падать",
                     "проигрывать",
-                    "признаваться",
-                    "поражение",
-                    "сожалеть"
+                    "дуэль",
+                    "поражение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
                     "падать",
                     "падение",
-                    "дуэль",
-                    "признаваться"
+                    "признаваться",
+                    "конец"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «gestehen»?",
                 "choices": [
-                    "поражение",
-                    "конец",
+                    "дуэль",
                     "признаваться",
-                    "падение"
+                    "проигрывать",
+                    "сожалеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
+                    "конец",
+                    "признаваться",
                     "поражение",
-                    "дуэль",
-                    "сожалеть",
-                    "конец"
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4336,6 +5548,9 @@ const characterId = "edmund";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["мудрость", "шут", "шутить", "печаль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["печаль", "шут", "шутить", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["шутить", "шут", "мудрость", "печаль"], "correct_index": 3}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["скучать", "шутить", "печаль", "умный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["забава", "умный", "печаль", "шутить"], "correct_index": 0}, {"question": "Что означает немецкое слово «klug»?", "choices": ["шутить", "умный", "печаль", "скучать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["остроумие", "печаль", "шут", "скучать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["скучать", "забава", "умный", "остроумие"], "correct_index": 3}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "шутка", "горький", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "предупреждение", "горький", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["шутка", "предупреждение", "дразнить", "раскрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "предупреждение", "правда", "дразнить"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["горький", "насмехаться", "раскрывать", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["горький", "дразнить", "предупреждение", "раскрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["раскрывать", "горький", "предупреждение", "дразнить"], "correct_index": 0}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "загадка", "предсказывать", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["предчувствие", "загадка", "пророчество", "предсказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадка", "толковать", "загадочный", "предчувствие"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предчувствовать", "загадка", "загадочный", "предсказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["пророчество", "загадочный", "толковать", "предчувствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "пророчество", "толковать", "загадка"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["загадка", "знамение", "пророчество", "предсказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "загадка", "предчувствие", "знамение"], "correct_index": 0}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "мёрзнуть", "дружба", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "безумие", "дружба", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["верный", "сопровождать", "мёрзнуть", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дружба", "сопровождать", "мёрзнуть", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «singen»?", "choices": ["дрожать", "петь", "мёрзнуть", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "сопровождать", "безумие", "петь"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["сопровождать", "безумие", "мёрзнуть", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["песня", "ирония", "утешение", "напевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["напевать", "песня", "ирония", "утешение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["напевать", "свистеть", "ирония", "песня"], "correct_index": 2}, {"question": "Что означает немецкое слово «summen»?", "choices": ["рифма", "напевать", "свистеть", "утешение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["мелодия", "звучать", "рифма", "свистеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "рифма", "утешение", "мелодия"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["утешение", "мелодия", "песня", "рифма"], "correct_index": 3}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["рифма", "песня", "утешение", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["размышлять", "судьба", "философия", "бренность"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["философия", "бренность", "судьба", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["познавать", "судьба", "смысл", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["бренность", "философия", "судьба", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["философия", "судьба", "размышлять", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["смысл", "философия", "размышлять", "преходящий"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "философия", "познавать", "смысл"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["тайна", "пустота", "исчезать", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["исчезать", "тайна", "растворяться", "пустота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["тайна", "исчезать", "пустота", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["уходить", "туман", "тайна", "растворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "загадочный", "туман", "уходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["пустота", "бесследно", "загадочный", "туман"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["уходить", "пустота", "тайна", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["бесследно", "исчезать", "уходить", "тайна"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шутить", "печаль", "мудрость", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "шут", "шутить", "печаль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["забава", "печаль", "умный", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["скучать", "забава", "шутить", "шут"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["остроумие", "забава", "шутить", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "умный", "остроумие", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["умный", "печаль", "скучать", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["остроумие", "печаль", "шутить", "мудрость"], "correct_index": 0}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "правда", "шутка", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["предупреждение", "шутка", "правда", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["насмехаться", "дразнить", "шутка", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "предупреждение", "шутка", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["предупреждение", "горький", "правда", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «necken»?", "choices": ["насмехаться", "шутка", "предупреждение", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["насмехаться", "раскрывать", "предупреждение", "горький"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предчувствие", "загадка", "предсказывать", "пророчество"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "предсказывать", "загадка", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["предсказывать", "предчувствие", "толковать", "пророчество"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предчувствовать", "толковать", "пророчество", "предсказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["предчувствовать", "толковать", "предчувствие", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["загадка", "пророчество", "предчувствовать", "предсказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["загадка", "предчувствие", "предчувствовать", "знамение"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадка", "предсказывать", "загадочный", "толковать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "сопровождать", "безумие", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "дружба", "мёрзнуть", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["дрожать", "петь", "сопровождать", "верный"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "петь", "сопровождать", "верный"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["дружба", "петь", "дрожать", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["верный", "дружба", "дрожать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["дружба", "безумие", "петь", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["песня", "напевать", "утешение", "ирония"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["напевать", "песня", "ирония", "утешение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["утешение", "мелодия", "рифма", "ирония"], "correct_index": 3}, {"question": "Что означает немецкое слово «summen»?", "choices": ["мелодия", "рифма", "утешение", "напевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["мелодия", "напевать", "ирония", "звучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["ирония", "свистеть", "звучать", "утешение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["рифма", "свистеть", "напевать", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["песня", "свистеть", "ирония", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["философия", "размышлять", "бренность", "судьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["размышлять", "бренность", "философия", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["размышлять", "судьба", "смысл", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["познавать", "судьба", "размышлять", "преходящий"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["судьба", "философия", "размышлять", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["размышлять", "судьба", "смысл", "философия"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "познавать", "философия", "размышлять"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "растворяться", "пустота", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "исчезать", "пустота", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["пустота", "растворяться", "загадочный", "туман"], "correct_index": 0}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["растворяться", "туман", "исчезать", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["исчезать", "уходить", "туман", "бесследно"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["растворяться", "уходить", "туман", "исчезать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["уходить", "тайна", "пустота", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["исчезать", "загадочный", "уходить", "растворяться"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,8 +662,24 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
@@ -678,15 +694,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
@@ -694,49 +710,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -746,45 +746,45 @@
                         <div class="quiz-question">Что означает немецкое слово «klug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,15 +797,15 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
@@ -813,33 +813,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -853,23 +853,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                             
@@ -877,33 +861,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,49 +916,49 @@
             <div class="quiz-phase-container" data-phase="prophecies">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -970,55 +970,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
                             
@@ -1028,17 +980,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,31 +1051,15 @@
             <div class="quiz-phase-container" data-phase="mad_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -1083,29 +1067,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
@@ -1115,33 +1083,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1151,11 +1151,11 @@
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
@@ -1176,11 +1176,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,33 +1202,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «summen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1240,43 +1240,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мелодия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
                             
@@ -1305,33 +1305,33 @@
             <div class="quiz-phase-container" data-phase="wisdom">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1341,7 +1341,7 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
@@ -1353,17 +1353,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1373,9 +1373,9 @@
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
                             
@@ -1385,17 +1385,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1407,11 +1407,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,40 +1424,24 @@
             <div class="quiz-phase-container" data-phase="vanishing">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
@@ -1466,55 +1450,71 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1526,9 +1526,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                             
@@ -1540,13 +1540,13 @@
                         <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1568,6 +1568,181 @@
     "jester": {
         "title": "Королевский шут",
         "description": "Акт I: При дворе, грустит о Корделии",
+        "vocabulary": [
+            {
+                "german": "der Narr",
+                "russian": "шут",
+                "sentence": "Im grellen Licht des Thronsaals schlägt Fool die Laute an. Ich presse das Wort „der Narr“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В ярком свете тронного зала Шут ударяет по струнам лютни. Я стискиваю слово «шут» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[дер НАР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im grellen Licht des Thronsaals schlägt Fool die Laute an.",
+                    "Ich presse das Wort „der Narr“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "шут"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Weisheit",
+                "russian": "мудрость",
+                "sentence": "Neben Lears Krone balanciert Fool auf einem Fuß. Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus.",
+                "sentence_translation": "Рядом с короной Лира Шут балансирует на одной ноге. Я глубоко вдыхаю и выпускаю только слово «мудрость».",
+                "russian_hint": "",
+                "transcription": "[ди ВАЙС-хайт]",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Neben Lears Krone balanciert Fool auf einem Fuß.",
+                    "Ich atme tief ein und lasse nur das Wort „die Weisheit“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "мудрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Trauer",
+                "russian": "печаль",
+                "sentence": "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig.",
+                "sentence_translation": "Между дамами двора и рыцарями Шут кружится в звенящем костюме. Каждой клеткой тела я обещаю: слово «печаль» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ТРАУ-ер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Hofdamen und Rittern wirbelt Fool mit flatterndem Schellenkleid.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Trauer“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "печаль",
+                    "скорбь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "scherzen",
+                "russian": "шутить",
+                "sentence": "Vor dem königlichen Podest verzieht Fool die Maske zum Spott. Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед королевским помостом Шут кривит маску насмешки. Я черчу слово «шутить» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ШЕР-цен]",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Vor dem königlichen Podest verzieht Fool die Maske zum Spott.",
+                    "Ich zeichne das Wort „scherzen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "шутить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Spaß",
+                "russian": "забава",
+                "sentence": "Am Bankettisch jongliert Fool mit goldenen Pokalen. Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern.",
+                "sentence_translation": "У банкетного стола Шут жонглирует золотыми кубками. Даже если мир распадается, слово «забава» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дер ШПАС]",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Am Bankettisch jongliert Fool mit goldenen Pokalen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Spaß“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "забава"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "klug",
+                "russian": "умный",
+                "sentence": "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft. Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Среди смеха и вздохов Шут рисует в воздухе гримасы. Холодный свет заставляет слово «умный» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[КЛУГ]",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Zwischen Lachern und Seufzern zeichnet Fool Grimassen in die Luft.",
+                    "Das kalte Licht lässt das Wort „klug“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "умный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vermissen",
+                "russian": "скучать",
+                "sentence": "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias. Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В тени колонн Шут прислушивается к тихим словам Корделии. Моё дыхание рисует слово «скучать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-МИ-сен]",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Säulen lauscht Fool den leisen Worten Cordelias.",
+                    "Mein Atem zeichnet das Wort „vermissen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "скучать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Witz",
+                "russian": "остроумие",
+                "sentence": "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig.",
+                "sentence_translation": "На мраморной ступени Шут пускает колокольчик плясать по полу. Каждой клеткой тела я обещаю: слово «остроумие» останется живым.",
+                "russian_hint": "",
+                "transcription": "[дер ВИТЦ]",
+                "themes": [
+                    "Narr",
+                    "Trauer",
+                    "Weisheit"
+                ],
+                "sentence_parts": [
+                    "Auf der Marmorstufe lässt Fool ein Glöckchen über den Boden tanzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Witz“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "остроумие"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Narr",
@@ -1794,82 +1969,82 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "мудрость",
-                    "шут",
                     "шутить",
-                    "печаль"
+                    "печаль",
+                    "мудрость",
+                    "шут"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "печаль",
+                    "мудрость",
                     "шут",
                     "шутить",
-                    "мудрость"
+                    "печаль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "шутить",
-                    "шут",
-                    "мудрость",
-                    "печаль"
+                    "забава",
+                    "печаль",
+                    "умный",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
                     "скучать",
+                    "забава",
                     "шутить",
-                    "печаль",
-                    "умный"
+                    "шут"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
+                    "остроумие",
                     "забава",
-                    "умный",
-                    "печаль",
-                    "шутить"
+                    "шутить",
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «klug»?",
                 "choices": [
-                    "шутить",
+                    "скучать",
                     "умный",
-                    "печаль",
-                    "скучать"
+                    "остроумие",
+                    "шут"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
-                    "остроумие",
+                    "умный",
                     "печаль",
-                    "шут",
-                    "скучать"
+                    "скучать",
+                    "шутить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
-                    "скучать",
-                    "забава",
-                    "умный",
-                    "остроумие"
+                    "остроумие",
+                    "печаль",
+                    "шутить",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -1960,6 +2135,158 @@
     "bitter_truths": {
         "title": "Горькие истины",
         "description": "Акт I: Говорит правду через шутки",
+        "vocabulary": [
+            {
+                "german": "die Wahrheit",
+                "russian": "правда",
+                "sentence": "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit. Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten.",
+                "sentence_translation": "У самого уха Лира Шут с блеском в глазах шепчет язвительную правду. Твёрдым голосом я клянусь себе: слово «правда» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди ВАР-хайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor Lears Ohr flüstert Fool mit funkelndem Blick die spöttische Wahrheit.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Wahrheit“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "правда"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Scherz",
+                "russian": "шутка",
+                "sentence": "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern. Ich presse das Wort „der Scherz“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На дворцовом балконе Шут указывает лютней на лицемерных сестёр. Я стискиваю слово «шутка» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[дер ШЕРЦ]",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hofbalkon zeigt Fool mit der Laute auf die heuchlerischen Schwestern.",
+                    "Ich presse das Wort „der Scherz“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "шутка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Warnung",
+                "russian": "предупреждение",
+                "sentence": "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf. Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Среди опрокинутых кубков Шут собирает ложь словно жемчуг. Я черчу слово «предупреждение» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди ВАР-нунг]",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Zwischen umgestoßenen Bechern sammelt Fool die Lügen wie Perlen auf.",
+                    "Ich zeichne das Wort „die Warnung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "предупреждение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bitter",
+                "russian": "горький",
+                "sentence": "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden. Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen.",
+                "sentence_translation": "Рядом с Лиром Шут мелом рисует корону на полу. Как тихая молитва слово «горький» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[БИ-тер]",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "An Lears Seite zeichnet Fool mit Kreide eine Krone auf den Boden.",
+                    "Wie ein stilles Gebet legt sich das Wort „bitter“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "горький"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "spotten",
+                "russian": "насмехаться",
+                "sentence": "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie. Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten.",
+                "sentence_translation": "В толчее придворных Шут играет пронзительную мелодию предупреждения. Твёрдым голосом я клянусь себе: слово «насмехаться» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ШПО-тен]",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Im Gedränge der Höflinge spielt Fool eine schrille Warnmelodie.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „spotten“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "насмехаться",
+                    "verhöhnen — тоже «насмехаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "necken",
+                "russian": "дразнить",
+                "sentence": "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten. Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На ступенях, ведущих к трону, Шут морщит лоб глубокими складками. Я стискиваю слово «дразнить» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[НЕ-кен]",
+                "themes": [
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Auf den Stufen zum Thron zieht Fool die Stirn in tiefe Falten.",
+                    "Ich presse das Wort „necken“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "дразнить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "enthüllen",
+                "russian": "раскрывать",
+                "sentence": "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht. Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Рядом с потоками слёз короля Шут стирает грим с лица. Я черчу слово «раскрывать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[энт-ХЮ-лен]",
+                "themes": [
+                    "Bruder",
+                    "Kampf",
+                    "Scherz",
+                    "Wahrheit",
+                    "Warnung"
+                ],
+                "sentence_parts": [
+                    "Neben dem Tränenstrom des Königs wischt Fool die Schminke vom Gesicht.",
+                    "Ich zeichne das Wort „enthüllen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "разоблачать",
+                    "раскрывать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Wahrheit",
@@ -2153,72 +2480,72 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "горький",
                     "правда",
                     "шутка",
-                    "горький",
                     "предупреждение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
-                    "правда",
                     "предупреждение",
-                    "горький",
-                    "шутка"
+                    "шутка",
+                    "правда",
+                    "горький"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
-                    "шутка",
-                    "предупреждение",
+                    "насмехаться",
                     "дразнить",
-                    "раскрывать"
+                    "шутка",
+                    "предупреждение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
                     "горький",
                     "предупреждение",
-                    "правда",
-                    "дразнить"
+                    "шутка",
+                    "правда"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
+                    "предупреждение",
                     "горький",
-                    "насмехаться",
-                    "раскрывать",
-                    "правда"
+                    "правда",
+                    "насмехаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «necken»?",
                 "choices": [
-                    "горький",
-                    "дразнить",
+                    "насмехаться",
+                    "шутка",
                     "предупреждение",
-                    "раскрывать"
+                    "дразнить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
+                    "насмехаться",
                     "раскрывать",
-                    "горький",
                     "предупреждение",
-                    "дразнить"
+                    "горький"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2299,6 +2626,179 @@
     "prophecies": {
         "title": "Пророчества",
         "description": "Акт II: Предсказывает беды",
+        "vocabulary": [
+            {
+                "german": "die Prophezeiung",
+                "russian": "пророчество",
+                "sentence": "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen. Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Под звёздным шатром Шут посохом указывает на мерцающие знаки. Холодный свет заставляет слово «пророчество» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ди про-фе-ЦАЙ-унг]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Unter dem Sternenzelt deutet Fool mit dem Stab die funkelnden Zeichen.",
+                    "Das kalte Licht lässt das Wort „die Prophezeiung“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "пророчество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Rätsel",
+                "russian": "загадка",
+                "sentence": "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen.",
+                "sentence_translation": "На стенах замка Шут декламирует стихи о грядущих бурях. Я шепчу стражам судьбы: слово «загадка» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[дас РЕТ-зель]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Auf den Mauern des Schlosses rezitiert Fool Verse von kommenden Stürmen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Rätsel“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "загадка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Vorahnung",
+                "russian": "предчувствие",
+                "sentence": "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime. Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten.",
+                "sentence_translation": "Среди дыма и аромата свечей Шут бросает загадочные рифмы. Твёрдым голосом я клянусь себе: слово «предчувствие» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди ФОР-а-нунг]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Zwischen Rauch und Kerzenduft schleudert Fool rätselhafte Reime.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Vorahnung“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "предчувствие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vorhersagen",
+                "russian": "предсказывать",
+                "sentence": "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln. Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus.",
+                "sentence_translation": "У дворцового фонтана Шут бросает гальку, чтобы отразить будущее. Я глубоко вдыхаю и выпускаю только слово «предсказывать».",
+                "russian_hint": "",
+                "transcription": "[ФОР-хер-за-ген]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Am Brunnen des Hofes wirft Fool Kiesel, um die Zukunft zu spiegeln.",
+                    "Ich atme tief ein und lasse nur das Wort „vorhersagen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "предсказывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "deuten",
+                "russian": "толковать",
+                "sentence": "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub. Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Перед поражёнными слугами Шут чертит круги в пыли. Я стискиваю слово «толковать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ДОЙ-тен]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Vor erstaunten Dienern zeichnet Fool Kreise in den Staub.",
+                    "Ich presse das Wort „deuten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "толковать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ahnen",
+                "russian": "предчувствовать",
+                "sentence": "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden. Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten.",
+                "sentence_translation": "На рыночной лестнице Шут поёт о королях, становящихся нищими. Твёрдым голосом я клянусь себе: слово «предчувствовать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[А-нен]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Auf der Markttreppe singt Fool von Königen, die zu Bettlern werden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ahnen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "предчувствовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Omen",
+                "russian": "знамение",
+                "sentence": "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel. Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten.",
+                "sentence_translation": "Рядом со странствующим пилигримом Шут указывает на пылающее небо. Твёрдым голосом я клянусь себе: слово «знамение» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[дас О-мен]",
+                "themes": [
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Neben einem reisenden Pilger deutet Fool in den flammenden Himmel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „das Omen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "знамение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "rätselhaft",
+                "russian": "загадочный",
+                "sentence": "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen. Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В свете грозы Шут отсчитывает удары, возвещающие будущее. Я черчу слово «загадочный» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[РЕТ-зель-хафт]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Verschwinden",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Im Gewitterlicht zählt Fool die Schläge, die die Zukunft ankündigen.",
+                    "Ich zeichne das Wort „rätselhaft“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "загадочный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Prophezeiung",
@@ -2517,39 +3017,39 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "пророчество",
+                    "предчувствие",
                     "загадка",
                     "предсказывать",
-                    "предчувствие"
+                    "пророчество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Rätsel»?",
                 "choices": [
-                    "предчувствие",
-                    "загадка",
                     "пророчество",
-                    "предсказывать"
+                    "предсказывать",
+                    "загадка",
+                    "предчувствие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "загадка",
+                    "предсказывать",
+                    "предчувствие",
                     "толковать",
-                    "загадочный",
-                    "предчувствие"
+                    "пророчество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
                     "предчувствовать",
-                    "загадка",
-                    "загадочный",
+                    "толковать",
+                    "пророчество",
                     "предсказывать"
                 ],
                 "correctIndex": 3
@@ -2557,42 +3057,42 @@
             {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
-                    "пророчество",
-                    "загадочный",
+                    "предчувствовать",
                     "толковать",
-                    "предчувствовать"
+                    "предчувствие",
+                    "загадочный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
-                    "предчувствовать",
+                    "загадка",
                     "пророчество",
-                    "толковать",
-                    "загадка"
+                    "предчувствовать",
+                    "предсказывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
                     "загадка",
-                    "знамение",
-                    "пророчество",
-                    "предсказывать"
+                    "предчувствие",
+                    "предчувствовать",
+                    "знамение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "загадочный",
                     "загадка",
-                    "предчувствие",
-                    "знамение"
+                    "предсказывать",
+                    "загадочный",
+                    "толковать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2682,6 +3182,161 @@
     "mad_companion": {
         "title": "Спутник безумия",
         "description": "Акт III: Единственный друг в буре",
+        "vocabulary": [
+            {
+                "german": "der Wahnsinn",
+                "russian": "безумие",
+                "sentence": "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände. Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На залитой бурей пустоши Шут сжимает озябшие руки Лира. Моё дыхание рисует слово «безумие» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ВАН-зин]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "In der sturmgepeitschten Heide drückt Fool Lear die klammen Hände.",
+                    "Mein Atem zeichnet das Wort „der Wahnsinn“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "безумие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Freundschaft",
+                "russian": "дружба",
+                "sentence": "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied. Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Среди разорванных шатров Шут поёт безутешную колыбельную. Я обнимаю слово «дружба», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди ФРОЙНД-шафт]",
+                "themes": [
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerrissenen Zelten singt Fool ein trostloses Wiegenlied.",
+                    "Ich umarme das Wort „die Freundschaft“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "дружба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begleiten",
+                "russian": "сопровождать",
+                "sentence": "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens. Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У перевёрнутой повозки Шут заслоняет короля от кнута дождя. Я стискиваю слово «сопровождать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЛАЙ-тен]",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Am umgestürzten Wagen schirmt Fool den König vor der Peitsche des Regens.",
+                    "Ich presse das Wort „begleiten“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "сопровождать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "frieren",
+                "russian": "мёрзнуть",
+                "sentence": "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt. Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen.",
+                "sentence_translation": "Под скрипучей крышей хижины Шут сидит вплотную к Лиру. Я шепчу стражам судьбы: слово «мёрзнуть» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ФРИ-рен]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Unter dem knarzenden Dach der Hütte sitzt Fool dicht an Lear gedrängt.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „frieren“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "мёрзнуть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "singen",
+                "russian": "петь",
+                "sentence": "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind. Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Перед бушующей ночью Шут выкрикивает свои шутки наперекор ветру. Я вывожу слово «петь» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ЗИН-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der tobenden Nacht schreit Fool seine Possen gegen den Wind.",
+                    "Ich zeichne das Wort „singen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "петь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zittern",
+                "russian": "дрожать",
+                "sentence": "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild. Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus.",
+                "sentence_translation": "На размокшей земле Шут рисует палкой и шутками защитный круг. Я глубоко вдыхаю и выпускаю только слово «дрожать».",
+                "russian_hint": "",
+                "transcription": "[ЦИ-терн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am aufgeweichten Boden zeichnet Fool mit Stock und Witz ein Schutzschild.",
+                    "Ich atme tief ein und lasse nur das Wort „zittern“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "дрожать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "treu",
+                "russian": "верный",
+                "sentence": "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an. Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В темноте леса Шут зажигает последний огонёк мужества. Я обнимаю слово «верный», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ТРОЙ]",
+                "themes": [
+                    "Freundschaft",
+                    "List",
+                    "Rückkehr",
+                    "Sturm",
+                    "Verkleidung",
+                    "Wahnsinn"
+                ],
+                "sentence_parts": [
+                    "In der Finsternis des Waldes zündet Fool einen letzten Funken Mut an.",
+                    "Ich umarme das Wort „treu“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "верный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Wahnsinn",
@@ -2887,69 +3542,69 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "безумие",
-                    "мёрзнуть",
                     "дружба",
-                    "сопровождать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Freundschaft»?",
-                "choices": [
                     "сопровождать",
                     "безумие",
-                    "дружба",
                     "мёрзнуть"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «begleiten»?",
+                "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
-                    "верный",
                     "сопровождать",
+                    "дружба",
                     "мёрзнуть",
-                    "дружба"
+                    "безумие"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «frieren»?",
+                "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "дружба",
+                    "дрожать",
+                    "петь",
                     "сопровождать",
-                    "мёрзнуть",
-                    "безумие"
+                    "верный"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «frieren»?",
+                "choices": [
+                    "мёрзнуть",
+                    "петь",
+                    "сопровождать",
+                    "верный"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «singen»?",
                 "choices": [
-                    "дрожать",
+                    "дружба",
                     "петь",
-                    "мёрзнуть",
-                    "дружба"
+                    "дрожать",
+                    "безумие"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
+                    "верный",
+                    "дружба",
                     "дрожать",
-                    "сопровождать",
-                    "безумие",
-                    "петь"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "сопровождать",
+                    "дружба",
                     "безумие",
-                    "мёрзнуть",
+                    "петь",
                     "верный"
                 ],
                 "correctIndex": 3
@@ -3032,6 +3687,176 @@
     "songs": {
         "title": "Песни в хижине",
         "description": "Акт III: Поёт и утешает",
+        "vocabulary": [
+            {
+                "german": "das Lied",
+                "russian": "песня",
+                "sentence": "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen. Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В тёплом свете хижины Шут напевает мелодию о потерянных коронах. Моё дыхание рисует слово «песня» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дас ЛИД]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Im warmen Schein der Hütte summt Fool eine Melodie über verlorene Kronen.",
+                    "Mein Atem zeichnet das Wort „das Lied“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "песня"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Trost",
+                "russian": "утешение",
+                "sentence": "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt. Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Рядом с Лиром Шут кладёт голову на колени и покачивается в такт. Я черчу слово «утешение» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер ТРОСТ]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Neben Lear legt Fool den Kopf auf die Knie und schaukelt im Takt.",
+                    "Ich zeichne das Wort „der Trost“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "утешение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ironie",
+                "russian": "ирония",
+                "sentence": "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände. Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus.",
+                "sentence_translation": "Перед потрескивающим огнём Шут отбивает ритм ладонями. Я глубоко вдыхаю и выпускаю только слово «ирония».",
+                "russian_hint": "",
+                "transcription": "[ди и-ро-НИ]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Vor der knisternden Feuerstelle klatscht Fool den Rhythmus in die Hände.",
+                    "Ich atme tief ein und lasse nur das Wort „die Ironie“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "ирония"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "summen",
+                "russian": "напевать",
+                "sentence": "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir.",
+                "sentence_translation": "На деревянной балке Шут сидит и качает ногами в такт песне. Буря за окнами усиливает клятву: слово «напевать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ЗУ-мен]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Auf dem Holzbalken sitzt Fool und schwingt die Beine zur Melodie.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „summen“ gehört mir."
+                ],
+                "synonyms": [
+                    "напевать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Melodie",
+                "russian": "мелодия",
+                "sentence": "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain. Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen.",
+                "sentence_translation": "Среди спящих Шут понижает голос до шёпотного припева. Как тихая молитва слово «мелодия» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди ме-ло-ДИ]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schlafenden senkt Fool die Stimme zu einem flüsternden Refrain.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Melodie“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "мелодия"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "pfeifen",
+                "russian": "свистеть",
+                "sentence": "Am offenen Feld singt Fool gegen das Heulen der Nacht. Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "На открытом поле Шут поёт наперекор вою ночи. Я обнимаю слово «свистеть», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ПФАЙ-фен]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Am offenen Feld singt Fool gegen das Heulen der Nacht.",
+                    "Ich umarme das Wort „pfeifen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "свистеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Reim",
+                "russian": "рифма",
+                "sentence": "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an. Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern.",
+                "sentence_translation": "На рассвете Шут заводит песню надежды. Даже если мир распадается, слово «рифма» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дер РАЙМ]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "In der Morgendämmerung stimmt Fool ein hoffnungsvolles Lied an.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Reim“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "рифма"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "klingen",
+                "russian": "звучать",
+                "sentence": "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn. Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Наклонившись над Лиром, Шут завершает песню мягким поцелуем в лоб. Я стискиваю слово «звучать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[КЛИН-ген]",
+                "themes": [
+                    "Ironie",
+                    "Lied",
+                    "Trost"
+                ],
+                "sentence_parts": [
+                    "Über Lear gebeugt beendet Fool das Lied mit einem sanften Kuss auf die Stirn.",
+                    "Ich presse das Wort „klingen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "звучать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "das Lied",
@@ -3247,9 +4072,9 @@
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
                     "песня",
-                    "ирония",
+                    "напевать",
                     "утешение",
-                    "напевать"
+                    "ирония"
                 ],
                 "correctIndex": 0
             },
@@ -3266,59 +4091,59 @@
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
-                    "напевать",
-                    "свистеть",
-                    "ирония",
-                    "песня"
+                    "утешение",
+                    "мелодия",
+                    "рифма",
+                    "ирония"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
+                    "мелодия",
                     "рифма",
-                    "напевать",
-                    "свистеть",
-                    "утешение"
+                    "утешение",
+                    "напевать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
                     "мелодия",
-                    "звучать",
-                    "рифма",
-                    "свистеть"
+                    "напевать",
+                    "ирония",
+                    "звучать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «pfeifen»?",
                 "choices": [
+                    "ирония",
                     "свистеть",
-                    "рифма",
-                    "утешение",
-                    "мелодия"
+                    "звучать",
+                    "утешение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
-                    "утешение",
-                    "мелодия",
-                    "песня",
-                    "рифма"
+                    "рифма",
+                    "свистеть",
+                    "напевать",
+                    "утешение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
-                    "рифма",
                     "песня",
-                    "утешение",
+                    "свистеть",
+                    "ирония",
                     "звучать"
                 ],
                 "correctIndex": 3
@@ -3411,6 +4236,156 @@
     "wisdom": {
         "title": "Последняя мудрость",
         "description": "Акт III-IV: Философские размышления",
+        "vocabulary": [
+            {
+                "german": "die Philosophie",
+                "russian": "философия",
+                "sentence": "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach. Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern.",
+                "sentence_translation": "На пустынном дворе Шут сидит на пустой бочке и размышляет вслух. Даже если мир распадается, слово «философия» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди фи-ло-зо-ФИ]",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
+                "sentence_parts": [
+                    "Im verlassenen Hof sitzt Fool auf einem leeren Fass und denkt laut nach.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Philosophie“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "философия"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Schicksal",
+                "russian": "судьба",
+                "sentence": "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen.",
+                "sentence_translation": "Под обнажённым дубом Шут пересчитывает ошибки власть имущих. Я шепчу стражам судьбы: слово «судьба» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[дас ШИК-заль]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter einer nackten Eiche zählt Fool die Fehler der Mächtigen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „das Schicksal“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "судьба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Vergänglichkeit",
+                "russian": "бренность",
+                "sentence": "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir.",
+                "sentence_translation": "У тихого ручья Шут бросает камни, чтобы измерить время. Буря за окнами усиливает клятву: слово «бренность» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ГЕНГ-лих-кайт]",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
+                "sentence_parts": [
+                    "Am stillen Bachlauf wirft Fool Steine, um die Zeit zu messen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Vergänglichkeit“ gehört mir."
+                ],
+                "synonyms": [
+                    "бренность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "nachdenken",
+                "russian": "размышлять",
+                "sentence": "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht. Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "У заброшенной сцены Шут репетирует строки о глупости и власти. Холодный свет заставляет слово «размышлять» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[НАХ-ден-кен]",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
+                "sentence_parts": [
+                    "Neben einer verlassenen Bühne probt Fool Zeilen über Narrheit und Macht.",
+                    "Das kalte Licht lässt das Wort „nachdenken“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "размышлять",
+                    "grübeln — тоже «размышлять»",
+                    "sinnen — тоже «размышлять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erkennen",
+                "russian": "познавать",
+                "sentence": "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme. Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus.",
+                "sentence_translation": "На чердаке замка Шут раскладывает воспоминания как старые костюмы. Я глубоко вдыхаю и выпускаю только слово «познавать».",
+                "russian_hint": "",
+                "transcription": "[ер-КЕН-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Dachboden der Burg sortiert Fool Erinnerungen wie alte Kostüme.",
+                    "Ich atme tief ein und lasse nur das Wort „erkennen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "познавать",
+                    "узнавать",
+                    "erfahren — тоже «узнавать»",
+                    "wiedererkennen — тоже «узнавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Sinn",
+                "russian": "смысл",
+                "sentence": "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht. Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern.",
+                "sentence_translation": "Перед зеркалом без стекла Шут разглядывает собственное усталое лицо. Даже если мир распадается, слово «смысл» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дер ЗИН]",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
+                "sentence_parts": [
+                    "Vor einem Spiegel ohne Glas betrachtet Fool das eigene müde Gesicht.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Sinn“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "смысл"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vergänglich",
+                "russian": "преходящий",
+                "sentence": "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament. Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus.",
+                "sentence_translation": "В первом утреннем свете Шут записывает последние остроты на пергамент. Я глубоко вдыхаю и выпускаю только слово «преходящий».",
+                "russian_hint": "",
+                "transcription": "[фер-ГЕНГ-лих]",
+                "themes": [
+                    "Philosophie",
+                    "Schicksal",
+                    "Vergänglichkeit"
+                ],
+                "sentence_parts": [
+                    "Im ersten Morgenlicht schreibt Fool letzte Sprüche auf Pergament.",
+                    "Ich atme tief ein und lasse nur das Wort „vergänglich“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "преходящий"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Philosophie",
@@ -3601,27 +4576,27 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
-                    "размышлять",
-                    "судьба",
                     "философия",
-                    "бренность"
+                    "размышлять",
+                    "бренность",
+                    "судьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "философия",
+                    "размышлять",
                     "бренность",
-                    "судьба",
-                    "размышлять"
+                    "философия",
+                    "судьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
-                    "познавать",
+                    "размышлять",
                     "судьба",
                     "смысл",
                     "бренность"
@@ -3631,18 +4606,18 @@
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "бренность",
-                    "философия",
+                    "познавать",
                     "судьба",
-                    "размышлять"
+                    "размышлять",
+                    "преходящий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "философия",
                     "судьба",
+                    "философия",
                     "размышлять",
                     "познавать"
                 ],
@@ -3651,20 +4626,20 @@
             {
                 "question": "Что означает немецкое слово «der Sinn»?",
                 "choices": [
-                    "смысл",
-                    "философия",
                     "размышлять",
-                    "преходящий"
+                    "судьба",
+                    "смысл",
+                    "философия"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
                     "преходящий",
-                    "философия",
                     "познавать",
-                    "смысл"
+                    "философия",
+                    "размышлять"
                 ],
                 "correctIndex": 0
             }
@@ -3746,6 +4721,176 @@
     "vanishing": {
         "title": "Исчезновение",
         "description": "Акт III: Таинственно исчезает",
+        "vocabulary": [
+            {
+                "german": "verschwinden",
+                "russian": "исчезать",
+                "sentence": "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir.",
+                "sentence_translation": "В утреннем тумане Шут растворяется между шатрами армии. Буря за окнами усиливает клятву: слово «исчезать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[фер-ШВИН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Nebel des Morgens löst sich Fool zwischen den Zelten der Armee auf.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verschwinden“ gehört mir."
+                ],
+                "synonyms": [
+                    "исчезать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Geheimnis",
+                "russian": "тайна",
+                "sentence": "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück. Ich presse das Wort „das Geheimnis“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На пустой тропе Шут оставляет лишь один колокольчик. Я стискиваю слово «тайна» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[дас ге-ХАЙМ-нис]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem verlassenen Pfad lässt Fool nur ein Glöckchen zurück.",
+                    "Ich presse das Wort „das Geheimnis“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "тайна"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Leere",
+                "russian": "пустота",
+                "sentence": "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig.",
+                "sentence_translation": "Среди разбросанных карт Шут исчезает за гобеленом. Каждой клеткой тела я обещаю: слово «пустота» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ЛЕ-ре]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Karten verschwindet Fool hinter einem Wandteppich.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leere“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "пустота"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sich auflösen",
+                "russian": "растворяться",
+                "sentence": "Am Rand des Schlachtfelds weht Fools bunter Schal davon. Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На краю поля битвы уносит пёстрый шарф Шут. Я вывожу слово «растворяться» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[зих АУФ-лё-зен]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
+                "sentence_parts": [
+                    "Am Rand des Schlachtfelds weht Fools bunter Schal davon.",
+                    "Ich zeichne das Wort „sich auflösen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "растворяться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "spurlos",
+                "russian": "бесследно",
+                "sentence": "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied. Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Под взглядами солдат Шут кланяется и уходит без прощания. Я обнимаю слово «бесследно», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ШПУР-лос]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
+                "sentence_parts": [
+                    "Unter den Blicken der Soldaten verbeugt sich Fool und geht ohne Abschied.",
+                    "Ich umarme das Wort „spurlos“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "бесследно"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Nebel",
+                "russian": "туман",
+                "sentence": "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen. Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus.",
+                "sentence_translation": "На лестнице замка одиноко остаётся жезл с бубенчиками Шут. Я глубоко вдыхаю и выпускаю только слово «туман».",
+                "russian_hint": "",
+                "transcription": "[дер НЕ-бель]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
+                "sentence_parts": [
+                    "Auf der Treppe der Burg bleibt Fools Schellenstab einsam liegen.",
+                    "Ich atme tief ein und lasse nur das Wort „der Nebel“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "туман"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "rätselhaft",
+                "russian": "загадочный",
+                "sentence": "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum. Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В шуме моря голос Шут растворяется как далёкий сон. Я обнимаю слово «загадочный», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[РЕТ-зель-хафт]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Prophezeiung",
+                    "Rätsel",
+                    "Verschwinden",
+                    "Vorahnung"
+                ],
+                "sentence_parts": [
+                    "Im Rauschen des Meeres verliert sich Fools Stimme wie ein ferner Traum.",
+                    "Ich umarme das Wort „rätselhaft“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "загадочный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "fortgehen",
+                "russian": "уходить",
+                "sentence": "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst. Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед восходящим солнцем Шут бросает последнюю тень и растворяется. Я черчу слово «уходить» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ФОРТ-ге-ен]",
+                "themes": [
+                    "Geheimnis",
+                    "Leere",
+                    "Verschwinden"
+                ],
+                "sentence_parts": [
+                    "Vor der aufgehenden Sonne wirft Fool einen letzten Schatten und verblasst.",
+                    "Ich zeichne das Wort „fortgehen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "уходить"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verschwinden",
@@ -3963,69 +5108,69 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "тайна",
-                    "пустота",
                     "исчезать",
-                    "растворяться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Geheimnis»?",
-                "choices": [
-                    "исчезать",
-                    "тайна",
                     "растворяться",
-                    "пустота"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Leere»?",
-                "choices": [
-                    "тайна",
-                    "исчезать",
                     "пустота",
-                    "бесследно"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «sich auflösen»?",
-                "choices": [
-                    "уходить",
-                    "туман",
-                    "тайна",
-                    "растворяться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «spurlos»?",
-                "choices": [
-                    "бесследно",
-                    "загадочный",
-                    "туман",
-                    "уходить"
+                    "тайна"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Nebel»?",
+                "question": "Что означает немецкое слово «das Geheimnis»?",
+                "choices": [
+                    "тайна",
+                    "исчезать",
+                    "пустота",
+                    "растворяться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
                     "пустота",
-                    "бесследно",
+                    "растворяться",
                     "загадочный",
                     "туман"
                 ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «sich auflösen»?",
+                "choices": [
+                    "растворяться",
+                    "туман",
+                    "исчезать",
+                    "тайна"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «spurlos»?",
+                "choices": [
+                    "исчезать",
+                    "уходить",
+                    "туман",
+                    "бесследно"
+                ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Nebel»?",
+                "choices": [
+                    "растворяться",
+                    "уходить",
+                    "туман",
+                    "исчезать"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
                     "уходить",
-                    "пустота",
                     "тайна",
+                    "пустота",
                     "загадочный"
                 ],
                 "correctIndex": 3
@@ -4033,10 +5178,10 @@
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
-                    "бесследно",
                     "исчезать",
+                    "загадочный",
                     "уходить",
-                    "тайна"
+                    "растворяться"
                 ],
                 "correctIndex": 2
             }
@@ -4132,6 +5277,9 @@ const characterId = "fool";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["граф", "доверять", "знать", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["служить", "граф", "доверять", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "честь", "долг", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["служить", "долг", "честь", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "знать", "праведный", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["долг", "праведный", "доверять", "честь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["знать", "долг", "честь", "уважать"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["граф", "уважать", "служить", "праведный"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обманывать", "обман", "письмо", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обман", "письмо", "верить", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["легковерный", "обманывать", "ловушка", "простодушный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["подозревать", "обманывать", "обман", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["обман", "подозревать", "обманывать", "простодушный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["подозревать", "легковерный", "обман", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["ловушка", "верить", "письмо", "легковерный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "обманывать", "письмо", "легковерный"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "проклинать", "сожалеть", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["изгонять", "заблуждение", "проклинать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["слепой", "изгонять", "проклинать", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["проклинать", "гнать", "слепой", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["заблуждение", "гнать", "слепой", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["слепой", "изгонять", "гнать", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгонять", "проклинать", "несправедливость", "сожалеть"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["рисковать", "сострадание", "помогать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["рисковать", "помогать", "сострадание", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["осмеливаться", "сострадание", "защищать", "рисковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "рисковать", "защищать", "сострадание"], "correct_index": 0}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["сострадание", "измена", "тайно", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "измена", "помогать", "рисковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "сострадание", "измена", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["опасность", "помогать", "защищать", "осмеливаться"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["боль", "ослеплять", "темнота", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "боль", "ослеплять", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["ослеплять", "темнота", "слепнуть", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["слепнуть", "темнота", "пытка", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["пытка", "кричать", "ослеплять", "слепнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["месть", "пытка", "ослеплять", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "слепнуть", "кричать", "пытка"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обман", "отчаяние", "прыгать", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "пропасть", "отчаяние", "прыгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "падать", "сдаваться", "безнадёжность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["сдаваться", "прыгать", "пропасть", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "избавлять", "падать", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["обман", "пропасть", "отчаяние", "безнадёжность"], "correct_index": 3}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "обман", "безнадёжность", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["безнадёжность", "сдаваться", "прыгать", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["осознание", "узнавать", "прощать", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["умирать", "прощать", "узнавать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["осознание", "примирение", "умирать", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["обнимать", "прощать", "осознание", "сердце"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["умирать", "раскаяние", "прощать", "примирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["узнавать", "раскаяние", "прощать", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["примирение", "узнавать", "обнимать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "раскаяние", "сердце", "узнавать"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "граф", "знать", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "служить", "доверять", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "уважать", "честь", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["уважать", "знать", "праведный", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["уважать", "честь", "служить", "праведный"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["долг", "доверять", "праведный", "знать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "служить", "доверять", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «achten»?", "choices": ["долг", "уважать", "граф", "служить"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "верить", "обманывать", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обман", "обманывать", "верить", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обман", "простодушный", "подозревать", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "обманывать", "ловушка", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["обманывать", "ловушка", "простодушный", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["обман", "легковерный", "обманывать", "подозревать"], "correct_index": 3}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["подозревать", "обманывать", "легковерный", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["обман", "ловушка", "легковерный", "подозревать"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "изгонять", "проклинать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "заблуждение", "сожалеть", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "гнать", "сожалеть", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["изгонять", "заблуждение", "слепой", "несправедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «blind»?", "choices": ["проклинать", "гнать", "слепой", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "проклинать", "сожалеть", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["заблуждение", "слепой", "сожалеть", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["рисковать", "опасность", "сострадание", "помогать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "сострадание", "рисковать", "помогать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["помогать", "рисковать", "опасность", "измена"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["сострадание", "опасность", "рисковать", "помогать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "измена", "сострадание", "рисковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["осмеливаться", "сострадание", "защищать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["рисковать", "измена", "защищать", "тайно"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["осмеливаться", "помогать", "опасность", "рисковать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["пытка", "ослеплять", "темнота", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "боль", "темнота", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["пытка", "боль", "слепнуть", "темнота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["слепнуть", "ослеплять", "боль", "темнота"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["ослеплять", "кричать", "темнота", "слепнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["слепнуть", "темнота", "месть", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["пытка", "темнота", "кричать", "месть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "пропасть", "прыгать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "отчаяние", "пропасть", "прыгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "безнадёжность", "прыгать", "пропасть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["прыгать", "сдаваться", "безнадёжность", "пропасть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "прыгать", "обман", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["пропасть", "безнадёжность", "прыгать", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["обман", "безнадёжность", "отчаяние", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["падать", "избавлять", "обман", "прыгать"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "узнавать", "умирать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "узнавать", "умирать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "узнавать", "раскаяние", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["сердце", "осознание", "обнимать", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["умирать", "прощать", "раскаяние", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["осознание", "обнимать", "узнавать", "примирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["примирение", "узнавать", "умирать", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "умирать", "прощать", "примирение"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -666,9 +666,9 @@
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
@@ -678,13 +678,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
@@ -700,11 +700,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -714,11 +714,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
@@ -726,49 +726,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -778,13 +778,13 @@
                         <div class="quiz-question">Что означает немецкое слово «achten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,17 +797,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -819,9 +819,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
@@ -829,97 +845,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,13 +932,29 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
@@ -948,49 +964,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1000,27 +1000,27 @@
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
@@ -1028,17 +1028,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,40 +1051,88 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
@@ -1093,87 +1141,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1190,13 +1190,13 @@
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1210,7 +1210,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                             
@@ -1218,33 +1234,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1254,11 +1254,11 @@
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
@@ -1266,33 +1266,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,17 +1305,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1327,9 +1327,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                             
@@ -1343,27 +1343,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1375,9 +1375,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
@@ -1385,49 +1385,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1444,27 +1444,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
@@ -1472,15 +1456,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
@@ -1488,49 +1504,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1544,25 +1544,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1584,6 +1584,172 @@
     "throne": {
         "title": "Благородный граф",
         "description": "Акт I: При дворе короля",
+        "vocabulary": [
+            {
+                "german": "der Adel",
+                "russian": "знать",
+                "sentence": "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals. Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern.",
+                "sentence_translation": "Глостер стоит под пылающей люстрой тронного зала. Даже если мир распадается, слово «знать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дер А-дель]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Gloucester steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „der Adel“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "знать",
+                    "kennen — тоже «знать»",
+                    "wissen — тоже «знать»",
+                    "дворянство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "dienen",
+                "russian": "служить",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch. Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten.",
+                "sentence_translation": "У развернутой карты королевства Глостер склоняется над тяжёлым столом Лира. Твёрдым голосом я клянусь себе: слово «служить» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ДИ-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Gloucester über Lears schweren Tisch.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „dienen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "служить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vertrauen",
+                "russian": "доверять",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken. Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus.",
+                "sentence_translation": "Перед каменными статуями предков Глостер сцепляет руки за спиной. Я глубоко вдыхаю и выпускаю только слово «доверять».",
+                "russian_hint": "",
+                "transcription": "[фер-ТРАУ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Gloucester die Hände hinter dem Rücken.",
+                    "Ich atme tief ein und lasse nur das Wort „vertrauen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "доверять",
+                    "misstrauen — тоже «доверять»",
+                    "trauen — тоже «доверять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Graf",
+                "russian": "граф",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden. Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Между шепчущимися придворными Глостер скользит по холодному мраморному полу. Я вывожу слово «граф» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[дер ГРАФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen flüsternden Höflingen gleitet Gloucester über den kalten Marmorboden.",
+                    "Ich zeichne das Wort „der Graf“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "граф"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ehre",
+                "russian": "честь",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs. Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На краю пурпурного ковра Глостер ждёт знака от короля. Я вывожу слово «честь» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди Э-ре]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand des purpurnen Teppichs wartet Gloucester auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Ehre“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "честь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "rechtschaffen",
+                "russian": "праведный",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick. Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Под развевающимися штандартами сестёр Глостер на миг опускает взгляд. Я стискиваю слово «праведный» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[РЕХТ-ша-фен]",
+                "themes": [
+                    "Adel",
+                    "Entscheidung",
+                    "Gerechtigkeit",
+                    "Moral",
+                    "dienen",
+                    "vertrauen"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Gloucester kurz den Blick.",
+                    "Ich presse das Wort „rechtschaffen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "праведный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Pflicht",
+                "russian": "долг",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir.",
+                "sentence_translation": "За позолоченной балюстрадой Глостер наблюдает за напряжёнными лицами двора. Буря за окнами усиливает клятву: слово «долг» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди ПФЛИХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Gloucester das gespannte Antlitz des Hofes.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Pflicht“ gehört mir."
+                ],
+                "synonyms": [
+                    "долг"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "achten",
+                "russian": "уважать",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme. Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В отблесках открытых жаровен Глостер медленно поднимает голос. Я вывожу слово «уважать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[АХ-тен]",
+                "themes": [
+                    "Adel",
+                    "dienen",
+                    "vertrauen"
+                ],
+                "sentence_parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Gloucester langsam die Stimme.",
+                    "Ich zeichne das Wort „achten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "уважать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Adel",
@@ -1803,8 +1969,8 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "граф",
                     "доверять",
+                    "граф",
                     "знать",
                     "служить"
                 ],
@@ -1813,29 +1979,29 @@
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "служить",
                     "граф",
+                    "служить",
                     "доверять",
                     "знать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
                     "доверять",
+                    "уважать",
                     "честь",
-                    "долг",
-                    "граф"
+                    "служить"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "служить",
-                    "долг",
-                    "честь",
+                    "уважать",
+                    "знать",
+                    "праведный",
                     "граф"
                 ],
                 "correctIndex": 3
@@ -1843,40 +2009,40 @@
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "доверять",
-                    "знать",
-                    "праведный",
-                    "честь"
+                    "уважать",
+                    "честь",
+                    "служить",
+                    "праведный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
                     "долг",
-                    "праведный",
                     "доверять",
-                    "честь"
+                    "праведный",
+                    "знать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "знать",
-                    "долг",
                     "честь",
-                    "уважать"
+                    "служить",
+                    "доверять",
+                    "долг"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "граф",
+                    "долг",
                     "уважать",
-                    "служить",
-                    "праведный"
+                    "граф",
+                    "служить"
                 ],
                 "correctIndex": 1
             }
@@ -1968,6 +2134,174 @@
     "goneril": {
         "title": "Обман Эдмунда",
         "description": "Акт I: Поддельное письмо",
+        "vocabulary": [
+            {
+                "german": "der Brief",
+                "russian": "письмо",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten. Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "В гулком проёме ворот замка Гонерильи Глостер замирает среди нагруженных ящиков. Холодный свет заставляет слово «письмо» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер БРИФ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Gloucester zwischen gepackten Kisten.",
+                    "Das kalte Licht lässt das Wort „der Brief“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "письмо"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "glauben",
+                "russian": "верить",
+                "sentence": "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir.",
+                "sentence_translation": "На продуваемой ветром лестнице Глостер смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «верить» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ГЛАУ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der windigen Freitreppe blickt Gloucester zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „glauben“ gehört mir."
+                ],
+                "synonyms": [
+                    "верить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "täuschen",
+                "russian": "обманывать",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir.",
+                "sentence_translation": "Среди оставленных слуг Глостер плотнее запахивает дорожный плащ. Буря за окнами усиливает клятву: слово «обманывать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ТОЙ-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Gloucester den Reisemantel enger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „täuschen“ gehört mir."
+                ],
+                "synonyms": [
+                    "обманывать",
+                    "betrügen — тоже «обманывать»",
+                    "hintergehen — тоже «обманывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Betrug",
+                "russian": "обман",
+                "sentence": "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne. Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "У тёмного конюшенного ряда Глостер гладит гриву нервного коня. Я черчу слово «обман» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер бе-ТРУГ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Pferdestall streicht Gloucester einem nervösen Tier über die Mähne.",
+                    "Ich zeichne das Wort „der Betrug“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "обман",
+                    "die Täuschung — тоже «обман»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "arglos",
+                "russian": "простодушный",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor. Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Перед скрипящим подъёмным мостом Глостер в последний раз касается родной двери. Я вывожу слово «простодушный» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[АРГ-лос]",
+                "themes": [
+                    "Brief",
+                    "glauben",
+                    "täuschen"
+                ],
+                "sentence_parts": [
+                    "Vor dem knarrenden Fallgatter tastet Gloucester ein letztes Mal nach dem Haustor.",
+                    "Ich zeichne das Wort „arglos“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "простодушный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verdächtigen",
+                "russian": "подозревать",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand. Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern.",
+                "sentence_translation": "Среди разбросанных свитков Глостер вертит кольцо на пальце. Даже если мир распадается, слово «подозревать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[фер-ДЕХ-ти-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Gloucester den Ring an der Hand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „verdächtigen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "подозревать",
+                    "argwöhnen — тоже «подозревать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leichtgläubig",
+                "russian": "легковерный",
+                "sentence": "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen. Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У пустого банкетного стола Глостер пересчитывает гаснущие свечи. Моё дыхание рисует слово «легковерный» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ЛАЙХТ-глой-биг]",
+                "themes": [
+                    "Brief",
+                    "glauben",
+                    "täuschen"
+                ],
+                "sentence_parts": [
+                    "Am leeren Bankettisch zählt Gloucester die verlöschenden Kerzen.",
+                    "Mein Atem zeichnet das Wort „leichtgläubig“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "легковерный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Falle",
+                "russian": "ловушка",
+                "sentence": "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Между молчаливыми стражниками Глостер выходит на холодный двор. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ФА-ле]",
+                "themes": [
+                    "Brief",
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "glauben",
+                    "täuschen"
+                ],
+                "sentence_parts": [
+                    "Zwischen schweigenden Wachen geht Gloucester auf den kalten Hof hinaus.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "ловушка"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Brief",
@@ -2186,82 +2520,82 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "обманывать",
                     "обман",
-                    "письмо",
-                    "верить"
+                    "верить",
+                    "обманывать",
+                    "письмо"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «glauben»?",
                 "choices": [
                     "обман",
-                    "письмо",
+                    "обманывать",
                     "верить",
-                    "обманывать"
+                    "письмо"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "легковерный",
-                    "обманывать",
-                    "ловушка",
-                    "простодушный"
+                    "обман",
+                    "простодушный",
+                    "подозревать",
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "подозревать",
-                    "обманывать",
                     "обман",
-                    "ловушка"
+                    "обманывать",
+                    "ловушка",
+                    "письмо"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
-                    "обман",
-                    "подозревать",
                     "обманывать",
-                    "простодушный"
+                    "ловушка",
+                    "простодушный",
+                    "обман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "подозревать",
-                    "легковерный",
                     "обман",
-                    "ловушка"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «leichtgläubig»?",
-                "choices": [
-                    "ловушка",
-                    "верить",
-                    "письмо",
-                    "легковерный"
+                    "легковерный",
+                    "обманывать",
+                    "подозревать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «leichtgläubig»?",
+                "choices": [
+                    "подозревать",
+                    "обманывать",
+                    "легковерный",
+                    "обман"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
+                    "обман",
                     "ловушка",
-                    "обманывать",
-                    "письмо",
-                    "легковерный"
+                    "легковерный",
+                    "подозревать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2352,6 +2686,164 @@
     "regan": {
         "title": "Изгнание Эдгара",
         "description": "Акт II: Изгнание сына",
+        "vocabulary": [
+            {
+                "german": "verstoßen",
+                "russian": "изгонять",
+                "sentence": "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde. Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В продуваемом ветром боковом крыле Глостер слушает вой прибрежного ветра. Я обнимаю слово «изгонять», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[фер-ШТО-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im zugigen Seitenflügel lauscht Gloucester dem Heulen der Küstenwinde.",
+                    "Ich umarme das Wort „verstoßen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "изгонять",
+                    "verbannen — тоже «изгонять»",
+                    "vertreiben — тоже «изгонять»",
+                    "отвергать",
+                    "abweisen — тоже «отвергать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verfluchen",
+                "russian": "проклинать",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief. Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед дымным камином замка Глостер складывает измятый лист. Я черчу слово «проклинать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[фер-ФЛУ-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Gloucester einen zerknitterten Brief.",
+                    "Ich zeichne das Wort „verfluchen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "проклинать",
+                    "fluchen — тоже «проклинать»",
+                    "verwünschen — тоже «проклинать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bereuen",
+                "russian": "сожалеть",
+                "sentence": "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab. Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Под выцветшими гобеленами Глостер беспокойно меряет шагами зал. Холодный свет заставляет слово «сожалеть» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[бе-РОЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter farblosen Wandteppichen schreitet Gloucester rastlos auf und ab.",
+                    "Das kalte Licht lässt das Wort „bereuen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "сожалеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Irrtum",
+                "russian": "заблуждение",
+                "sentence": "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof. Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У узкой бойницы Глостер считает факелы на дворе. Я держу слово «заблуждение» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер ИР-тум]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "An der schmalen Fensterluke zählt Gloucester die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „der Irrtum“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "заблуждение",
+                    "ошибка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "blind",
+                "russian": "слепой",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften. Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen.",
+                "sentence_translation": "Среди дорожных сундуков послов Глостер ищет свежие вести. Как тихая молитва слово «слепой» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[БЛИНД]",
+                "themes": [
+                    "Klippe",
+                    "bereuen",
+                    "blind",
+                    "führen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Gloucester nach frischen Botschaften.",
+                    "Wie ein stilles Gebet legt sich das Wort „blind“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "слепой"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "jagen",
+                "russian": "гнать",
+                "sentence": "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur. Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig.",
+                "sentence_translation": "В тихой капелле Глостер преклоняет колени перед холодной каменной фигурой. Каждой клеткой тела я обещаю: слово «гнать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[Я-ген]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Im stillen Kapellenraum kniet Gloucester vor der kalten Steinfigur.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „jagen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "гнаться",
+                    "гнать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ungerechtigkeit",
+                "russian": "несправедливость",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig.",
+                "sentence_translation": "На балконе, омываемом морскими брызгами, Глостер крепко держит фонарь. Каждой клеткой тела я обещаю: слово «несправедливость» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди УН-ге-рех-тиг-кайт]",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Gloucester die Laterne fest.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Ungerechtigkeit“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "несправедливость"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verstoßen",
@@ -2557,71 +3049,71 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "заблуждение",
+                    "изгонять",
                     "проклинать",
-                    "сожалеть",
-                    "изгонять"
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "изгонять",
-                    "заблуждение",
                     "проклинать",
-                    "сожалеть"
+                    "заблуждение",
+                    "сожалеть",
+                    "изгонять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "слепой",
                     "изгонять",
-                    "проклинать",
-                    "сожалеть"
+                    "гнать",
+                    "сожалеть",
+                    "слепой"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Irrtum»?",
                 "choices": [
-                    "проклинать",
-                    "гнать",
+                    "изгонять",
+                    "заблуждение",
                     "слепой",
-                    "заблуждение"
+                    "несправедливость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "заблуждение",
+                    "проклинать",
                     "гнать",
                     "слепой",
-                    "изгонять"
+                    "сожалеть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "слепой",
-                    "изгонять",
                     "гнать",
+                    "проклинать",
+                    "сожалеть",
                     "несправедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "изгонять",
-                    "проклинать",
-                    "несправедливость",
-                    "сожалеть"
+                    "заблуждение",
+                    "слепой",
+                    "сожалеть",
+                    "несправедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2701,6 +3193,169 @@
     "storm": {
         "title": "Помощь Лиру",
         "description": "Акт III: Тайная помощь",
+        "vocabulary": [
+            {
+                "german": "helfen",
+                "russian": "помогать",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind. Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Посреди хлещущей дождём пустоши Глостер упирается в ветер. Эхо слова «помогать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ХЕЛЬ-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Gloucester gegen den Wind.",
+                    "Das Echo des Wortes „helfen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "помогать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Mitleid",
+                "russian": "сострадание",
+                "sentence": "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern.",
+                "sentence_translation": "Под разорванным знаменем Глостер прикрывает глаза от молний. Даже если мир распадается, слово «сострадание» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дас МИТ-лайд]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerrissenen Banner schützt Gloucester die Augen vor den Blitzen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Mitleid“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "сострадание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "riskieren",
+                "russian": "рисковать",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner. Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern.",
+                "sentence_translation": "У поваленного дерева Глостер ищет укрытия от грома. Даже если мир распадается, слово «рисковать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[рис-КИ-рен]",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
+                "sentence_parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Gloucester Deckung vor dem Donner.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „riskieren“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "рисковать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gefahr",
+                "russian": "опасность",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm. Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Между пенящимися лужами Глостер пробирается через грязь. Холодный свет заставляет слово «опасность» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ди ге-ФАР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Gloucester durch den Schlamm.",
+                    "Das kalte Licht lässt das Wort „die Gefahr“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "опасность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "heimlich",
+                "russian": "тайно",
+                "sentence": "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir.",
+                "sentence_translation": "На фоне вспыхивающего неба Глостер упрямо поднимает руки. Буря за окнами усиливает клятву: слово «тайно» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ХАЙМ-лих]",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
+                "sentence_parts": [
+                    "Vor einem zuckenden Himmel hebt Gloucester die Arme trotzig an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „heimlich“ gehört mir."
+                ],
+                "synonyms": [
+                    "тайно"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schützen",
+                "russian": "защищать",
+                "sentence": "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte. Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig.",
+                "sentence_translation": "Под промокшим плащом Глостер прижимает дыхание к груди, спасаясь от холода. Каждой клеткой тела я обещаю: слово «защищать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ШЮ-цен]",
+                "themes": [
+                    "Mitleid",
+                    "helfen",
+                    "riskieren"
+                ],
+                "sentence_parts": [
+                    "Unter dem durchtränkten Umhang presst Gloucester den Atem gegen die Kälte.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „schützen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "защищать",
+                    "beschützen — тоже «защищать»",
+                    "verteidigen — тоже «защищать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Verrat",
+                "russian": "измена",
+                "sentence": "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir.",
+                "sentence_translation": "У жалких огненных углей Глостер греет дрожащие пальцы. Буря за окнами усиливает клятву: слово «измена» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дер фер-РАТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am kläglichen Feuerrest wärmt Gloucester zitternde Finger.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Verrat“ gehört mir."
+                ],
+                "synonyms": [
+                    "предательство",
+                    "измена"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "wagen",
+                "russian": "осмеливаться",
+                "sentence": "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir.",
+                "sentence_translation": "Среди воющих псов Глостер перекрикивает беснующуюся бурю. Буря за окнами усиливает клятву: слово «осмеливаться» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ВА-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen heulenden Hunden ruft Gloucester gegen den tosenden Sturm an.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „wagen“ gehört mir."
+                ],
+                "synonyms": [
+                    "осмеливаться"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "helfen",
@@ -2915,81 +3570,81 @@
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
                     "рисковать",
+                    "опасность",
                     "сострадание",
-                    "помогать",
-                    "опасность"
+                    "помогать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Mitleid»?",
                 "choices": [
-                    "рисковать",
-                    "помогать",
+                    "опасность",
                     "сострадание",
-                    "опасность"
+                    "рисковать",
+                    "помогать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
-                    "осмеливаться",
-                    "сострадание",
-                    "защищать",
-                    "рисковать"
+                    "помогать",
+                    "рисковать",
+                    "опасность",
+                    "измена"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
+                    "сострадание",
                     "опасность",
                     "рисковать",
-                    "защищать",
-                    "сострадание"
+                    "помогать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
-                    "сострадание",
-                    "измена",
                     "тайно",
-                    "осмеливаться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schützen»?",
-                "choices": [
-                    "защищать",
                     "измена",
-                    "помогать",
+                    "сострадание",
                     "рисковать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Verrat»?",
+                "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
-                    "тайно",
+                    "осмеливаться",
                     "сострадание",
-                    "измена",
+                    "защищать",
                     "опасность"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Verrat»?",
+                "choices": [
+                    "рисковать",
+                    "измена",
+                    "защищать",
+                    "тайно"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "опасность",
+                    "осмеливаться",
                     "помогать",
-                    "защищать",
-                    "осмеливаться"
+                    "опасность",
+                    "рисковать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3079,6 +3734,155 @@
     "hut": {
         "title": "Ослепление",
         "description": "Акт III: Потеря глаз",
+        "vocabulary": [
+            {
+                "german": "blenden",
+                "russian": "ослеплять",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir.",
+                "sentence_translation": "В тёмном шатре полевых лекарей Глостер сидит у мерцающей свечи. Буря за окнами усиливает клятву: слово «ослеплять» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[БЛЕН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Gloucester bei der flackernden Kerze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „blenden“ gehört mir."
+                ],
+                "synonyms": [
+                    "ослеплять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Folter",
+                "russian": "пытка",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen. Ich presse das Wort „die Folter“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Среди помятых доспехов Глостер гладит старый герб. Я стискиваю слово «пытка» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ФОЛЬ-тер]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Gloucester über ein altes Wappen.",
+                    "Ich presse das Wort „die Folter“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "пытка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Schmerz",
+                "russian": "боль",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf. Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "О низкую балку хижины Глостер едва не ударяется головой. Я обнимаю слово «боль», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер ШМЕРЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Gloucester fast den Kopf.",
+                    "Ich umarme das Wort „der Schmerz“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "боль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Dunkelheit",
+                "russian": "темнота",
+                "sentence": "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht. Ich presse das Wort „die Dunkelheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Рядом со спящим стражем Глостер шепчет в тяжёлую ночь. Я стискиваю слово «темнота» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ДУН-кель-хайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schlafenden Wache flüstert Gloucester in die schwere Nacht.",
+                    "Ich presse das Wort „die Dunkelheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "темнота"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schreien",
+                "russian": "кричать",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten. Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten.",
+                "sentence_translation": "Перед грубой походной койкой Глостер разглядывает шрамы прошлых битв. Твёрдым голосом я клянусь себе: слово «кричать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ШРАЙ-ен]",
+                "themes": [
+                    "Folter",
+                    "Schmerz",
+                    "Sturm",
+                    "Wahnsinn",
+                    "blenden",
+                    "toben"
+                ],
+                "sentence_parts": [
+                    "Vor dem einfachen Feldbett betrachtet Gloucester die Narben vergangener Schlachten.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „schreien“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "кричать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erblinden",
+                "russian": "слепнуть",
+                "sentence": "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen.",
+                "sentence_translation": "В запахе влажной соломы Глостер откладывает плащ в сторону. Я шепчу стражам судьбы: слово «слепнуть» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ер-БЛИН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Geruch von feuchtem Stroh legt Gloucester den Mantel zur Seite.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erblinden“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "слепнуть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rache",
+                "russian": "месть",
+                "sentence": "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe. Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen.",
+                "sentence_translation": "На шатком деревянном столе Глостер раскладывает зачитанные письма. Как тихая молитва слово «месть» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди РА-хе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem wackligen Holztisch ordnet Gloucester zerlesene Briefe.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Rache“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "месть"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "blenden",
@@ -3283,10 +4087,10 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "боль",
+                    "пытка",
                     "ослеплять",
                     "темнота",
-                    "пытка"
+                    "боль"
                 ],
                 "correctIndex": 1
             },
@@ -3295,37 +4099,37 @@
                 "choices": [
                     "пытка",
                     "боль",
-                    "ослеплять",
-                    "темнота"
+                    "темнота",
+                    "ослеплять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "ослеплять",
-                    "темнота",
+                    "пытка",
+                    "боль",
                     "слепнуть",
-                    "боль"
+                    "темнота"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
                     "слепнуть",
-                    "темнота",
-                    "пытка",
-                    "ослеплять"
+                    "ослеплять",
+                    "боль",
+                    "темнота"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "пытка",
-                    "кричать",
                     "ослеплять",
+                    "кричать",
+                    "темнота",
                     "слепнуть"
                 ],
                 "correctIndex": 1
@@ -3333,22 +4137,22 @@
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
+                    "слепнуть",
+                    "темнота",
                     "месть",
-                    "пытка",
-                    "ослеплять",
-                    "слепнуть"
+                    "боль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
-                    "слепнуть",
+                    "пытка",
+                    "темнота",
                     "кричать",
-                    "пытка"
+                    "месть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3430,6 +4234,178 @@
     "dover": {
         "title": "Скалы Дувра",
         "description": "Акт IV: Попытка самоубийства",
+        "vocabulary": [
+            {
+                "german": "die Verzweiflung",
+                "russian": "отчаяние",
+                "sentence": "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern.",
+                "sentence_translation": "На белых скалах Дувра Глостер смотрит в вздыбленный пролив. Даже если мир распадается, слово «отчаяние» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ЦВАЙ-флунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf den weißen Klippen von Dover blickt Gloucester in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Verzweiflung“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "отчаяние"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "springen",
+                "russian": "прыгать",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Gloucester den Helm. Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Среди хлопающих штандартов Глостер поправляет шлем. Эхо слова «прыгать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ШПРИН-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen flatternden Feldzeichen richtet Gloucester den Helm.",
+                    "Das Echo des Wortes „springen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "прыгать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Täuschung",
+                "russian": "обман",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand. Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У французского костра Глостер рисует в песке путь марша. Я держу слово «обман» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ТОЙ-шунг]",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Gloucester Marschrouten in den Sand.",
+                    "Ich halte das Wort „die Täuschung“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "обман",
+                    "der Betrug — тоже «обман»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Abgrund",
+                "russian": "пропасть",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel. Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У перевязанных провиантных ящиков Глостер проверяет печати. Я держу слово «пропасть» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер АБ-грунд]",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Gloucester das Siegel.",
+                    "Ich halte das Wort „der Abgrund“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "пропасть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufgeben",
+                "russian": "сдаваться",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer. Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Перед шёлковым шатром полководцев Глостер слушает глухой шум моря. Холодный свет заставляет слово «сдаваться» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[АУФ-ге-бен]",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "Täuschung",
+                    "Verzweiflung",
+                    "ewige Treue",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Gloucester dem dumpfen Meer.",
+                    "Das kalte Licht lässt das Wort „aufgeben“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "сдаваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hoffnungslosigkeit",
+                "russian": "безнадёжность",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts. Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На песчаном плацу Глостер отрабатывает выхват меча. Моё дыхание рисует слово «безнадёжность» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ХОФ-нунгс-ло-зиг-кайт]",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Auf dem sandigen Trainingsplatz übt Gloucester das Ziehen des Schwerts.",
+                    "Mein Atem zeichnet das Wort „die Hoffnungslosigkeit“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "безнадёжность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "stürzen",
+                "russian": "падать",
+                "sentence": "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung. Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Под гул барабанов Глостер поднимает знамя надежды. Холодный свет заставляет слово «падать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ШТЮР-цен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen pochenden Trommeln hebt Gloucester das Banner der Hoffnung.",
+                    "Das kalte Licht lässt das Wort „stürzen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "падать",
+                    "fallen — тоже «падать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erlösen",
+                "russian": "избавлять",
+                "sentence": "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz. Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В утреннем тумане побережья Глостер кладёт ладонь на бьющееся сердце. Я стискиваю слово «избавлять» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ер-ЛЁ-зен]",
+                "themes": [
+                    "Täuschung",
+                    "Verzweiflung",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Am Morgennebel der Küste legt Gloucester die Hand auf das pochende Herz.",
+                    "Ich presse das Wort „erlösen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "избавлять"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Verzweiflung",
@@ -3652,19 +4628,19 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "обман",
                     "отчаяние",
+                    "пропасть",
                     "прыгать",
-                    "пропасть"
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «springen»?",
                 "choices": [
                     "обман",
-                    "пропасть",
                     "отчаяние",
+                    "пропасть",
                     "прыгать"
                 ],
                 "correctIndex": 3
@@ -3673,28 +4649,28 @@
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
                     "обман",
-                    "падать",
-                    "сдаваться",
-                    "безнадёжность"
+                    "безнадёжность",
+                    "прыгать",
+                    "пропасть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "сдаваться",
                     "прыгать",
-                    "пропасть",
-                    "отчаяние"
+                    "сдаваться",
+                    "безнадёжность",
+                    "пропасть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
                     "сдаваться",
-                    "избавлять",
-                    "падать",
+                    "прыгать",
+                    "обман",
                     "отчаяние"
                 ],
                 "correctIndex": 0
@@ -3702,32 +4678,32 @@
             {
                 "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "обман",
                     "пропасть",
-                    "отчаяние",
-                    "безнадёжность"
+                    "безнадёжность",
+                    "прыгать",
+                    "обман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "падать",
                     "обман",
                     "безнадёжность",
-                    "прыгать"
+                    "отчаяние",
+                    "падать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
-                    "безнадёжность",
-                    "сдаваться",
-                    "прыгать",
-                    "избавлять"
+                    "падать",
+                    "избавлять",
+                    "обман",
+                    "прыгать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3817,6 +4793,170 @@
     "prison": {
         "title": "Прозрение и смерть",
         "description": "Акт V: Узнавание Эдгара",
+        "vocabulary": [
+            {
+                "german": "erkennen",
+                "russian": "узнавать",
+                "sentence": "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein. Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В сыром подземелье Глостер опирается на сочащийся камень. Я обнимаю слово «узнавать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ер-КЕН-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im feuchten Kerker stützt Gloucester sich an den tropfenden Stein.",
+                    "Ich umarme das Wort „erkennen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "познавать",
+                    "узнавать",
+                    "erfahren — тоже «узнавать»",
+                    "wiedererkennen — тоже «узнавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vergeben",
+                "russian": "прощать",
+                "sentence": "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette. Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под мутным фонарём Глостер пересчитывает железные кольца цепи. Я черчу слово «прощать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[фер-ГЕ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter der trüben Laterne zählt Gloucester die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „vergeben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "прощать",
+                    "verzeihen — тоже «прощать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sterben",
+                "russian": "умирать",
+                "sentence": "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen. Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У тяжёлой двери Глостер прислушивается к далёким рыданиям. Я держу слово «умирать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ШТЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schweren Holztür horcht Gloucester auf entferntes Schluchzen.",
+                    "Ich halte das Wort „sterben“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "умирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Erkenntnis",
+                "russian": "осознание",
+                "sentence": "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern. Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На холодной каменной скамье Глостер плотнее кутается в плащ. Эхо слова «осознание» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ер-КЕНТ-нис]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Steinbank zieht Gloucester den Mantel enger um die Schultern.",
+                    "Das Echo des Wortes „die Erkenntnis“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "осознание",
+                    "познание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Reue",
+                "russian": "раскаяние",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht. Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Между тенями решёток Глостер поднимает лицо к свету. Я черчу слово «раскаяние» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди РОЙ-е]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Gloucester das Gesicht zum Licht.",
+                    "Ich zeichne das Wort „die Reue“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "раскаяние"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "umarmen",
+                "russian": "обнимать",
+                "sentence": "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen. Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen.",
+                "sentence_translation": "У ржавого ведра с водой Глостер на мгновение видит отражение глаз. Как тихая молитва слово «обнимать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ум-АР-мен]",
+                "themes": [
+                    "erkennen",
+                    "heilen",
+                    "sterben",
+                    "umarmen",
+                    "vergeben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Am rostigen Wassereimer spiegelt Gloucester kurz die eigenen Augen.",
+                    "Wie ein stilles Gebet legt sich das Wort „umarmen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "обнимать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Versöhnung",
+                "russian": "примирение",
+                "sentence": "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen. Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В глухом эхе шагов Глостер отсчитывает ритм часовых. Моё дыхание рисует слово «примирение» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ЗЁ-нунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dumpfen Hall der Schritte zählt Gloucester den Rhythmus der Wachen.",
+                    "Mein Atem zeichnet das Wort „die Versöhnung“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "примирение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Herz",
+                "russian": "сердце",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub. Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед заколоченным окном Глостер чертит круги в пыли. Я держу слово «сердце» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дас ХЕРЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem verriegelten Fenster zeichnet Gloucester Kreise in den Staub.",
+                    "Ich halte das Wort „das Herz“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "сердце"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "erkennen",
@@ -4041,82 +5181,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "осознание",
-                    "узнавать",
                     "прощать",
-                    "умирать"
+                    "узнавать",
+                    "умирать",
+                    "осознание"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "умирать",
                     "прощать",
                     "узнавать",
+                    "умирать",
                     "осознание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "осознание",
-                    "примирение",
                     "умирать",
-                    "раскаяние"
+                    "узнавать",
+                    "раскаяние",
+                    "прощать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "обнимать",
-                    "прощать",
+                    "сердце",
                     "осознание",
-                    "сердце"
+                    "обнимать",
+                    "раскаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
                     "умирать",
-                    "раскаяние",
                     "прощать",
-                    "примирение"
+                    "раскаяние",
+                    "осознание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
+                    "осознание",
+                    "обнимать",
                     "узнавать",
-                    "раскаяние",
-                    "прощать",
-                    "обнимать"
+                    "примирение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
                     "примирение",
                     "узнавать",
-                    "обнимать",
-                    "раскаяние"
+                    "умирать",
+                    "прощать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "прощать",
-                    "раскаяние",
                     "сердце",
-                    "узнавать"
+                    "умирать",
+                    "прощать",
+                    "примирение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4209,6 +5349,9 @@ const characterId = "gloucester";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["клясться", "лицемерить", "ложь", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["ложь", "наследство", "клясться", "лицемерить"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["состояние", "наследство", "обманывать", "жадность"], "correct_index": 1}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["состояние", "лицемерить", "клясться", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "лицемерить", "клясться", "льстить"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ложь", "жадность", "обманывать", "состояние"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["клясться", "льстить", "ложь", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["льстить", "обманывать", "состояние", "жадность"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "приказывать", "трон", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "власть", "приказывать", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["управлять", "власть", "приказывать", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["подчинять", "трон", "приказывать", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["приказывать", "завоёвывать", "власть", "подчинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["подчинять", "приказывать", "господство", "управлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["подчинять", "приказывать", "управлять", "господство"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["подчинять", "править", "власть", "господство"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["жестокий", "унижать", "изгонять", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["изгонять", "месть", "жестокий", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["изгонять", "месть", "отказывать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["жестокий", "изгонять", "унижать", "отказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["ограничивать", "мучить", "презирать", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["унижать", "месть", "жестокий", "отказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "презирать", "мучить", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "месть", "унижать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["запирать", "буря", "отвергать", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["запирать", "безжалостный", "отвергать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["буря", "запирать", "безжалостный", "ожесточаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["беспощадный", "ожесточаться", "отвергать", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["безжалостный", "буря", "ожесточаться", "холод"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ожесточаться", "беспощадный", "буря", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["беспощадный", "ожесточаться", "буря", "безжалостный"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["предавать", "ссориться", "раздор", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "раздор", "ненавидеть", "ссориться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["предавать", "презрение", "ссориться", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["страсть", "ненавидеть", "презрение", "предавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["раздор", "предавать", "страсть", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["ненавидеть", "презрение", "изменять", "предавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["предавать", "разрушать", "изменять", "ссориться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["разрушать", "ссориться", "страсть", "ненавидеть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["соперничать", "бороться", "желать", "ревность"], "correct_index": 3}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "ревность", "соперничать", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["ревность", "убивать", "бороться", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["желать", "убивать", "соперничать", "устранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "бороться", "убивать", "ревность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "бороться", "соперничать", "яд"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["яд", "соперничать", "ревность", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «morden»?", "choices": ["интрига", "ревность", "соперничать", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["умирать", "вина", "отравлять", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["вина", "умирать", "отчаяние", "отравлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сожалеть", "отравлять", "вина", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["погибель", "ад", "уничтожать", "вина"], "correct_index": 3}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["сожалеть", "уничтожать", "вина", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["вина", "погибель", "умирать", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["вина", "сожалеть", "отчаяние", "отравлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["отчаяние", "ад", "отравлять", "вина"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "лицемерить", "ложь", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["ложь", "лицемерить", "клясться", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["состояние", "обманывать", "льстить", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["лицемерить", "клясться", "наследство", "состояние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["лицемерить", "клясться", "жадность", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["жадность", "наследство", "обманывать", "ложь"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["льстить", "лицемерить", "наследство", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["состояние", "клясться", "наследство", "жадность"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "приказывать", "править", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["власть", "править", "приказывать", "трон"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["приказывать", "завоёвывать", "господство", "управлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "править", "власть", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["управлять", "господство", "приказывать", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["трон", "господство", "завоёвывать", "подчинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["приказывать", "власть", "управлять", "подчинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["приказывать", "завоёвывать", "власть", "подчинять"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["месть", "жестокий", "унижать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["месть", "изгонять", "жестокий", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "изгонять", "месть", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["отказывать", "унижать", "изгонять", "жестокий"], "correct_index": 2}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["мучить", "унижать", "жестокий", "презирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["отказывать", "жестокий", "изгонять", "презирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["жестокий", "изгонять", "мучить", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["презирать", "ограничивать", "изгонять", "мучить"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "запирать", "отвергать", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "отвергать", "безжалостный", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["буря", "безжалостный", "отвергать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["ожесточаться", "отвергать", "беспощадный", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["ожесточаться", "запирать", "холод", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["запирать", "холод", "беспощадный", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["ожесточаться", "беспощадный", "отвергать", "безжалостный"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["ссориться", "предавать", "ненавидеть", "раздор"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["раздор", "предавать", "ссориться", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["ссориться", "разрушать", "раздор", "презрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["раздор", "разрушать", "ненавидеть", "страсть"], "correct_index": 2}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["ненавидеть", "страсть", "разрушать", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["раздор", "предавать", "презрение", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["ненавидеть", "разрушать", "страсть", "ссориться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["ссориться", "изменять", "страсть", "ненавидеть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["соперничать", "ревность", "желать", "бороться"], "correct_index": 1}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "соперничать", "желать", "ревность"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["устранять", "бороться", "яд", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["устранять", "убивать", "ревность", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["убивать", "интрига", "ревность", "устранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["яд", "интрига", "соперничать", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["соперничать", "устранять", "желать", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «morden»?", "choices": ["убивать", "желать", "устранять", "бороться"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отчаяние", "умирать", "вина", "отравлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отравлять", "отчаяние", "вина", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сожалеть", "умирать", "ад", "уничтожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["ад", "отчаяние", "вина", "погибель"], "correct_index": 2}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["сожалеть", "ад", "уничтожать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["умирать", "погибель", "уничтожать", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "погибель", "вина", "ад"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["умирать", "ад", "погибель", "отравлять"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -666,13 +666,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -684,38 +684,6 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
@@ -726,17 +694,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -746,43 +746,43 @@
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
@@ -805,21 +805,21 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
                             
@@ -829,13 +829,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
                             
@@ -845,24 +877,40 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
@@ -877,54 +925,6 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                 
                 <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
             </div>
@@ -932,17 +932,17 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -952,9 +952,9 @@
                         <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
@@ -964,65 +964,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,13 +1032,13 @@
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1052,9 +1052,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1071,9 +1071,9 @@
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
@@ -1083,33 +1083,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1119,11 +1119,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
@@ -1131,47 +1131,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
@@ -1186,47 +1186,15 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
                             
@@ -1234,17 +1202,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1254,11 +1254,11 @@
                         <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                             
@@ -1266,17 +1266,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
                             
@@ -1302,9 +1302,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
                             
@@ -1321,13 +1321,29 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
@@ -1337,31 +1353,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
@@ -1369,15 +1369,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                             
@@ -1385,33 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,11 +1421,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
@@ -1433,17 +1433,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">устранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1456,31 +1456,15 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
@@ -1488,13 +1472,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
@@ -1504,31 +1488,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
@@ -1540,29 +1540,29 @@
                         <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1572,13 +1572,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1600,6 +1600,166 @@
     "throne": {
         "title": "Лесть и обман",
         "description": "Акт I: Фальшивая любовь",
+        "vocabulary": [
+            {
+                "german": "die Lüge",
+                "russian": "ложь",
+                "sentence": "Goneril steht unter dem glühenden Kronleuchter des Thronsaals. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig.",
+                "sentence_translation": "Гонерилья стоит под пылающей люстрой тронного зала. Каждой клеткой тела я обещаю: слово «ложь» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ЛЮ-ге]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Goneril steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Lüge“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "ложь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schwören",
+                "russian": "клясться",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch. Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen.",
+                "sentence_translation": "У развернутой карты королевства Гонерилья склоняется над тяжёлым столом Лира. Я шепчу стражам судьбы: слово «клясться» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ШВЁ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Goneril über Lears schweren Tisch.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „schwören“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "клясться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Erbe",
+                "russian": "наследство",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken. Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig.",
+                "sentence_translation": "Перед каменными статуями предков Гонерилья сцепляет руки за спиной. Каждой клеткой тела я обещаю: слово «наследство» останется живым.",
+                "russian_hint": "",
+                "transcription": "[дас ЕР-бе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Goneril die Hände hinter dem Rücken.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „das Erbe“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "наследство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "heucheln",
+                "russian": "лицемерить",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden. Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Между шепчущимися придворными Гонерилья скользит по холодному мраморному полу. Я обнимаю слово «лицемерить», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ХОЙ-хельн]",
+                "themes": [
+                    "Erbe",
+                    "Heuchelei",
+                    "Lüge"
+                ],
+                "sentence_parts": [
+                    "Zwischen flüsternden Höflingen gleitet Goneril über den kalten Marmorboden.",
+                    "Ich umarme das Wort „heucheln“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "лицемерить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gier",
+                "russian": "жадность",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs. Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На краю пурпурного ковра Гонерилья ждёт знака от короля. Я черчу слово «жадность» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди ГИР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand des purpurnen Teppichs wartet Goneril auf ein Zeichen des Königs.",
+                    "Ich zeichne das Wort „die Gier“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "жадность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "täuschen",
+                "russian": "обманывать",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick. Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig.",
+                "sentence_translation": "Под развевающимися штандартами сестёр Гонерилья на миг опускает взгляд. Каждой клеткой тела я обещаю: слово «обманывать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ТОЙ-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Goneril kurz den Blick.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „täuschen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "обманывать",
+                    "betrügen — тоже «обманывать»",
+                    "hintergehen — тоже «обманывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schmeicheln",
+                "russian": "льстить",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes. Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "За позолоченной балюстрадой Гонерилья наблюдает за напряжёнными лицами двора. Эхо слова «льстить» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ШМАЙ-хельн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Goneril das gespannte Antlitz des Hofes.",
+                    "Das Echo des Wortes „schmeicheln“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "льстить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Vermögen",
+                "russian": "состояние",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme. Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В отблесках открытых жаровен Гонерилья медленно поднимает голос. Я обнимаю слово «состояние», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дас фер-МЁ-ген]",
+                "themes": [
+                    "Erbe",
+                    "Heuchelei",
+                    "Lüge"
+                ],
+                "sentence_parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Goneril langsam die Stimme.",
+                    "Ich umarme das Wort „das Vermögen“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "состояние"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Lüge",
@@ -1811,10 +1971,10 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "клясться",
+                    "наследство",
                     "лицемерить",
                     "ложь",
-                    "наследство"
+                    "клясться"
                 ],
                 "correctIndex": 2
             },
@@ -1822,9 +1982,9 @@
                 "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
                     "ложь",
-                    "наследство",
+                    "лицемерить",
                     "клясться",
-                    "лицемерить"
+                    "наследство"
                 ],
                 "correctIndex": 2
             },
@@ -1832,61 +1992,61 @@
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
                     "состояние",
-                    "наследство",
                     "обманывать",
-                    "жадность"
+                    "льстить",
+                    "наследство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «heucheln»?",
                 "choices": [
-                    "состояние",
                     "лицемерить",
                     "клясться",
-                    "наследство"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
-                    "жадность",
-                    "лицемерить",
-                    "клясться",
-                    "льстить"
+                    "наследство",
+                    "состояние"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "лицемерить",
+                    "клясться",
+                    "жадность",
+                    "наследство"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "ложь",
                     "жадность",
+                    "наследство",
                     "обманывать",
-                    "состояние"
+                    "ложь"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "клясться",
                     "льстить",
-                    "ложь",
-                    "наследство"
+                    "лицемерить",
+                    "наследство",
+                    "жадность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
-                    "льстить",
-                    "обманывать",
                     "состояние",
+                    "клясться",
+                    "наследство",
                     "жадность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -1976,6 +2136,170 @@
     "goneril": {
         "title": "Захват власти",
         "description": "Акт I: Раздел королевства",
+        "vocabulary": [
+            {
+                "german": "die Macht",
+                "russian": "власть",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten. Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В гулком проёме ворот замка Гонерильи Гонерилья замирает среди нагруженных ящиков. Я обнимаю слово «власть», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ди МАХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Goneril zwischen gepackten Kisten.",
+                    "Ich umarme das Wort „die Macht“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "власть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "herrschen",
+                "russian": "править",
+                "sentence": "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir.",
+                "sentence_translation": "На продуваемой ветром лестнице Гонерилья смотрит вниз на молчаливый двор. Буря за окнами усиливает клятву: слово «править» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ХЕР-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der windigen Freitreppe blickt Goneril zum schweigenden Hof hinunter.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „herrschen“ gehört mir."
+                ],
+                "synonyms": [
+                    "править",
+                    "regieren — тоже «править»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "befehlen",
+                "russian": "приказывать",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger. Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Среди оставленных слуг Гонерилья плотнее запахивает дорожный плащ. Эхо слова «приказывать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[бе-ФЕ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Goneril den Reisemantel enger.",
+                    "Das Echo des Wortes „befehlen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "приказывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Thron",
+                "russian": "трон",
+                "sentence": "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne. Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У тёмного конюшенного ряда Гонерилья гладит гриву нервного коня. Моё дыхание рисует слово «трон» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ТРОН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Pferdestall streicht Goneril einem nervösen Tier über die Mähne.",
+                    "Mein Atem zeichnet das Wort „der Thron“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "трон"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erobern",
+                "russian": "завоёвывать",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor. Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig.",
+                "sentence_translation": "Перед скрипящим подъёмным мостом Гонерилья в последний раз касается родной двери. Каждой клеткой тела я обещаю: слово «завоёвывать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ер-О-берн]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem knarrenden Fallgatter tastet Goneril ein letztes Mal nach dem Haustor.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „erobern“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "завоёвывать",
+                    "завоевывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Herrschaft",
+                "russian": "господство",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir.",
+                "sentence_translation": "Среди разбросанных свитков Гонерилья вертит кольцо на пальце. Буря за окнами усиливает клятву: слово «господство» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди ХЕР-шафт]",
+                "themes": [
+                    "Herrschaft",
+                    "Macht",
+                    "Neuanfang",
+                    "Weisheit",
+                    "befehlen",
+                    "herrschen"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Goneril den Ring an der Hand.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Herrschaft“ gehört mir."
+                ],
+                "synonyms": [
+                    "правление",
+                    "господство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "regieren",
+                "russian": "управлять",
+                "sentence": "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen. Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten.",
+                "sentence_translation": "У пустого банкетного стола Гонерилья пересчитывает гаснущие свечи. Твёрдым голосом я клянусь себе: слово «управлять» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ре-ГИ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am leeren Bankettisch zählt Goneril die verlöschenden Kerzen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „regieren“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "править",
+                    "herrschen — тоже «править»",
+                    "управлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unterwerfen",
+                "russian": "подчинять",
+                "sentence": "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig.",
+                "sentence_translation": "Между молчаливыми стражниками Гонерилья выходит на холодный двор. Каждой клеткой тела я обещаю: слово «подчинять» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ун-тер-ВЕР-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen schweigenden Wachen geht Goneril auf den kalten Hof hinaus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „unterwerfen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "подчинять"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Macht",
@@ -2196,80 +2520,80 @@
                 "choices": [
                     "власть",
                     "приказывать",
-                    "трон",
-                    "править"
+                    "править",
+                    "трон"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "править",
                     "власть",
+                    "править",
                     "приказывать",
                     "трон"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «befehlen»?",
-                "choices": [
-                    "управлять",
-                    "власть",
-                    "приказывать",
-                    "завоёвывать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Thron»?",
-                "choices": [
-                    "подчинять",
-                    "трон",
-                    "приказывать",
-                    "завоёвывать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «erobern»?",
+                "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
                     "приказывать",
                     "завоёвывать",
+                    "господство",
+                    "управлять"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Thron»?",
+                "choices": [
+                    "трон",
+                    "править",
                     "власть",
+                    "завоёвывать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erobern»?",
+                "choices": [
+                    "управлять",
+                    "господство",
+                    "приказывать",
+                    "завоёвывать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Herrschaft»?",
+                "choices": [
+                    "трон",
+                    "господство",
+                    "завоёвывать",
                     "подчинять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Herrschaft»?",
-                "choices": [
-                    "подчинять",
-                    "приказывать",
-                    "господство",
-                    "управлять"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "подчинять",
                     "приказывать",
+                    "власть",
                     "управлять",
-                    "господство"
+                    "подчинять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "подчинять",
-                    "править",
+                    "приказывать",
+                    "завоёвывать",
                     "власть",
-                    "господство"
+                    "подчинять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2359,6 +2683,178 @@
     "regan": {
         "title": "Унижение отца",
         "description": "Акт II: Жестокость к Лиру",
+        "vocabulary": [
+            {
+                "german": "demütigen",
+                "russian": "унижать",
+                "sentence": "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde. Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В продуваемом ветром боковом крыле Гонерилья слушает вой прибрежного ветра. Я вывожу слово «унижать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[де-МЮ-ти-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Im zugigen Seitenflügel lauscht Goneril dem Heulen der Küstenwinde.",
+                    "Ich zeichne das Wort „demütigen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "унижать",
+                    "erniedrigen — тоже «унижать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "grausam",
+                "russian": "жестокий",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir.",
+                "sentence_translation": "Перед дымным камином замка Гонерилья складывает измятый лист. Буря за окнами усиливает клятву: слово «жестокий» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ГРАУ-зам]",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Goneril einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „grausam“ gehört mir."
+                ],
+                "synonyms": [
+                    "жестокий"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rache",
+                "russian": "месть",
+                "sentence": "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab. Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern.",
+                "sentence_translation": "Под выцветшими гобеленами Гонерилья беспокойно меряет шагами зал. Даже если мир распадается, слово «месть» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди РА-хе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter farblosen Wandteppichen schreitet Goneril rastlos auf und ab.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Rache“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "месть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vertreiben",
+                "russian": "изгонять",
+                "sentence": "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof. Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten.",
+                "sentence_translation": "У узкой бойницы Гонерилья считает факелы на дворе. Твёрдым голосом я клянусь себе: слово «изгонять» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[фер-ТРАЙ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "An der schmalen Fensterluke zählt Goneril die Fackeln auf dem Hof.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „vertreiben“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "изгонять",
+                    "verbannen — тоже «изгонять»",
+                    "verstoßen — тоже «изгонять»",
+                    "прогонять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verachten",
+                "russian": "презирать",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften. Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten.",
+                "sentence_translation": "Среди дорожных сундуков послов Гонерилья ищет свежие вести. Твёрдым голосом я клянусь себе: слово «презирать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[фер-АХ-тен]",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Goneril nach frischen Botschaften.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „verachten“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "презирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verweigern",
+                "russian": "отказывать",
+                "sentence": "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur. Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В тихой капелле Гонерилья преклоняет колени перед холодной каменной фигурой. Я черчу слово «отказывать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[фер-ВАЙ-герн]",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Im stillen Kapellenraum kniet Goneril vor der kalten Steinfigur.",
+                    "Ich zeichne das Wort „verweigern“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "отказывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "quälen",
+                "russian": "мучить",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest. Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern.",
+                "sentence_translation": "На балконе, омываемом морскими брызгами, Гонерилья крепко держит фонарь. Даже если мир распадается, слово «мучить» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[КВЕ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Goneril die Laterne fest.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „quälen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "мучить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beschränken",
+                "russian": "ограничивать",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort. Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В тени высоких стен Гонерилья пишет лихорадочный ответ. Я стискиваю слово «ограничивать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[бе-ШРЕН-кен]",
+                "themes": [
+                    "demütigen",
+                    "grausam",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Goneril eine fiebrige Antwort.",
+                    "Ich presse das Wort „beschränken“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "ограничивать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "demütigen",
@@ -2582,18 +3078,18 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
+                    "месть",
                     "жестокий",
                     "унижать",
-                    "изгонять",
-                    "месть"
+                    "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
-                    "изгонять",
                     "месть",
+                    "изгонять",
                     "жестокий",
                     "унижать"
                 ],
@@ -2602,50 +3098,50 @@
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "изгонять",
-                    "месть",
-                    "отказывать",
-                    "мучить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
                     "жестокий",
                     "изгонять",
-                    "унижать",
-                    "отказывать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verachten»?",
-                "choices": [
-                    "ограничивать",
-                    "мучить",
-                    "презирать",
-                    "месть"
+                    "месть",
+                    "ограничивать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verweigern»?",
+                "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
+                    "отказывать",
                     "унижать",
-                    "месть",
+                    "изгонять",
+                    "жестокий"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verachten»?",
+                "choices": [
+                    "мучить",
+                    "унижать",
                     "жестокий",
-                    "отказывать"
+                    "презирать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verweigern»?",
+                "choices": [
+                    "отказывать",
+                    "жестокий",
+                    "изгонять",
+                    "презирать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "унижать",
-                    "презирать",
+                    "жестокий",
+                    "изгонять",
                     "мучить",
-                    "изгонять"
+                    "ограничивать"
                 ],
                 "correctIndex": 2
             },
@@ -2654,8 +3150,8 @@
                 "choices": [
                     "презирать",
                     "ограничивать",
-                    "месть",
-                    "унижать"
+                    "изгонять",
+                    "мучить"
                 ],
                 "correctIndex": 1
             }
@@ -2747,6 +3243,161 @@
     "storm": {
         "title": "Изгнание в бурю",
         "description": "Акт III: Лир в буре",
+        "vocabulary": [
+            {
+                "german": "verstoßen",
+                "russian": "отвергать",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind. Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen.",
+                "sentence_translation": "Посреди хлещущей дождём пустоши Гонерилья упирается в ветер. Как тихая молитва слово «отвергать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[фер-ШТО-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Goneril gegen den Wind.",
+                    "Wie ein stilles Gebet legt sich das Wort „verstoßen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "изгонять",
+                    "verbannen — тоже «изгонять»",
+                    "vertreiben — тоже «изгонять»",
+                    "отвергать",
+                    "abweisen — тоже «отвергать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Sturm",
+                "russian": "буря",
+                "sentence": "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen. Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Под разорванным знаменем Гонерилья прикрывает глаза от молний. Я обнимаю слово «буря», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[дер ШТУРМ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerrissenen Banner schützt Goneril die Augen vor den Blitzen.",
+                    "Ich umarme das Wort „der Sturm“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "буря"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gnadenlos",
+                "russian": "безжалостный",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner. Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У поваленного дерева Гонерилья ищет укрытия от грома. Я держу слово «безжалостный» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ГНА-ден-лос]",
+                "themes": [
+                    "Sturm",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Goneril Deckung vor dem Donner.",
+                    "Ich halte das Wort „gnadenlos“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "безжалостный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verschließen",
+                "russian": "запирать",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm. Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Между пенящимися лужами Гонерилья пробирается через грязь. Я стискиваю слово «запирать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[фер-ШЛИ-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Goneril durch den Schlamm.",
+                    "Ich presse das Wort „verschließen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "запирать",
+                    "einsperren — тоже «запирать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Kälte",
+                "russian": "холод",
+                "sentence": "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an. Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus.",
+                "sentence_translation": "На фоне вспыхивающего неба Гонерилья упрямо поднимает руки. Я глубоко вдыхаю и выпускаю только слово «холод».",
+                "russian_hint": "",
+                "transcription": "[ди КЕЛ-те]",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Vor einem zuckenden Himmel hebt Goneril die Arme trotzig an.",
+                    "Ich atme tief ein und lasse nur das Wort „die Kälte“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "холод"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erbarmungslos",
+                "russian": "беспощадный",
+                "sentence": "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte. Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Под промокшим плащом Гонерилья прижимает дыхание к груди, спасаясь от холода. Я стискиваю слово «беспощадный» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ер-БАР-мунгс-лос]",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Unter dem durchtränkten Umhang presst Goneril den Atem gegen die Kälte.",
+                    "Ich presse das Wort „erbarmungslos“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "беспощадный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verhärten",
+                "russian": "ожесточаться",
+                "sentence": "Am kläglichen Feuerrest wärmt Goneril zitternde Finger. Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus.",
+                "sentence_translation": "У жалких огненных углей Гонерилья греет дрожащие пальцы. Я глубоко вдыхаю и выпускаю только слово «ожесточаться».",
+                "russian_hint": "",
+                "transcription": "[фер-ХЕР-тен]",
+                "themes": [
+                    "Sturm",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Am kläglichen Feuerrest wärmt Goneril zitternde Finger.",
+                    "Ich atme tief ein und lasse nur das Wort „verhärten“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "ожесточаться"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verstoßen",
@@ -2948,8 +3599,8 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "запирать",
                     "буря",
+                    "запирать",
                     "отвергать",
                     "безжалостный"
                 ],
@@ -2958,29 +3609,29 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "запирать",
-                    "безжалостный",
+                    "буря",
                     "отвергать",
-                    "буря"
+                    "безжалостный",
+                    "запирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
                     "буря",
-                    "запирать",
                     "безжалостный",
-                    "ожесточаться"
+                    "отвергать",
+                    "холод"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
-                    "беспощадный",
                     "ожесточаться",
                     "отвергать",
+                    "беспощадный",
                     "запирать"
                 ],
                 "correctIndex": 3
@@ -2988,32 +3639,32 @@
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "безжалостный",
-                    "буря",
                     "ожесточаться",
-                    "холод"
+                    "запирать",
+                    "холод",
+                    "безжалостный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "ожесточаться",
+                    "запирать",
+                    "холод",
                     "беспощадный",
-                    "буря",
-                    "холод"
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
-                    "беспощадный",
                     "ожесточаться",
-                    "буря",
+                    "беспощадный",
+                    "отвергать",
                     "безжалостный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3093,6 +3744,172 @@
     "hut": {
         "title": "Конфликт с мужем",
         "description": "Акт IV: Разлад с Олбани",
+        "vocabulary": [
+            {
+                "german": "streiten",
+                "russian": "ссориться",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze. Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus.",
+                "sentence_translation": "В тёмном шатре полевых лекарей Гонерилья сидит у мерцающей свечи. Я глубоко вдыхаю и выпускаю только слово «ссориться».",
+                "russian_hint": "",
+                "transcription": "[ШТРАЙ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Goneril bei der flackernden Kerze.",
+                    "Ich atme tief ein und lasse nur das Wort „streiten“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "спорить",
+                    "ссориться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verraten",
+                "russian": "предавать",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen. Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus.",
+                "sentence_translation": "Среди помятых доспехов Гонерилья гладит старый герб. Я глубоко вдыхаю и выпускаю только слово «предавать».",
+                "russian_hint": "",
+                "transcription": "[фер-РА-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Goneril über ein altes Wappen.",
+                    "Ich atme tief ein und lasse nur das Wort „verraten“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "предавать",
+                    "выдавать",
+                    "ausliefern — тоже «выдавать»",
+                    "verheiraten — тоже «выдавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Zwietracht",
+                "russian": "раздор",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf. Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "О низкую балку хижины Гонерилья едва не ударяется головой. Я черчу слово «раздор» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди ЦВИ-трахт]",
+                "themes": [
+                    "Zwietracht",
+                    "streiten",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Goneril fast den Kopf.",
+                    "Ich zeichne das Wort „die Zwietracht“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "раздор"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hassen",
+                "russian": "ненавидеть",
+                "sentence": "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht. Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Рядом со спящим стражем Гонерилья шепчет в тяжёлую ночь. Я черчу слово «ненавидеть» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ХА-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schlafenden Wache flüstert Goneril in die schwere Nacht.",
+                    "Ich zeichne das Wort „hassen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "ненавидеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "betrügen",
+                "russian": "изменять",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten. Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед грубой походной койкой Гонерилья разглядывает шрамы прошлых битв. Я черчу слово «изменять» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[бе-ТРЮ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem einfachen Feldbett betrachtet Goneril die Narben vergangener Schlachten.",
+                    "Ich zeichne das Wort „betrügen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "изменять",
+                    "verstellen — тоже «изменять»",
+                    "обманывать",
+                    "hintergehen — тоже «обманывать»",
+                    "täuschen — тоже «обманывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verachtung",
+                "russian": "презрение",
+                "sentence": "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig.",
+                "sentence_translation": "В запахе влажной соломы Гонерилья откладывает плащ в сторону. Каждой клеткой тела я обещаю: слово «презрение» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди фер-АХ-тунг]",
+                "themes": [
+                    "Zwietracht",
+                    "streiten",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Im Geruch von feuchtem Stroh legt Goneril den Mantel zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verachtung“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "презрение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zerstören",
+                "russian": "разрушать",
+                "sentence": "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe. Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На шатком деревянном столе Гонерилья раскладывает зачитанные письма. Я стискиваю слово «разрушать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[цер-ШТЁ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem wackligen Holztisch ordnet Goneril zerlesene Briefe.",
+                    "Ich presse das Wort „zerstören“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "разрушать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Leidenschaft",
+                "russian": "страсть",
+                "sentence": "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig.",
+                "sentence_translation": "У входа в хижину Гонерилья высматривает знакомую тень. Каждой клеткой тела я обещаю: слово «страсть» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ЛАЙ-ден-шафт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Eingang der Hütte späht Goneril nach einem vertrauten Schatten.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Leidenschaft“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "страсть"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "streiten",
@@ -3304,49 +4121,49 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
+                    "ссориться",
+                    "предавать",
+                    "ненавидеть",
+                    "раздор"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verraten»?",
+                "choices": [
+                    "раздор",
                     "предавать",
                     "ссориться",
-                    "раздор",
                     "ненавидеть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verraten»?",
-                "choices": [
-                    "предавать",
-                    "раздор",
-                    "ненавидеть",
-                    "ссориться"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
-                    "предавать",
-                    "презрение",
                     "ссориться",
-                    "раздор"
+                    "разрушать",
+                    "раздор",
+                    "презрение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "страсть",
+                    "раздор",
+                    "разрушать",
                     "ненавидеть",
-                    "презрение",
-                    "предавать"
+                    "страсть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
-                    "раздор",
-                    "предавать",
+                    "ненавидеть",
                     "страсть",
+                    "разрушать",
                     "изменять"
                 ],
                 "correctIndex": 3
@@ -3354,19 +4171,19 @@
             {
                 "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
-                    "ненавидеть",
+                    "раздор",
+                    "предавать",
                     "презрение",
-                    "изменять",
-                    "предавать"
+                    "изменять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
-                    "предавать",
+                    "ненавидеть",
                     "разрушать",
-                    "изменять",
+                    "страсть",
                     "ссориться"
                 ],
                 "correctIndex": 1
@@ -3374,8 +4191,8 @@
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "разрушать",
                     "ссориться",
+                    "изменять",
                     "страсть",
                     "ненавидеть"
                 ],
@@ -3469,6 +4286,173 @@
     "dover": {
         "title": "Соперничество",
         "description": "Акт V: Борьба за Эдмунда",
+        "vocabulary": [
+            {
+                "german": "die Eifersucht",
+                "russian": "ревность",
+                "sentence": "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal. Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen.",
+                "sentence_translation": "На белых скалах Дувра Гонерилья смотрит в вздыбленный пролив. Как тихая молитва слово «ревность» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди АЙ-фер-зухт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf den weißen Klippen von Dover blickt Goneril in den aufgewühlten Kanal.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Eifersucht“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "ревность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "rivalisieren",
+                "russian": "соперничать",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Goneril den Helm. Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen.",
+                "sentence_translation": "Среди хлопающих штандартов Гонерилья поправляет шлем. Как тихая молитва слово «соперничать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ри-ва-ли-ЗИ-рен]",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
+                "sentence_parts": [
+                    "Zwischen flatternden Feldzeichen richtet Goneril den Helm.",
+                    "Wie ein stilles Gebet legt sich das Wort „rivalisieren“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "соперничать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "kämpfen",
+                "russian": "бороться",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand. Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern.",
+                "sentence_translation": "У французского костра Гонерилья рисует в песке путь марша. Даже если мир распадается, слово «бороться» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[КЕМП-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Goneril Marschrouten in den Sand.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „kämpfen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "бороться",
+                    "bekämpfen — тоже «бороться»",
+                    "сражаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begehren",
+                "russian": "желать",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel. Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten.",
+                "sentence_translation": "У перевязанных провиантных ящиков Гонерилья проверяет печати. Твёрдым голосом я клянусь себе: слово «желать» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЕ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Goneril das Siegel.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „begehren“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "вожделеть",
+                    "желать",
+                    "verlangen — тоже «желать»",
+                    "wünschen — тоже «желать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beseitigen",
+                "russian": "устранять",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer. Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед шёлковым шатром полководцев Гонерилья слушает глухой шум моря. Я черчу слово «устранять» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[бе-ЗАЙ-ти-ген]",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
+                "sentence_parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Goneril dem dumpfen Meer.",
+                    "Ich zeichne das Wort „beseitigen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "устранять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Gift",
+                "russian": "яд",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts. Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На песчаном плацу Гонерилья отрабатывает выхват меча. Я вывожу слово «яд» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[дас ГИФТ]",
+                "themes": [
+                    "Eifersucht",
+                    "kämpfen",
+                    "rivalisieren"
+                ],
+                "sentence_parts": [
+                    "Auf dem sandigen Trainingsplatz übt Goneril das Ziehen des Schwerts.",
+                    "Ich zeichne das Wort „das Gift“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "яд"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Intrige",
+                "russian": "интрига",
+                "sentence": "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen.",
+                "sentence_translation": "Под гул барабанов Гонерилья поднимает знамя надежды. Я шепчу стражам судьбы: слово «интрига» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ин-ТРИ-ге]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen pochenden Trommeln hebt Goneril das Banner der Hoffnung.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Intrige“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "интрига",
+                    "die Affäre — тоже «интрига»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "morden",
+                "russian": "убивать",
+                "sentence": "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz. Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen.",
+                "sentence_translation": "В утреннем тумане побережья Гонерилья кладёт ладонь на бьющееся сердце. Как тихая молитва слово «убивать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[МОР-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Morgennebel der Küste legt Goneril die Hand auf das pochende Herz.",
+                    "Wie ein stilles Gebet legt sich das Wort „morden“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "убивать",
+                    "töten — тоже «убивать»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Eifersucht",
@@ -3684,68 +4668,68 @@
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
                     "соперничать",
-                    "бороться",
+                    "ревность",
                     "желать",
-                    "ревность"
+                    "бороться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
                     "бороться",
-                    "ревность",
                     "соперничать",
-                    "желать"
+                    "желать",
+                    "ревность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "ревность",
-                    "убивать",
+                    "устранять",
                     "бороться",
+                    "яд",
                     "желать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "желать",
-                    "убивать",
-                    "соперничать",
-                    "устранять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «beseitigen»?",
-                "choices": [
                     "устранять",
-                    "бороться",
                     "убивать",
-                    "ревность"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Gift»?",
-                "choices": [
-                    "устранять",
-                    "бороться",
-                    "соперничать",
-                    "яд"
+                    "ревность",
+                    "желать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Intrige»?",
+                "question": "Что означает немецкое слово «beseitigen»?",
+                "choices": [
+                    "убивать",
+                    "интрига",
+                    "ревность",
+                    "устранять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
                     "яд",
+                    "интрига",
                     "соперничать",
-                    "ревность",
+                    "бороться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Intrige»?",
+                "choices": [
+                    "соперничать",
+                    "устранять",
+                    "желать",
                     "интрига"
                 ],
                 "correctIndex": 3
@@ -3753,12 +4737,12 @@
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "интрига",
-                    "ревность",
-                    "соперничать",
-                    "убивать"
+                    "убивать",
+                    "желать",
+                    "устранять",
+                    "бороться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3848,6 +4832,162 @@
     "prison": {
         "title": "Самоуничтожение",
         "description": "Акт V: Отравление и смерть",
+        "vocabulary": [
+            {
+                "german": "vergiften",
+                "russian": "отравлять",
+                "sentence": "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein. Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В сыром подземелье Гонерилья опирается на сочащийся камень. Эхо слова «отравлять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[фер-ГИФ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im feuchten Kerker stützt Goneril sich an den tropfenden Stein.",
+                    "Das Echo des Wortes „vergiften“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "отравлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verzweiflung",
+                "russian": "отчаяние",
+                "sentence": "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette. Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Под мутным фонарём Гонерилья пересчитывает железные кольца цепи. Эхо слова «отчаяние» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ЦВАЙ-флунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter der trüben Laterne zählt Goneril die eisernen Ringe der Kette.",
+                    "Das Echo des Wortes „die Verzweiflung“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "отчаяние"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sterben",
+                "russian": "умирать",
+                "sentence": "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen. Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "У тяжёлой двери Гонерилья прислушивается к далёким рыданиям. Я черчу слово «умирать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ШТЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Neben der schweren Holztür horcht Goneril auf entferntes Schluchzen.",
+                    "Ich zeichne das Wort „sterben“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "умирать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Schuld",
+                "russian": "вина",
+                "sentence": "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern. Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На холодной каменной скамье Гонерилья плотнее кутается в плащ. Я держу слово «вина» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ШУЛЬД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Steinbank zieht Goneril den Mantel enger um die Schultern.",
+                    "Ich halte das Wort „die Schuld“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "вина"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vernichten",
+                "russian": "уничтожать",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir.",
+                "sentence_translation": "Между тенями решёток Гонерилья поднимает лицо к свету. Буря за окнами усиливает клятву: слово «уничтожать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[фер-НИХ-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Goneril das Gesicht zum Licht.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „vernichten“ gehört mir."
+                ],
+                "synonyms": [
+                    "уничтожать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Verderben",
+                "russian": "погибель",
+                "sentence": "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen. Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "У ржавого ведра с водой Гонерилья на мгновение видит отражение глаз. Моё дыхание рисует слово «погибель» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дас фер-ДЕР-бен]",
+                "themes": [
+                    "Verzweiflung",
+                    "sterben",
+                    "vergiften"
+                ],
+                "sentence_parts": [
+                    "Am rostigen Wassereimer spiegelt Goneril kurz die eigenen Augen.",
+                    "Mein Atem zeichnet das Wort „das Verderben“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "погибель"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bereuen",
+                "russian": "сожалеть",
+                "sentence": "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen.",
+                "sentence_translation": "В глухом эхе шагов Гонерилья отсчитывает ритм часовых. Я шепчу стражам судьбы: слово «сожалеть» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[бе-РОЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dumpfen Hall der Schritte zählt Goneril den Rhythmus der Wachen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „bereuen“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "сожалеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hölle",
+                "russian": "ад",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub. Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern.",
+                "sentence_translation": "Перед заколоченным окном Гонерилья чертит круги в пыли. Даже если мир распадается, слово «ад» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ХЁ-ле]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem verriegelten Fenster zeichnet Goneril Kreise in den Staub.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Hölle“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "ад"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "vergiften",
@@ -4065,80 +5205,80 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
+                    "отчаяние",
                     "умирать",
                     "вина",
-                    "отравлять",
-                    "отчаяние"
+                    "отравлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "вина",
-                    "умирать",
-                    "отчаяние",
-                    "отравлять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "сожалеть",
                     "отравлять",
-                    "вина",
-                    "умирать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Schuld»?",
-                "choices": [
-                    "погибель",
-                    "ад",
-                    "уничтожать",
-                    "вина"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «vernichten»?",
-                "choices": [
-                    "сожалеть",
-                    "уничтожать",
+                    "отчаяние",
                     "вина",
                     "умирать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "сожалеть",
+                    "умирать",
+                    "ад",
+                    "уничтожать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Schuld»?",
+                "choices": [
+                    "ад",
+                    "отчаяние",
+                    "вина",
+                    "погибель"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «vernichten»?",
+                "choices": [
+                    "сожалеть",
+                    "ад",
+                    "уничтожать",
+                    "умирать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «das Verderben»?",
                 "choices": [
-                    "вина",
-                    "погибель",
                     "умирать",
-                    "ад"
+                    "погибель",
+                    "уничтожать",
+                    "вина"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "вина",
                     "сожалеть",
-                    "отчаяние",
-                    "отравлять"
+                    "погибель",
+                    "вина",
+                    "ад"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "отчаяние",
+                    "умирать",
                     "ад",
-                    "отравлять",
-                    "вина"
+                    "погибель",
+                    "отравлять"
                 ],
                 "correctIndex": 1
             }
@@ -4233,6 +5373,9 @@ const characterId = "goneril";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["мужество", "верность", "защищать", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "мужество", "верность", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["защищать", "предупреждать", "возражать", "верность"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["слуга", "возражать", "защищать", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["искренний", "возражать", "справедливый", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["справедливый", "мужество", "слуга", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["мужество", "верность", "предупреждать", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["искренний", "возражать", "справедливый", "защищать"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["гнев", "несправедливость", "изгнание", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнание", "гнев", "изгнанный", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнание", "гнев", "изгнанный", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["наказание", "гнев", "изгнанный", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["несправедливость", "изгнанный", "прощание", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["прощание", "изгнание", "наказание", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "изгнанный", "несправедливость", "прощание"], "correct_index": 0}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["переодевание", "неузнанный", "притворяться", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "переодевание", "хитрость", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "изменять", "притворяться", "борода"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["изменять", "хитрость", "переодевание", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["неузнанный", "хитрость", "борода", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["хитрость", "верный", "неузнанный", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["хитрость", "неузнанный", "изменять", "наниматься"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["борода", "неузнанный", "изменять", "верный"], "correct_index": 3}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "охранять", "опасность", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["защита", "охранять", "служба", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["служба", "стража", "защита", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["сражаться", "охранять", "служба", "стража"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["опасность", "защита", "советовать", "сражаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "сражаться", "защита", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "служба", "сражаться", "стража"], "correct_index": 3}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["сковывать", "стойкость", "наказание", "унижение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "сковывать", "унижение", "стойкость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["унижение", "сковывать", "выдерживать", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["унижение", "сковывать", "наказание", "выдерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["стойкость", "терпеть", "выдерживать", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["стойкость", "колодка", "терпеть", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["позор", "стойкость", "унижение", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["унижение", "выдерживать", "позор", "стойкость"], "correct_index": 2}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "сопровождать", "поддержка", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["сопровождать", "поддержка", "утешать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["выдерживать", "поддержка", "холод", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["поддержка", "утешать", "сопровождать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["утешать", "буря", "выдерживать", "убежище"], "correct_index": 3}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["выдерживать", "поддержка", "сопровождать", "убежище"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["холод", "убежище", "сопровождать", "выдерживать"], "correct_index": 0}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "прощание", "плакать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "смерть", "прощание", "плакать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["скорбь", "вечный", "следовать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["смерть", "следовать", "плакать", "истощение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["плакать", "истощение", "скорбь", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["скорбь", "прощание", "сдаваться", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощание", "скорбь", "плакать", "следовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["вечный", "прощание", "следовать", "сдаваться"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "защищать", "возражать", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "верность", "защищать", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["верность", "справедливый", "возражать", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["искренний", "мужество", "предупреждать", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["слуга", "справедливый", "искренний", "предупреждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["предупреждать", "слуга", "справедливый", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "мужество", "слуга", "возражать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["возражать", "справедливый", "мужество", "защищать"], "correct_index": 1}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["гнев", "несправедливость", "изгнанный", "изгнание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнание", "несправедливость", "гнев", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнанный", "возвращаться", "прощание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнанный", "возвращаться", "гнев", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["изгнанный", "прощание", "возвращаться", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "изгнанный", "наказание", "изгнание"], "correct_index": 2}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["изгнание", "прощание", "наказание", "возвращаться"], "correct_index": 3}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "притворяться", "неузнанный", "переодевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["переодевание", "хитрость", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["борода", "неузнанный", "хитрость", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["борода", "изменять", "притворяться", "наниматься"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["хитрость", "переодевание", "изменять", "верный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["притворяться", "борода", "изменять", "переодевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["переодевание", "хитрость", "наниматься", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["наниматься", "изменять", "хитрость", "верный"], "correct_index": 3}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["защита", "охранять", "опасность", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["защита", "опасность", "служба", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["защита", "опасность", "служба", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["сражаться", "служба", "охранять", "советовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "защита", "советовать", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "опасность", "сражаться", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["защита", "стража", "опасность", "охранять"], "correct_index": 1}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "стойкость", "унижение", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["наказание", "стойкость", "сковывать", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["терпеть", "сковывать", "позор", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["сковывать", "колодка", "стойкость", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "наказание", "позор", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["колодка", "сковывать", "терпеть", "стойкость"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["выдерживать", "колодка", "стойкость", "сковывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["позор", "выдерживать", "сковывать", "стойкость"], "correct_index": 0}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["поддержка", "сопровождать", "буря", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["сопровождать", "буря", "утешать", "поддержка"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["холод", "выдерживать", "сопровождать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["буря", "убежище", "утешать", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["буря", "утешать", "убежище", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["сопровождать", "выдерживать", "буря", "убежище"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["выдерживать", "холод", "убежище", "утешать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "прощание", "плакать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "плакать", "смерть", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "сдаваться", "прощание", "плакать"], "correct_index": 0}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["плакать", "истощение", "следовать", "скорбь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["следовать", "смерть", "скорбь", "истощение"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["плакать", "вечный", "сдаваться", "скорбь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["следовать", "вечный", "скорбь", "плакать"], "correct_index": 2}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["следовать", "истощение", "прощание", "сдаваться"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,33 +662,33 @@
             <div class="quiz-phase-container active" data-phase="loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -698,73 +698,25 @@
                         <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
                             
@@ -774,15 +726,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
@@ -797,7 +797,7 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
@@ -805,7 +805,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                             
@@ -813,65 +829,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -881,29 +881,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,31 +916,31 @@
             <div class="quiz-phase-container" data-phase="disguise">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
@@ -948,81 +948,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,11 +1032,11 @@
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
@@ -1073,59 +1073,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1137,27 +1137,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,33 +1170,33 @@
             <div class="quiz-phase-container" data-phase="stocks">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1206,11 +1206,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                             
@@ -1218,47 +1218,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
                             
@@ -1266,31 +1250,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                             
@@ -1305,15 +1305,15 @@
             <div class="quiz-phase-container" data-phase="storm_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
@@ -1321,97 +1321,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1440,13 +1440,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
@@ -1456,49 +1472,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1508,43 +1508,43 @@
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
@@ -1568,6 +1568,169 @@
     "loyalty": {
         "title": "Верность королю",
         "description": "Акт I: Защищает Корделию в тронном зале",
+        "vocabulary": [
+            {
+                "german": "die Treue",
+                "russian": "верность",
+                "sentence": "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron. Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Посреди суматохи тронной церемонии Кент выходит к королевскому трону. Я вывожу слово «верность» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди ТРОЙ-е]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mitten im Tumult der Thronfeier tritt Kent vor den Königsthron.",
+                    "Ich zeichne das Wort „die Treue“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "верность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Mut",
+                "russian": "мужество",
+                "sentence": "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter. Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Между обнажёнными мечами Кент встаёт перед младшей дочерью. Я держу слово «мужество» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер МУТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen scharfgezogenen Schwertern stellt sich Kent vor die jüngste Tochter.",
+                    "Ich halte das Wort „der Mut“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "мужество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "widersprechen",
+                "russian": "возражать",
+                "sentence": "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer. Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Перед изумлёнными рыцарями Кент срывает герб с нагрудника. Я стискиваю слово «возражать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ВИ-дер-шпре-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der erstaunten Ritterschar reißt Kent sein Wappen vom Brustpanzer.",
+                    "Ich presse das Wort „widersprechen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "возражать",
+                    "противоречить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verteidigen",
+                "russian": "защищать",
+                "sentence": "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer. Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen.",
+                "sentence_translation": "Под строгими взглядами двора Кент бьёт кулаком по перилам. Я шепчу стражам судьбы: слово «защищать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[фер-ТАЙ-ди-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter den strengen Blicken des Hofes schlägt Kent die Faust auf das Geländer.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „verteidigen“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "защищать",
+                    "beschützen — тоже «защищать»",
+                    "schützen — тоже «защищать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufrichtig",
+                "russian": "искренний",
+                "sentence": "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf. Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У посоха Лира Кент встаёт на колено и упрямо поднимает голову. Эхо слова «искренний» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[АУФ-рих-тиг]",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Neben Lears Stab kniet Kent und hebt unbeirrbar den Kopf.",
+                    "Das Echo des Wortes „aufrichtig“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "искренний"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Diener",
+                "russian": "слуга",
+                "sentence": "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig.",
+                "sentence_translation": "На ступенях ведущих к трону Кент защитно разводит руки. Каждой клеткой тела я обещаю: слово «слуга» останется живым.",
+                "russian_hint": "",
+                "transcription": "[дер ДИ-нер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf den Stufen zur Thronrampe breitet Kent schützend die Arme aus.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Diener“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "слуга"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "warnen",
+                "russian": "предупреждать",
+                "sentence": "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir.",
+                "sentence_translation": "Среди придворных фанфар Кент выкрикивает предупреждение против шёпота двора. Буря за окнами усиливает клятву: слово «предупреждать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ВАР-нен]",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Zwischen höfischen Fanfaren ruft Kent seine Warnung gegen das Hofgeflüster.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „warnen“ gehört mir."
+                ],
+                "synonyms": [
+                    "предупреждать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "gerecht",
+                "russian": "справедливый",
+                "sentence": "Im Schatten des Königsbanners legt Kent die Hand auf das Herz. Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В тени королевского знамени Кент кладёт руку на сердце. Я стискиваю слово «справедливый» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ге-РЕХТ]",
+                "themes": [
+                    "Mut",
+                    "Treue",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Im Schatten des Königsbanners legt Kent die Hand auf das Herz.",
+                    "Ich presse das Wort „gerecht“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "справедливый"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Treue",
@@ -1780,82 +1943,82 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "мужество",
                     "верность",
                     "защищать",
-                    "возражать"
+                    "возражать",
+                    "мужество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
                     "возражать",
-                    "мужество",
                     "верность",
-                    "защищать"
+                    "защищать",
+                    "мужество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
-                    "защищать",
-                    "предупреждать",
+                    "верность",
+                    "справедливый",
                     "возражать",
-                    "верность"
+                    "слуга"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "слуга",
-                    "возражать",
-                    "защищать",
-                    "справедливый"
+                    "искренний",
+                    "мужество",
+                    "предупреждать",
+                    "защищать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "искренний",
-                    "возражать",
+                    "слуга",
                     "справедливый",
-                    "защищать"
+                    "искренний",
+                    "предупреждать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "справедливый",
-                    "мужество",
+                    "предупреждать",
                     "слуга",
-                    "защищать"
+                    "справедливый",
+                    "возражать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «warnen»?",
                 "choices": [
-                    "мужество",
-                    "верность",
                     "предупреждать",
-                    "защищать"
+                    "мужество",
+                    "слуга",
+                    "возражать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
-                    "искренний",
                     "возражать",
                     "справедливый",
+                    "мужество",
                     "защищать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -1945,6 +2108,165 @@
     "banishment": {
         "title": "Изгнание",
         "description": "Акт I: Изгнан за правду",
+        "vocabulary": [
+            {
+                "german": "die Verbannung",
+                "russian": "изгнание",
+                "sentence": "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung. Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На холодных ступенях двора Кент слышит приговор об изгнании. Я черчу слово «изгнание» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди фер-БА-нунг]",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn"
+                ],
+                "sentence_parts": [
+                    "Auf den kalten Stufen des Hofes hört Kent das Urteil der Verbannung.",
+                    "Ich zeichne das Wort „die Verbannung“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "изгнание",
+                    "das Exil — тоже «изгнание»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ungerechtigkeit",
+                "russian": "несправедливость",
+                "sentence": "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand. Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen.",
+                "sentence_translation": "Среди расходящихся солдат Кент сжимает в руке лишь дорожный посох. Как тихая молитва слово «несправедливость» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди УН-ге-рех-тиг-кайт]",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Zwischen abziehenden Soldaten hält Kent nur den Reisestock in der Hand.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Ungerechtigkeit“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "несправедливость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Zorn",
+                "russian": "гнев",
+                "sentence": "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück. Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "У закрытых ворот замка Кент бросает последний взгляд назад. Холодный свет заставляет слово «гнев» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер ЦОРН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor dem geschlossenen Burgtor wirft Kent den Blick noch einmal zurück.",
+                    "Das kalte Licht lässt das Wort „der Zorn“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "гнев"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verbannt",
+                "russian": "изгнанный",
+                "sentence": "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir.",
+                "sentence_translation": "На мокрой мостовой Кент замирает, пока барабаны смолкают. Буря за окнами усиливает клятву: слово «изгнанный» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[фер-БАНТ]",
+                "themes": [
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn"
+                ],
+                "sentence_parts": [
+                    "Auf dem Regenpflaster bleibt Kent stehen, während die Trommeln schweigen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „verbannt“ gehört mir."
+                ],
+                "synonyms": [
+                    "изгнанный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Abschied",
+                "russian": "прощание",
+                "sentence": "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel. Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus.",
+                "sentence_translation": "Среди разбросанных узлов Кент затягивает меч на поясе. Я глубоко вдыхаю и выпускаю только слово «прощание».",
+                "russian_hint": "",
+                "transcription": "[дер АБ-шид]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Reisebündeln befestigt Kent das Schwert am Gürtel.",
+                    "Ich atme tief ein und lasse nur das Wort „der Abschied“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "прощание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Strafe",
+                "russian": "наказание",
+                "sentence": "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch. Ich presse das Wort „die Strafe“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Под серым небом Кент поднимает ворот плаща. Я стискиваю слово «наказание» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ШТРА-фе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter dem grauen Himmel zieht Kent den Mantelkragen hoch.",
+                    "Ich presse das Wort „die Strafe“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "кара",
+                    "наказание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zurückkehren",
+                "russian": "возвращаться",
+                "sentence": "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn. Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Перед пустынной дорогой Кент решительно смотрит вперёд. Моё дыхание рисует слово «возвращаться» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[цу-РЮК-ке-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der trostlosen Landstraße richtet Kent den Blick entschlossen nach vorn.",
+                    "Mein Atem zeichnet das Wort „zurückkehren“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "возвращаться",
+                    "umkehren — тоже «возвращаться»",
+                    "wiederkehren — тоже «возвращаться»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Verbannung",
@@ -2156,70 +2478,70 @@
                 "choices": [
                     "гнев",
                     "несправедливость",
-                    "изгнание",
-                    "изгнанный"
+                    "изгнанный",
+                    "изгнание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
                     "изгнание",
+                    "несправедливость",
                     "гнев",
-                    "изгнанный",
-                    "несправедливость"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Zorn»?",
-                "choices": [
-                    "изгнание",
-                    "гнев",
-                    "изгнанный",
-                    "прощание"
+                    "изгнанный"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Zorn»?",
+                "choices": [
+                    "изгнанный",
+                    "возвращаться",
+                    "прощание",
+                    "гнев"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
-                    "наказание",
-                    "гнев",
                     "изгнанный",
-                    "несправедливость"
+                    "возвращаться",
+                    "гнев",
+                    "наказание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "несправедливость",
                     "изгнанный",
                     "прощание",
-                    "возвращаться"
+                    "возвращаться",
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "прощание",
-                    "изгнание",
+                    "возвращаться",
+                    "изгнанный",
                     "наказание",
-                    "несправедливость"
+                    "изгнание"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "возвращаться",
-                    "изгнанный",
-                    "несправедливость",
-                    "прощание"
+                    "изгнание",
+                    "прощание",
+                    "наказание",
+                    "возвращаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2300,6 +2622,191 @@
     "disguise": {
         "title": "Маскировка",
         "description": "Акт I-II: Возвращается как слуга Кай",
+        "vocabulary": [
+            {
+                "german": "die Verkleidung",
+                "russian": "переодевание",
+                "sentence": "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über. Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen.",
+                "sentence_translation": "В задымлённой харчевне Кент натягивает грубое платье слуги. Как тихая молитва слово «переодевание» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ди фер-КЛАЙ-дунг]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "In der verqualmten Herberge streift Kent das grobe Knechtsgewand über.",
+                    "Wie ein stilles Gebet legt sich das Wort „die Verkleidung“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "маскировка",
+                    "переодевание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die List",
+                "russian": "хитрость",
+                "sentence": "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays. Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern.",
+                "sentence_translation": "Перед запотевшим зеркалом Кент тренирует хриплый голос Кая. Даже если мир распадается, слово «хитрость» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ЛИСТ]",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Vor einem beschlagenen Spiegel übt Kent die raue Stimme des Kays.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die List“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "хитрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unerkannt",
+                "russian": "неузнанный",
+                "sentence": "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir.",
+                "sentence_translation": "Под мятой шляпой Кент скрывает королевскую осанку. Буря за окнами усиливает клятву: слово «неузнанный» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[УН-ер-кант]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerknitterten Hut verbirgt Kent die königliche Haltung.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „unerkannt“ gehört mir."
+                ],
+                "synonyms": [
+                    "неузнанный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vorgeben",
+                "russian": "притворяться",
+                "sentence": "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle. Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Среди любопытных возниц Кент изучает служебные приказы. Я вывожу слово «притворяться» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ФОР-ге-бен]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
+                "sentence_parts": [
+                    "Zwischen neugierigen Fuhrknechten studiert Kent die Dienstbefehle.",
+                    "Ich zeichne das Wort „vorgeben“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "притворяться",
+                    "vortäuschen — тоже «притворяться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verstellen",
+                "russian": "изменять",
+                "sentence": "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab. Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus.",
+                "sentence_translation": "На пристани Кент смывает следы прежней жизни. Я глубоко вдыхаю и выпускаю только слово «изменять».",
+                "russian_hint": "",
+                "transcription": "[фер-ШТЕ-лен]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
+                "sentence_parts": [
+                    "Am Ufer des Hafens wäscht Kent die Spuren des alten Lebens ab.",
+                    "Ich atme tief ein und lasse nur das Wort „verstellen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "изменять",
+                    "betrügen — тоже «изменять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Bart",
+                "russian": "борода",
+                "sentence": "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks. Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen.",
+                "sentence_translation": "На пыльном рынке Кент проверяет ремни поклажи. Я шепчу стражам судьбы: слово «борода» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[дер БАРТ]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
+                "sentence_parts": [
+                    "Auf dem staubigen Markt prüft Kent die Tragriemen des Gepäcks.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „der Bart“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "борода"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "anheuern",
+                "russian": "наниматься",
+                "sentence": "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring. Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "В тени переулка Кент прячет некогда блестящий перстень. Холодный свет заставляет слово «наниматься» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[АН-хой-ерн]",
+                "themes": [
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung"
+                ],
+                "sentence_parts": [
+                    "Im Schatten einer Gasse versteckt Kent den einst glänzenden Siegelring.",
+                    "Das kalte Licht lässt das Wort „anheuern“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "наниматься"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "treu",
+                "russian": "верный",
+                "sentence": "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt. Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Под колесом телеги Кент затаивается, пока не прозвучит зов для слуг. Эхо слова «верный» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ТРОЙ]",
+                "themes": [
+                    "Freundschaft",
+                    "List",
+                    "Rückkehr",
+                    "Sturm",
+                    "Verkleidung",
+                    "Wahnsinn"
+                ],
+                "sentence_parts": [
+                    "Unter einem Wagenrad kauert Kent, bis der Ruf nach Dienern erschallt.",
+                    "Das Echo des Wortes „treu“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "верный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Verkleidung",
@@ -2530,79 +3037,79 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "переодевание",
-                    "неузнанный",
+                    "хитрость",
                     "притворяться",
-                    "хитрость"
+                    "неузнанный",
+                    "переодевание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "неузнанный",
                     "переодевание",
                     "хитрость",
+                    "неузнанный",
+                    "притворяться"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «unerkannt»?",
+                "choices": [
+                    "борода",
+                    "неузнанный",
+                    "хитрость",
+                    "верный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «vorgeben»?",
+                "choices": [
+                    "борода",
+                    "изменять",
+                    "притворяться",
+                    "наниматься"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verstellen»?",
+                "choices": [
+                    "хитрость",
+                    "переодевание",
+                    "изменять",
+                    "верный"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Bart»?",
+                "choices": [
+                    "притворяться",
+                    "борода",
+                    "изменять",
+                    "переодевание"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «anheuern»?",
+                "choices": [
+                    "переодевание",
+                    "хитрость",
+                    "наниматься",
                     "притворяться"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «unerkannt»?",
-                "choices": [
-                    "неузнанный",
-                    "изменять",
-                    "притворяться",
-                    "борода"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vorgeben»?",
-                "choices": [
-                    "изменять",
-                    "хитрость",
-                    "переодевание",
-                    "притворяться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verstellen»?",
-                "choices": [
-                    "неузнанный",
-                    "хитрость",
-                    "борода",
-                    "изменять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Bart»?",
-                "choices": [
-                    "хитрость",
-                    "верный",
-                    "неузнанный",
-                    "борода"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «anheuern»?",
-                "choices": [
-                    "хитрость",
-                    "неузнанный",
-                    "изменять",
-                    "наниматься"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "борода",
-                    "неузнанный",
+                    "наниматься",
                     "изменять",
+                    "хитрость",
                     "верный"
                 ],
                 "correctIndex": 3
@@ -2695,6 +3202,153 @@
     "service": {
         "title": "Тайная служба",
         "description": "Акт II-III: Служит неузнанным",
+        "vocabulary": [
+            {
+                "german": "der Dienst",
+                "russian": "служба",
+                "sentence": "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs. Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В ночной караульной Кент молча полирует королевские доспехи. Эхо слова «служба» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[дер ДИНСТ]",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
+                "sentence_parts": [
+                    "Im nächtlichen Wachraum poliert Kent schweigend die Rüstung des Königs.",
+                    "Das Echo des Wortes „der Dienst“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "служба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Schutz",
+                "russian": "защита",
+                "sentence": "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache. Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У ложа измождённого правителя Кент неподвижно несёт стражу. Эхо слова «защита» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[дер ШУТЦ]",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
+                "sentence_parts": [
+                    "Neben dem Lager des erschöpften Herrschers hält Kent unbeweglich Wache.",
+                    "Das Echo des Wortes „der Schutz“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "защита"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Gefahr",
+                "russian": "опасность",
+                "sentence": "Unter Regenmänteln der Wachen verbirgt Kent seine Narben. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig.",
+                "sentence_translation": "Под дождевыми плащами стражей Кент скрывает свои шрамы. Каждой клеткой тела я обещаю: слово «опасность» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ге-ФАР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter Regenmänteln der Wachen verbirgt Kent seine Narben.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Gefahr“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "опасность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bewachen",
+                "russian": "охранять",
+                "sentence": "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd. Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern.",
+                "sentence_translation": "У дверей конюшни Кент в темноте осёдлывает упрямого коня. Даже если мир распадается, слово «охранять» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[бе-ВА-хен]",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
+                "sentence_parts": [
+                    "Am Stalltor sattelt Kent in der Dunkelheit ein trotziges Pferd.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „bewachen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "охранять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "kämpfen",
+                "russian": "сражаться",
+                "sentence": "In der Küche der Dienerschaft füllt Kent den dampfenden Becher. Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В кухне прислуги Кент наполняет дымящийся кубок. Я черчу слово «сражаться» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[КЕМП-фен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "In der Küche der Dienerschaft füllt Kent den dampfenden Becher.",
+                    "Ich zeichne das Wort „kämpfen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "бороться",
+                    "bekämpfen — тоже «бороться»",
+                    "сражаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "raten",
+                "russian": "советовать",
+                "sentence": "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken. Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Перед ложем короля Кент раскладывает разбросанные покрывала. Я обнимаю слово «советовать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[РА-тен]",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
+                "sentence_parts": [
+                    "Vor der Schlafstatt des Königs ordnet Kent die verstreuten Decken.",
+                    "Ich umarme das Wort „raten“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "советовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Wache",
+                "russian": "стража",
+                "sentence": "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut. Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern.",
+                "sentence_translation": "Во дворе Кент проверяет уздечку, пока не рассвело. Даже если мир распадается, слово «стража» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ВА-хе]",
+                "themes": [
+                    "Dienst",
+                    "Gefahr",
+                    "Schutz"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hof prüft Kent das Zaumzeug, bevor der Morgen graut.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Wache“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "стража"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Dienst",
@@ -2895,61 +3549,61 @@
                 "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
                     "защита",
-                    "охранять",
+                    "опасность",
                     "служба",
-                    "опасность"
+                    "охранять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "служба",
-                    "стража",
                     "защита",
-                    "опасность"
+                    "опасность",
+                    "служба",
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
                     "сражаться",
-                    "охранять",
                     "служба",
-                    "стража"
+                    "охранять",
+                    "советовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "опасность",
+                    "сражаться",
                     "защита",
                     "советовать",
-                    "сражаться"
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
                     "советовать",
+                    "опасность",
                     "сражаться",
-                    "защита",
-                    "опасность"
+                    "охранять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
+                    "защита",
+                    "стража",
                     "опасность",
-                    "служба",
-                    "сражаться",
-                    "стража"
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3029,6 +3683,178 @@
     "stocks": {
         "title": "В колодках",
         "description": "Акт II: Наказан Корнуоллом",
+        "vocabulary": [
+            {
+                "german": "die Strafe",
+                "russian": "наказание",
+                "sentence": "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen.",
+                "sentence_translation": "Под дождём у крепостной стены Кент сидит с закреплёнными ногами в жёстких колодках. Я шепчу стражам судьбы: слово «наказание» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ШТРА-фе]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Regen der Burgmauer sitzt Kent mit gefesselten Füßen in den harten Hölzern.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Strafe“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "кара",
+                    "наказание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Demütigung",
+                "russian": "унижение",
+                "sentence": "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben. Ich presse das Wort „die Demütigung“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Под насмешливые песни стражи Кент гордо держит голову. Я стискиваю слово «унижение» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди де-МЮ-ти-гунг]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Neben den Spottliedern der Wachen hält Kent den Kopf stolz erhoben.",
+                    "Ich presse das Wort „die Demütigung“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "унижение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Standhaftigkeit",
+                "russian": "стойкость",
+                "sentence": "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken. Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В тусклом лунном свете Кент растирает затёкшую шею. Я черчу слово «стойкость» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди ШТАНД-хаф-тиг-кайт]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Vor dem trüben Mondlicht reibt Kent den schmerzenden Nacken.",
+                    "Ich zeichne das Wort „die Standhaftigkeit“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "стойкость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "fesseln",
+                "russian": "сковывать",
+                "sentence": "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel. Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern.",
+                "sentence_translation": "Среди ночных луж сапоги Кент устремлены в небо. Даже если мир распадается, слово «сковывать» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ФЕ-сельн]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Zwischen den Pfützen der Nacht starren Kents Schuhe in den Himmel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „fesseln“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "сковывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erdulden",
+                "russian": "терпеть",
+                "sentence": "Am Morgenfrost haucht Kent Eisblumen auf das Holz. Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern.",
+                "sentence_translation": "В утренний мороз Кент выдыхает ледяные узоры на дерево. Даже если мир распадается, слово «терпеть» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ер-ДУЛЬ-ден]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Am Morgenfrost haucht Kent Eisblumen auf das Holz.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „erdulden“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "терпеть",
+                    "dulden — тоже «терпеть»",
+                    "ertragen — тоже «терпеть»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Stock",
+                "russian": "колодка",
+                "sentence": "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung. Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Рядом с заблудившимся крестьянином Кент улыбается несмотря на унижение. Холодный свет заставляет слово «колодка» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер ШТОК]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Neben einem verirrten Bauernkind lächelt Kent trotz der Demütigung.",
+                    "Das kalte Licht lässt das Wort „der Stock“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "колодка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ausharren",
+                "russian": "выдерживать",
+                "sentence": "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht. Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen.",
+                "sentence_translation": "Под серым небом Кент терпеливо считает капли на лице. Я шепчу стражам судьбы: слово «выдерживать» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[АУС-ха-рен]",
+                "themes": [
+                    "Demütigung",
+                    "Standhaftigkeit",
+                    "Strafe"
+                ],
+                "sentence_parts": [
+                    "Unter dem grauen Himmel zählt Kent geduldig die Tropfen auf dem Gesicht.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „ausharren“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "выдерживать",
+                    "aushalten — тоже «выдерживать»",
+                    "durchhalten — тоже «выдерживать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Schande",
+                "russian": "позор",
+                "sentence": "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner. Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "На пустынном дворе Кент прислушивается к далёкому грохоту грома. Холодный свет заставляет слово «позор» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ди ШАН-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem verlassenen Hof lauscht Kent dem fern rollenden Donner.",
+                    "Das kalte Licht lässt das Wort „die Schande“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "позор"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Strafe",
@@ -3246,29 +4072,29 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "сковывать",
-                    "стойкость",
                     "наказание",
-                    "унижение"
+                    "стойкость",
+                    "унижение",
+                    "сковывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
                     "наказание",
+                    "стойкость",
                     "сковывать",
-                    "унижение",
-                    "стойкость"
+                    "унижение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
-                    "унижение",
+                    "терпеть",
                     "сковывать",
-                    "выдерживать",
+                    "позор",
                     "стойкость"
                 ],
                 "correctIndex": 3
@@ -3276,52 +4102,52 @@
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
-                    "унижение",
                     "сковывать",
-                    "наказание",
-                    "выдерживать"
+                    "колодка",
+                    "стойкость",
+                    "терпеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
-                    "стойкость",
                     "терпеть",
-                    "выдерживать",
+                    "наказание",
+                    "позор",
                     "сковывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
-                    "стойкость",
                     "колодка",
+                    "сковывать",
                     "терпеть",
-                    "сковывать"
+                    "стойкость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
-                    "позор",
+                    "выдерживать",
+                    "колодка",
                     "стойкость",
-                    "унижение",
-                    "выдерживать"
+                    "сковывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
-                    "унижение",
-                    "выдерживать",
                     "позор",
+                    "выдерживать",
+                    "сковывать",
                     "стойкость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3412,6 +4238,160 @@
     "storm_companion": {
         "title": "Спутник в буре",
         "description": "Акт III: Поддерживает Лира",
+        "vocabulary": [
+            {
+                "german": "der Sturm",
+                "russian": "буря",
+                "sentence": "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs. Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen.",
+                "sentence_translation": "С фонарём в кулаке Кент ищет тень короля. Как тихая молитва слово «буря» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер ШТУРМ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mit der Laterne in der Faust sucht Kent nach dem Schatten des Königs.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Sturm“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "буря"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Beistand",
+                "russian": "поддержка",
+                "sentence": "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild. Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Рядом с бушующим монархом Кент раскрывает плащ как щит. Холодный свет заставляет слово «поддержка» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер БАЙ-штанд]",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue"
+                ],
+                "sentence_parts": [
+                    "Neben dem tobenden Monarchen breitet Kent den Mantel wie ein Schild.",
+                    "Das kalte Licht lässt das Wort „der Beistand“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "поддержка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begleiten",
+                "russian": "сопровождать",
+                "sentence": "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel. Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "На затопленной тропе Кент держит коня за повод. Я вывожу слово «сопровождать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЛАЙ-тен]",
+                "themes": [
+                    "Beistand",
+                    "Freundschaft",
+                    "Sturm",
+                    "Treue",
+                    "Wahnsinn",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "Auf dem überfluteten Pfad hält Kent das Pferd am Zügel.",
+                    "Ich zeichne das Wort „begleiten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "сопровождать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "trösten",
+                "russian": "утешать",
+                "sentence": "Zwischen klatschenden Ästen ruft Kent beruhigende Worte. Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Среди хлещущих веток Кент говорит успокаивающие слова. Моё дыхание рисует слово «утешать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ТРЁС-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen klatschenden Ästen ruft Kent beruhigende Worte.",
+                    "Mein Atem zeichnet das Wort „trösten“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "утешать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Zuflucht",
+                "russian": "убежище",
+                "sentence": "Vor der klappernden Hütte hebt Kent die Fackel, um den Weg zu zeigen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig.",
+                "sentence_translation": "Перед дрожащей хижиной Кент поднимает факел, освещая путь. Каждой клеткой тела я обещаю: слово «убежище» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ЦУ-флухт]",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue"
+                ],
+                "sentence_parts": [
+                    "Vor der klappernden Hütte hebt Kent die Fackel,",
+                    "um den Weg zu zeigen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Zuflucht“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "убежище",
+                    "das Asyl — тоже «убежище»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "durchhalten",
+                "russian": "выдерживать",
+                "sentence": "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher. Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "На краю болотного поля Кент поддерживает качающегося правителя. Я обнимаю слово «выдерживать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ДУРХ-халь-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Rand des Moorfelds stützt Kent den taumelnden Herrscher.",
+                    "Ich umarme das Wort „durchhalten“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "выдерживать",
+                    "aushalten — тоже «выдерживать»",
+                    "ausharren — тоже «выдерживать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Kälte",
+                "russian": "холод",
+                "sentence": "Unter dem peitschenden Regen spricht Kent ein leises Trostlied. Ich presse das Wort „die Kälte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Под хлещущим дождём Кент тихо напевает утешительную песнь. Я стискиваю слово «холод» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди КЕЛ-те]",
+                "themes": [
+                    "Beistand",
+                    "Sturm",
+                    "Treue",
+                    "gnadenlos",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Unter dem peitschenden Regen spricht Kent ein leises Trostlied.",
+                    "Ich presse das Wort „die Kälte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "холод"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Sturm",
@@ -3613,72 +4593,72 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
-                    "сопровождать",
                     "поддержка",
+                    "сопровождать",
+                    "буря",
                     "утешать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
                     "сопровождать",
-                    "поддержка",
+                    "буря",
                     "утешать",
-                    "буря"
+                    "поддержка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "выдерживать",
-                    "поддержка",
                     "холод",
-                    "сопровождать"
+                    "выдерживать",
+                    "сопровождать",
+                    "поддержка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "поддержка",
+                    "буря",
+                    "убежище",
                     "утешать",
-                    "сопровождать",
-                    "холод"
+                    "поддержка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "утешать",
                     "буря",
-                    "выдерживать",
-                    "убежище"
+                    "утешать",
+                    "убежище",
+                    "поддержка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "выдерживать",
-                    "поддержка",
                     "сопровождать",
+                    "выдерживать",
+                    "буря",
                     "убежище"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
+                    "выдерживать",
                     "холод",
                     "убежище",
-                    "сопровождать",
-                    "выдерживать"
+                    "утешать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3760,6 +4740,185 @@
     "final_loyalty": {
         "title": "Верность до конца",
         "description": "Акт V: Остаётся с умирающим Лиром",
+        "vocabulary": [
+            {
+                "german": "der Tod",
+                "russian": "смерть",
+                "sentence": "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir.",
+                "sentence_translation": "В тихой опочивальне смерти Кент стоит у последнего ложа Лира. Буря за окнами усиливает клятву: слово «смерть» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дер ТОД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im stillen Sterbezimmer wacht Kent an Lears letztem Lager.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Tod“ gehört mir."
+                ],
+                "synonyms": [
+                    "смерть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Abschied",
+                "russian": "прощание",
+                "sentence": "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang. Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen.",
+                "sentence_translation": "У догорающей свечи Кент гладит разорванный плащ. Как тихая молитва слово «прощание» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер АБ-шид]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Neben der verlöschenden Kerze streicht Kent über den zerrissenen Umhang.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Abschied“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "прощание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ewig",
+                "russian": "вечный",
+                "sentence": "Vor den starren Wachen flüstert Kent ein letztes Versprechen. Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten.",
+                "sentence_translation": "Перед оцепеневшими стражами Кент шепчет последнее обещание. Твёрдым голосом я клянусь себе: слово «вечный» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[Э-виг]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Vor den starren Wachen flüstert Kent ein letztes Versprechen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „ewig“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "вечный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "weinen",
+                "russian": "плакать",
+                "sentence": "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder. Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На пустом троне Кент кладёт свой посох. Моё дыхание рисует слово «плакать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ВАЙ-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem leeren Thronstuhl legt Kent den eigenen Stab nieder.",
+                    "Mein Atem zeichnet das Wort „weinen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "плакать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Erschöpfung",
+                "russian": "истощение",
+                "sentence": "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern.",
+                "sentence_translation": "Среди блекнущих настенных росписей Кент на мгновение закрывает глаза. Даже если мир распадается, слово «истощение» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ер-ШЁП-фунг]",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "ewige Treue"
+                ],
+                "sentence_parts": [
+                    "Zwischen verblassenden Wandmalereien schließt Kent kurz die Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Erschöpfung“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "истощение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufgeben",
+                "russian": "сдаваться",
+                "sentence": "Am offenen Fenster lässt Kent den kalten Morgen herein. Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen.",
+                "sentence_translation": "У распахнутого окна Кент впускает холодное утро. Я шепчу стражам судьбы: слово «сдаваться» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[АУФ-ге-бен]",
+                "themes": [
+                    "Abschied",
+                    "Tod",
+                    "Täuschung",
+                    "Verzweiflung",
+                    "ewige Treue",
+                    "springen"
+                ],
+                "sentence_parts": [
+                    "Am offenen Fenster lässt Kent den kalten Morgen herein.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „aufgeben“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "сдаваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Trauer",
+                "russian": "скорбь",
+                "sentence": "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag. Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "В тени скорбящих Кент держит руку Лира до последнего удара. Я вывожу слово «скорбь» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ди ТРАУ-ер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Trauernden hält Kent Lears Hand bis zum letzten Schlag.",
+                    "Ich zeichne das Wort „die Trauer“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "печаль",
+                    "скорбь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "folgen",
+                "russian": "следовать",
+                "sentence": "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet. Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед молчаливой придворной часовней Кент преклоняет колено в безмолвной молитве. Я держу слово «следовать» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ФОЛЬ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor der stillen Hofkapelle beugt Kent das Knie für ein stummes Gebet.",
+                    "Ich halte das Wort „folgen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "следовать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Tod",
@@ -4009,71 +5168,71 @@
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
                     "вечный",
+                    "плакать",
                     "смерть",
-                    "прощание",
-                    "плакать"
+                    "прощание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "скорбь",
                     "вечный",
-                    "следовать",
-                    "смерть"
+                    "сдаваться",
+                    "прощание",
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
-                    "смерть",
-                    "следовать",
                     "плакать",
-                    "истощение"
+                    "истощение",
+                    "следовать",
+                    "скорбь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
-                    "плакать",
-                    "истощение",
+                    "следовать",
+                    "смерть",
                     "скорбь",
-                    "вечный"
+                    "истощение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "скорбь",
-                    "прощание",
+                    "плакать",
+                    "вечный",
                     "сдаваться",
-                    "смерть"
+                    "скорбь"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "прощание",
+                    "следовать",
+                    "вечный",
                     "скорбь",
-                    "плакать",
-                    "следовать"
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
-                    "вечный",
-                    "прощание",
                     "следовать",
+                    "истощение",
+                    "прощание",
                     "сдаваться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4166,6 +5325,9 @@ const characterId = "kent";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "трон", "королевство", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "королевство", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["королевство", "трон", "власть", "великолепный"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["великолепный", "провозглашать", "королевство", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "церемония", "королевство", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["королевство", "провозглашать", "церемония", "корона"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "великолепный", "корона", "провозглашать"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "трон", "власть", "корона"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["гнев", "проклинать", "неблагодарность", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["проклинать", "неблагодарность", "гнев", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["проклятие", "проклинать", "унижать", "неблагодарность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["обида", "проклинать", "проклятие", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "обида", "сожалеть", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["неблагодарность", "обида", "гнев", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "проклинать", "неблагодарность", "обида"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["унижать", "гнев", "проклятие", "проклинать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "жестокость", "отвергать", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "отчаяние", "отвергать", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "просить", "отчаяние", "нужда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отвергать", "нужда", "отчаяние", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["одиночество", "нужда", "отчаяние", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["отчаяние", "отвергать", "одиночество", "просить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["слеза", "жестокость", "отчаяние", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["отчаяние", "просить", "слеза", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["хаос", "молния", "голый", "бушевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["голый", "буря", "кричать", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["буря", "гром", "голый", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["гром", "кричать", "молния", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["хаос", "голый", "кричать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["буря", "бушевать", "хаос", "гром"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["мёрзнуть", "нищий", "нищета", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "нищета", "бедный", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "мёрзнуть", "нищий", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "нищета", "нищий", "шут"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["мёрзнуть", "познание", "нищета", "хижина"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["нищий", "нищета", "шут", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["нищета", "хижина", "шут", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["страдать", "познание", "шут", "мёрзнуть"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["мудрость", "понимать", "правда", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["прощать", "раскаяние", "понимать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["виновный", "понимать", "мудрость", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "прощать", "понимать", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прозрение", "прощать", "раскаяние", "виновный"], "correct_index": 0}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["раскаяние", "правда", "мудрость", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["смерть", "конец", "умирать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["прощать", "конец", "умирать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "сердце", "умирать", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "смерть", "конец", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["вечный", "конец", "сердце", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скорбь", "вечный", "прощать", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["скорбь", "прощание", "смерть", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "скорбь", "умирать", "сердце"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "править", "трон", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "править", "королевство", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "власть", "корона", "провозглашать"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["провозглашать", "власть", "великолепный", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["трон", "провозглашать", "королевство", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["трон", "власть", "провозглашать", "корона"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["великолепный", "власть", "королевство", "церемония"], "correct_index": 3}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["провозглашать", "великолепный", "церемония", "корона"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["проклинать", "неблагодарность", "унижать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["проклинать", "неблагодарность", "гнев", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["неблагодарность", "обида", "сожалеть", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["неблагодарность", "проклятие", "обида", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["проклятие", "изгонять", "проклинать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["гнев", "проклинать", "сожалеть", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "сожалеть", "проклятие", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["обида", "сожалеть", "проклинать", "проклятие"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "отчаяние", "жестокость", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "отвергать", "покидать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["нужда", "отвергать", "жестокость", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "нужда", "слеза", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["отчаяние", "покидать", "слеза", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["просить", "покидать", "одиночество", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["одиночество", "жестокость", "слеза", "нужда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["просить", "нужда", "слеза", "отвергать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["гром", "безумие", "бушевать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["бушевать", "гром", "буря", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «toben»?", "choices": ["гром", "кричать", "хаос", "бушевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["буря", "гром", "безумие", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["кричать", "гром", "безумие", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "гром", "безумие", "хаос"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["кричать", "гром", "голый", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["буря", "гром", "кричать", "хаос"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["бедный", "нищета", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "бедный", "нищета", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «arm»?", "choices": ["мёрзнуть", "страдать", "бедный", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["хижина", "познание", "мёрзнуть", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["нищета", "страдать", "хижина", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мёрзнуть", "шут", "нищий", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["бедный", "хижина", "мёрзнуть", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["бедный", "мёрзнуть", "познание", "хижина"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "правда", "раскаяние", "понимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["правда", "узнавать", "понимать", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["прозрение", "узнавать", "правда", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["виновный", "раскаяние", "узнавать", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["узнавать", "мудрость", "виновный", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "узнавать", "виновный", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["мудрость", "понимать", "правда", "прозрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["правда", "прощать", "узнавать", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["конец", "умирать", "прощать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "прощать", "смерть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "умирать", "прощание", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "прощание", "скорбь", "сердце"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["вечный", "скорбь", "сердце", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "сердце", "умирать", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["сердце", "прощание", "вечный", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["прощание", "скорбь", "вечный", "умирать"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,109 +662,45 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
                             
@@ -774,15 +710,79 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
                             
@@ -797,17 +797,17 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -829,47 +829,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обида</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
@@ -877,31 +861,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
                             
@@ -909,17 +893,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -938,59 +938,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1000,11 +1000,11 @@
                         <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
                             
@@ -1016,27 +1016,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
@@ -1044,17 +1028,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,33 +1067,33 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1103,11 +1103,11 @@
                         <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
@@ -1115,17 +1115,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1135,11 +1135,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                             
@@ -1147,31 +1147,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
@@ -1179,17 +1179,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,17 +1202,17 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1224,7 +1224,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                             
@@ -1234,49 +1250,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
@@ -1298,33 +1298,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1337,17 +1337,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1359,11 +1359,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1371,6 +1371,70 @@
                     
                     <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
@@ -1385,79 +1449,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                             
@@ -1472,31 +1472,15 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1504,15 +1488,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
@@ -1520,17 +1520,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1542,7 +1542,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
@@ -1552,17 +1552,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1572,29 +1572,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1616,6 +1616,204 @@
     "throne": {
         "title": "Тронный зал",
         "description": "Акт I: Разделение королевства",
+        "vocabulary": [
+            {
+                "german": "der Thron",
+                "russian": "трон",
+                "sentence": "König Lear sitzt majestätisch auf seinem goldenen Thron im prächtigen Thronsaal des Schlosses.",
+                "sentence_translation": "Король Лир сидит величественно на своём золотом троне в великолепном тронном зале замка.",
+                "russian_hint": "символ королевской власти",
+                "transcription": "[дер ТРОН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "sitzt majestätisch",
+                    "auf seinem goldenen Thron",
+                    "im prächtigen Thronsaal des Schlosses."
+                ],
+                "synonyms": [
+                    "престол",
+                    "царское место",
+                    "королевское кресло"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Königreich",
+                "russian": "королевство",
+                "sentence": "Der alte König Lear will sein mächtiges Königreich unter seinen drei Töchtern aufteilen.",
+                "sentence_translation": "Старый Король Лир хочет разделить своё могущественное королевство между своими тремя дочерьми.",
+                "russian_hint": "государство короля",
+                "transcription": "[дас КЁ-ниг-райх]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der alte König Lear",
+                    "will aufteilen",
+                    "sein mächtiges Königreich",
+                    "unter seinen drei Töchtern."
+                ],
+                "synonyms": [
+                    "царство",
+                    "держава",
+                    "государство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Macht",
+                "russian": "власть",
+                "sentence": "König Lear übergibt die absolute Macht an Goneril und Regan nach ihrer falschen Liebeserklärung.",
+                "sentence_translation": "Король Лир передаёт абсолютную власть Гонерилье и Регане после их фальшивого признания в любви.",
+                "russian_hint": "сила управления",
+                "transcription": "[ди МАХТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "übergibt",
+                    "die absolute Macht",
+                    "an Goneril und Regan nach ihrer falschen Liebeserklärung."
+                ],
+                "synonyms": [
+                    "могущество",
+                    "господство",
+                    "владычество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "herrschen",
+                "russian": "править",
+                "sentence": "Goneril und Regan wollen grausam herrschen nachdem sie das Königreich von ihrem Vater bekommen.",
+                "sentence_translation": "Гонерилья и Регана хотят жестоко править после того как получили королевство от своего отца.",
+                "russian_hint": "управлять государством",
+                "transcription": "[ХЕР-шен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Goneril und Regan",
+                    "wollen grausam herrschen",
+                    "nachdem sie das Königreich",
+                    "von ihrem Vater bekommen."
+                ],
+                "synonyms": [
+                    "властвовать",
+                    "царствовать",
+                    "управлять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verkünden",
+                "russian": "провозглашать",
+                "sentence": "König Lear verkündet feierlich vor dem ganzen Hof seine Entscheidung das Königreich zu teilen.",
+                "sentence_translation": "Король Лир провозглашает торжественно перед всем двором своё решение разделить королевство.",
+                "russian_hint": "официально объявлять",
+                "transcription": "[фер-КЮН-ден]",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "verkündet feierlich",
+                    "vor dem ganzen Hof",
+                    "seine Entscheidung das Königreich zu teilen."
+                ],
+                "synonyms": [
+                    "объявлять",
+                    "возвещать",
+                    "оглашать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Krone",
+                "russian": "корона",
+                "sentence": "Die schwere goldene Krone auf König Lears Haupt symbolisiert seine schwindende königliche Macht.",
+                "sentence_translation": "Тяжёлая золотая корона на голове Короля Лира символизирует его угасающую королевскую власть.",
+                "russian_hint": "символ королевской власти",
+                "transcription": "[ди КРО-не]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die schwere goldene Krone",
+                    "auf König Lears Haupt",
+                    "symbolisiert",
+                    "seine schwindende königliche Macht."
+                ],
+                "synonyms": [
+                    "венец",
+                    "диадема",
+                    "царский венец"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Zeremonie",
+                "russian": "церемония",
+                "sentence": "Die verhängnisvolle Zeremonie der Reichsteilung wird für König Lear zum Beginn seiner tragischen Reise.",
+                "sentence_translation": "Роковая церемония разделения королевства становится для Короля Лира началом его трагического пути.",
+                "russian_hint": "торжественный ритуал",
+                "transcription": "[ди це-ре-мо-НИ]",
+                "themes": [
+                    "Ehrlichkeit",
+                    "König",
+                    "Liebe",
+                    "Macht",
+                    "Thron",
+                    "Wahrheit"
+                ],
+                "sentence_parts": [
+                    "Die verhängnisvolle Zeremonie",
+                    "der Reichsteilung",
+                    "wird für König Lear",
+                    "zum Beginn seiner tragischen Reise."
+                ],
+                "synonyms": [
+                    "обряд",
+                    "ритуал",
+                    "торжество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "prächtig",
+                "russian": "великолепный",
+                "sentence": "Der prächtige Thronsaal wird zum Schauplatz wo König Lear seine ehrliche Tochter Cordelia verstößt.",
+                "sentence_translation": "Великолепный тронный зал становится местом где Король Лир отвергает свою честную дочь Корделию.",
+                "russian_hint": "роскошный, пышный",
+                "transcription": "[ПРЕХ-тиг]",
+                "themes": [
+                    "König",
+                    "Macht",
+                    "Thron"
+                ],
+                "sentence_parts": [
+                    "Der prächtige Thronsaal",
+                    "wird zum Schauplatz",
+                    "wo König Lear",
+                    "seine ehrliche Tochter Cordelia verstößt."
+                ],
+                "synonyms": [
+                    "роскошный",
+                    "пышный",
+                    "величественный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Thron",
@@ -1856,38 +2054,38 @@
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
                     "власть",
-                    "трон",
-                    "королевство",
-                    "править"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Königreich»?",
-                "choices": [
-                    "трон",
-                    "королевство",
                     "править",
-                    "власть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Macht»?",
-                "choices": [
-                    "королевство",
                     "трон",
-                    "власть",
-                    "великолепный"
+                    "королевство"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «das Königreich»?",
+                "choices": [
+                    "власть",
+                    "править",
+                    "королевство",
+                    "трон"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Macht»?",
+                "choices": [
+                    "трон",
+                    "власть",
+                    "корона",
+                    "провозглашать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "великолепный",
                     "провозглашать",
-                    "королевство",
+                    "власть",
+                    "великолепный",
                     "править"
                 ],
                 "correctIndex": 3
@@ -1895,19 +2093,19 @@
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
+                    "трон",
                     "провозглашать",
-                    "церемония",
                     "королевство",
-                    "править"
+                    "власть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
-                    "королевство",
+                    "трон",
+                    "власть",
                     "провозглашать",
-                    "церемония",
                     "корона"
                 ],
                 "correctIndex": 3
@@ -1915,22 +2113,22 @@
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "церемония",
                     "великолепный",
-                    "корона",
-                    "провозглашать"
+                    "власть",
+                    "королевство",
+                    "церемония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
+                    "провозглашать",
                     "великолепный",
-                    "трон",
-                    "власть",
+                    "церемония",
                     "корона"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2036,6 +2234,202 @@
     "goneril": {
         "title": "У Гонерильи",
         "description": "Акт I: Предательство старшей дочери",
+        "vocabulary": [
+            {
+                "german": "demütigen",
+                "russian": "унижать",
+                "sentence": "Die undankbare Goneril will ihren alten Vater König Lear demütigen indem sie seine Dienerschaft reduziert.",
+                "sentence_translation": "Неблагодарная Гонерилья хочет унизить своего старого отца Короля Лира сокращая его свиту.",
+                "russian_hint": "оскорблять достоинство",
+                "transcription": "[де-МЮ-ти-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "demütigen",
+                    "grausam",
+                    "reduzieren",
+                    "vertreiben"
+                ],
+                "sentence_parts": [
+                    "Die undankbare Goneril",
+                    "will demütigen",
+                    "ihren alten Vater König Lear",
+                    "indem sie seine Dienerschaft reduziert."
+                ],
+                "synonyms": [
+                    "оскорблять",
+                    "позорить",
+                    "уничижать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Zorn",
+                "russian": "гнев",
+                "sentence": "König Lears gerechter Zorn entflammt als Goneril ihm die königlichen Ehren verweigert und beleidigt.",
+                "sentence_translation": "Праведный гнев Короля Лира вспыхивает когда Гонерилья отказывает ему в королевских почестях и оскорбляет.",
+                "russian_hint": "благородный, праведный",
+                "transcription": "[дер ЦОРН]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lears gerechter Zorn",
+                    "entflammt",
+                    "als Goneril ihm die königlichen Ehren",
+                    "verweigert und beleidigt."
+                ],
+                "synonyms": [
+                    "ярость",
+                    "негодование",
+                    "возмущение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Undankbarkeit",
+                "russian": "неблагодарность",
+                "sentence": "Die bittere Undankbarkeit seiner Tochter Goneril verwandelt König Lears Vaterliebe in brennenden Schmerz.",
+                "sentence_translation": "Горькая неблагодарность его дочери Гонерильи превращает отцовскую любовь Короля Лира в жгучую боль.",
+                "russian_hint": "отсутствие благодарности",
+                "transcription": "[ди УН-данк-бар-кайт]",
+                "themes": [
+                    "Zorn",
+                    "demütigen",
+                    "reduzieren"
+                ],
+                "sentence_parts": [
+                    "Die bittere Undankbarkeit",
+                    "seiner Tochter Goneril",
+                    "verwandelt König Lears Vaterliebe",
+                    "in brennenden Schmerz."
+                ],
+                "synonyms": [
+                    "черная неблагодарность",
+                    "неблагодарность",
+                    "забывчивость добра"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verfluchen",
+                "russian": "проклинать",
+                "sentence": "Der verzweifelte König Lear verflucht seine grausame Tochter Goneril mit schrecklichen Worten vor allen Dienern.",
+                "sentence_translation": "Отчаявшийся Король Лир проклинает свою жестокую дочь Гонерилью страшными словами перед всеми слугами.",
+                "russian_hint": "насылать проклятие",
+                "transcription": "[фер-ФЛУ-хен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der verzweifelte König Lear",
+                    "verflucht",
+                    "seine grausame Tochter Goneril",
+                    "mit schrecklichen Worten vor allen Dienern."
+                ],
+                "synonyms": [
+                    "предавать проклятию",
+                    "клясть",
+                    "анафематствовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vertreiben",
+                "russian": "изгонять",
+                "sentence": "Goneril will ihren königlichen Vater aus dem Schloss vertreiben das er ihr geschenkt hat.",
+                "sentence_translation": "Гонерилья хочет изгнать своего королевского отца из замка который он ей подарил.",
+                "russian_hint": "силой из места",
+                "transcription": "[фер-ТРАЙ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Goneril",
+                    "will vertreiben",
+                    "ihren königlichen Vater",
+                    "aus dem Schloss das er ihr geschenkt hat."
+                ],
+                "synonyms": [
+                    "выгонять",
+                    "прогонять",
+                    "выдворять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Kränkung",
+                "russian": "обида",
+                "sentence": "Die tiefe Kränkung durch Gonerils Verrat brennt in König Lears Herz wie glühendes Eisen.",
+                "sentence_translation": "Глубокая обида от предательства Гонерильи жжёт в сердце Короля Лира как раскалённое железо.",
+                "russian_hint": "душевная рана",
+                "transcription": "[ди КРЭН-кунг]",
+                "themes": [
+                    "Zorn",
+                    "demütigen",
+                    "reduzieren"
+                ],
+                "sentence_parts": [
+                    "Die tiefe Kränkung",
+                    "durch Gonerils Verrat",
+                    "brennt in König Lears Herz",
+                    "wie glühendes Eisen."
+                ],
+                "synonyms": [
+                    "оскорбление",
+                    "уязвление",
+                    "унижение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bereuen",
+                "russian": "сожалеть",
+                "sentence": "König Lear beginnt bitter zu bereuen dass er Cordelia verstieß und Goneril vertraute.",
+                "sentence_translation": "Король Лир начинает горько сожалеть что отверг Корделию и доверился Гонерилье.",
+                "russian_hint": "раскаиваться в содеянном",
+                "transcription": "[бе-РОЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "beginnt bitter zu bereuen",
+                    "dass er Cordelia verstieß",
+                    "und Goneril vertraute."
+                ],
+                "synonyms": [
+                    "раскаиваться",
+                    "жалеть",
+                    "каяться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Fluch",
+                "russian": "проклятие",
+                "sentence": "König Lears furchtbarer Fluch gegen Goneril hallt durch die Säle des Schlosses wie Donner.",
+                "sentence_translation": "Страшное проклятие Короля Лира против Гонерильи разносится по залам замка как гром.",
+                "russian_hint": "злое пожелание",
+                "transcription": "[дер ФЛУХ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lears furchtbarer Fluch",
+                    "gegen Goneril",
+                    "hallt durch die Säle",
+                    "des Schlosses wie Donner."
+                ],
+                "synonyms": [
+                    "заклятие",
+                    "анафема",
+                    "проклятье"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "demütigen",
@@ -2277,12 +2671,12 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "гнев",
                     "проклинать",
                     "неблагодарность",
-                    "унижать"
+                    "унижать",
+                    "гнев"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
@@ -2297,62 +2691,62 @@
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
-                    "проклятие",
-                    "проклинать",
-                    "унижать",
-                    "неблагодарность"
+                    "неблагодарность",
+                    "обида",
+                    "сожалеть",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "обида",
-                    "проклинать",
+                    "неблагодарность",
                     "проклятие",
-                    "неблагодарность"
+                    "обида",
+                    "проклинать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
+                    "проклятие",
                     "изгонять",
-                    "обида",
-                    "сожалеть",
-                    "проклинать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Kränkung»?",
-                "choices": [
-                    "неблагодарность",
-                    "обида",
-                    "гнев",
-                    "унижать"
+                    "проклинать",
+                    "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «bereuen»?",
+                "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "сожалеть",
+                    "гнев",
                     "проклинать",
-                    "неблагодарность",
+                    "сожалеть",
                     "обида"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «bereuen»?",
+                "choices": [
+                    "изгонять",
+                    "сожалеть",
+                    "проклятие",
+                    "проклинать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "унижать",
-                    "гнев",
-                    "проклятие",
-                    "проклинать"
+                    "обида",
+                    "сожалеть",
+                    "проклинать",
+                    "проклятие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2458,6 +2852,207 @@
     "regan": {
         "title": "У Реганы",
         "description": "Акт II: Предательство младшей дочери",
+        "vocabulary": [
+            {
+                "german": "verlassen",
+                "russian": "покидать",
+                "sentence": "Der gebrochene König Lear muss Regans Schloss verlassen während draußen ein furchtbarer Sturm tobt.",
+                "sentence_translation": "Сломленный Король Лир должен покинуть замок Реганы в то время как снаружи бушует ужасная буря.",
+                "russian_hint": "оставлять навсегда",
+                "transcription": "[фер-ЛА-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der gebrochene König Lear",
+                    "muss verlassen",
+                    "Regans Schloss",
+                    "während draußen ein furchtbarer Sturm tobt."
+                ],
+                "synonyms": [
+                    "оставлять",
+                    "уходить",
+                    "бросать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verstoßen",
+                "russian": "отвергать",
+                "sentence": "Regan und Goneril verstoßen gemeinsam ihren alten Vater König Lear in die stürmische Nacht.",
+                "sentence_translation": "Регана и Гонерилья вместе отвергают своего старого отца Короля Лира в штормовую ночь.",
+                "russian_hint": "из семьи, от себя",
+                "transcription": "[фер-ШТО-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Regan und Goneril",
+                    "verstoßen gemeinsam",
+                    "ihren alten Vater König Lear",
+                    "in die stürmische Nacht."
+                ],
+                "synonyms": [
+                    "отрекаться",
+                    "изгонять",
+                    "отталкивать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Grausamkeit",
+                "russian": "жестокость",
+                "sentence": "Die kalte Grausamkeit seiner Töchter Regan und Goneril zerbricht König Lears stolzes königliches Herz.",
+                "sentence_translation": "Холодная жестокость его дочерей Реганы и Гонерильи разбивает гордое королевское сердце Короля Лира.",
+                "russian_hint": "безжалостность к другим",
+                "transcription": "[ди ГРАУ-зам-кайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Die kalte Grausamkeit",
+                    "seiner Töchter Regan und Goneril",
+                    "zerbricht",
+                    "König Lears stolzes königliches Herz."
+                ],
+                "synonyms": [
+                    "безжалостность",
+                    "бесчеловечность",
+                    "свирепость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Verzweiflung",
+                "russian": "отчаяние",
+                "sentence": "Die tiefe Verzweiflung überwältigt König Lear als beide Töchter ihm jegliche Unterkunft verweigern.",
+                "sentence_translation": "Глубокое отчаяние охватывает Короля Лира когда обе дочери отказывают ему в любом приюте.",
+                "russian_hint": "потеря всякой надежды",
+                "transcription": "[ди фер-ЦВАЙ-флунг]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die tiefe Verzweiflung",
+                    "überwältigt König Lear",
+                    "als beide Töchter",
+                    "ihm jegliche Unterkunft verweigern."
+                ],
+                "synonyms": [
+                    "безнадёжность",
+                    "безысходность",
+                    "уныние"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "betteln",
+                "russian": "просить",
+                "sentence": "Der einst mächtige König Lear muss bei seinen herzlosen Töchtern um einen Schlafplatz betteln.",
+                "sentence_translation": "Некогда могущественный Король Лир вынужден просить у своих бессердечных дочерей место для ночлега.",
+                "russian_hint": "униженно молить",
+                "transcription": "[БЕ-тельн]",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "Verzweiflung",
+                    "verlassen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Der einst mächtige König Lear",
+                    "muss betteln",
+                    "bei seinen herzlosen Töchtern",
+                    "um einen Schlafplatz."
+                ],
+                "synonyms": [
+                    "умолять",
+                    "молить",
+                    "выпрашивать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Einsamkeit",
+                "russian": "одиночество",
+                "sentence": "Die schreckliche Einsamkeit umgibt König Lear nachdem seine eigenen Töchter ihn verraten haben.",
+                "sentence_translation": "Страшное одиночество окружает Короля Лира после того как его собственные дочери предали его.",
+                "russian_hint": "состояние без близких",
+                "transcription": "[ди АЙН-зам-кайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die schreckliche Einsamkeit",
+                    "umgibt König Lear",
+                    "nachdem seine eigenen Töchter",
+                    "ihn verraten haben."
+                ],
+                "synonyms": [
+                    "уединение",
+                    "изоляция",
+                    "оставленность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Träne",
+                "russian": "слеза",
+                "sentence": "König Lear kämpft gegen die bitteren Tränen an während er Regans grausame Worte hört.",
+                "sentence_translation": "Король Лир борется с горькими слезами когда слышит жестокие слова Реганы.",
+                "russian_hint": "капля из глаз",
+                "transcription": "[ди ТРЭ-не]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "kämpft gegen die bitteren Tränen an",
+                    "während er",
+                    "Regans grausame Worte hört."
+                ],
+                "synonyms": [
+                    "слезинка",
+                    "капля горя",
+                    "слёзы"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Not",
+                "russian": "нужда",
+                "sentence": "In seiner größten Not erkennt König Lear dass nur Cordelia ihn wirklich liebte.",
+                "sentence_translation": "В своей величайшей нужде Король Лир понимает что только Корделия действительно любила его.",
+                "russian_hint": "крайняя бедность",
+                "transcription": "[ди НОТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "In seiner größten Not",
+                    "erkennt König Lear",
+                    "dass nur Cordelia",
+                    "ihn wirklich liebte."
+                ],
+                "synonyms": [
+                    "бедность",
+                    "лишения",
+                    "недостаток"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verlassen",
@@ -2706,48 +3301,48 @@
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
                     "покидать",
+                    "отчаяние",
                     "жестокость",
-                    "отвергать",
-                    "отчаяние"
+                    "отвергать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "жестокость",
                     "отчаяние",
                     "отвергать",
-                    "покидать"
+                    "покидать",
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "жестокость",
-                    "просить",
-                    "отчаяние",
-                    "нужда"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "отвергать",
                     "нужда",
-                    "отчаяние",
+                    "отвергать",
+                    "жестокость",
                     "покидать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "отчаяние",
+                    "нужда",
+                    "слеза",
+                    "жестокость"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "одиночество",
-                    "нужда",
                     "отчаяние",
+                    "покидать",
+                    "слеза",
                     "просить"
                 ],
                 "correctIndex": 3
@@ -2755,32 +3350,32 @@
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "отчаяние",
-                    "отвергать",
+                    "просить",
+                    "покидать",
                     "одиночество",
-                    "просить"
+                    "отвергать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "слеза",
+                    "одиночество",
                     "жестокость",
-                    "отчаяние",
-                    "отвергать"
+                    "слеза",
+                    "нужда"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "отчаяние",
                     "просить",
+                    "нужда",
                     "слеза",
-                    "нужда"
+                    "отвергать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2886,6 +3481,202 @@
     "storm": {
         "title": "Буря",
         "description": "Акт III: Безумие в буре",
+        "vocabulary": [
+            {
+                "german": "der Sturm",
+                "russian": "буря",
+                "sentence": "Der wilde Sturm tobt draußen während König Lear sein Schicksal verflucht und gegen die Elemente schreit.",
+                "sentence_translation": "Дикая буря бушует снаружи в то время как Король Лир проклинает свою судьбу и кричит против стихий.",
+                "russian_hint": "сильная непогода",
+                "transcription": "[дер ШТУРМ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der wilde Sturm",
+                    "tobt draußen",
+                    "während König Lear sein Schicksal verflucht",
+                    "und gegen die Elemente schreit."
+                ],
+                "synonyms": [
+                    "ураган",
+                    "шторм",
+                    "непогода"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Wahnsinn",
+                "russian": "безумие",
+                "sentence": "König Lear verfällt langsam dem schrecklichen Wahnsinn während der wilden Sturmnacht auf der Heide.",
+                "sentence_translation": "Король Лир медленно впадает в ужасное безумие во время дикой штормовой ночи на пустоши.",
+                "russian_hint": "полная потеря разума",
+                "transcription": "[дер ВАН-зин]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "verfällt langsam",
+                    "dem schrecklichen Wahnsinn",
+                    "während der wilden Sturmnacht auf der Heide."
+                ],
+                "synonyms": [
+                    "сумасшествие",
+                    "помешательство",
+                    "умопомрачение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "toben",
+                "russian": "бушевать",
+                "sentence": "Die Naturgewalten toben wild um den wahnsinnigen König Lear der seine Kleider zerreißt.",
+                "sentence_translation": "Силы природы дико бушуют вокруг обезумевшего Короля Лира который рвёт свою одежду.",
+                "russian_hint": "неистовствовать, бесноваться",
+                "transcription": "[ТО-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die Naturgewalten",
+                    "toben wild",
+                    "um den wahnsinnigen König Lear",
+                    "der seine Kleider zerreißt."
+                ],
+                "synonyms": [
+                    "свирепствовать",
+                    "неистовствовать",
+                    "буйствовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Donner",
+                "russian": "гром",
+                "sentence": "Der laute Donner übertönt König Lears verzweifelte Schreie als er den Himmel herausfordert.",
+                "sentence_translation": "Громкий гром заглушает отчаянные крики Короля Лира когда он бросает вызов небесам.",
+                "russian_hint": "звук после молнии",
+                "transcription": "[дер ДО-нер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der laute Donner",
+                    "übertönt",
+                    "König Lears verzweifelte Schreie",
+                    "als er den Himmel herausfordert."
+                ],
+                "synonyms": [
+                    "громыхание",
+                    "раскат грома",
+                    "грохот"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Blitz",
+                "russian": "молния",
+                "sentence": "Die grellen Blitze erhellen König Lears verzerrtes Gesicht während er im Sturm sein Leid beklagt.",
+                "sentence_translation": "Яркие молнии освещают искажённое лицо Короля Лира когда он в буре оплакивает своё горе.",
+                "russian_hint": "электрический разряд",
+                "transcription": "[дер БЛИЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die grellen Blitze",
+                    "erhellen",
+                    "König Lears verzerrtes Gesicht",
+                    "während er im Sturm sein Leid beklagt."
+                ],
+                "synonyms": [
+                    "зарница",
+                    "разряд",
+                    "вспышка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schreien",
+                "russian": "кричать",
+                "sentence": "Der verzweifelte König Lear schreit seine Wut und seinen Schmerz in die tobende Sturmnacht hinaus.",
+                "sentence_translation": "Отчаявшийся Король Лир кричит свою ярость и свою боль в бушующую штормовую ночь.",
+                "russian_hint": "громко звать",
+                "transcription": "[ШРАЙ-ен]",
+                "themes": [
+                    "Folter",
+                    "Schmerz",
+                    "Sturm",
+                    "Wahnsinn",
+                    "blenden",
+                    "toben"
+                ],
+                "sentence_parts": [
+                    "Der verzweifelte König Lear",
+                    "schreit",
+                    "seine Wut und seinen Schmerz",
+                    "in die tobende Sturmnacht hinaus."
+                ],
+                "synonyms": [
+                    "вопить",
+                    "орать",
+                    "реветь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "nackt",
+                "russian": "голый",
+                "sentence": "König Lear reißt seine königlichen Gewänder ab und steht nackt im Sturm wie ein armer Bettler.",
+                "sentence_translation": "Король Лир срывает свои королевские одеяния и стоит голый в буре как бедный нищий.",
+                "russian_hint": "без одежды",
+                "transcription": "[НАКТ]",
+                "themes": [
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "nackt",
+                    "toben",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "reißt seine königlichen Gewänder ab",
+                    "und steht nackt im Sturm",
+                    "wie ein armer Bettler."
+                ],
+                "synonyms": [
+                    "обнажённый",
+                    "нагой",
+                    "раздетый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Chaos",
+                "russian": "хаос",
+                "sentence": "Das wilde Chaos der Natur spiegelt König Lears zerbrochenen Geisteszustand während er durch den Sturm irrt.",
+                "sentence_translation": "Дикий хаос природы отражает разрушенное состояние разума Короля Лира когда он блуждает в буре.",
+                "russian_hint": "полный беспорядок",
+                "transcription": "[дас ХА-ос]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Das wilde Chaos der Natur",
+                    "spiegelt",
+                    "König Lears zerbrochenen Geisteszustand",
+                    "während er durch den Sturm irrt."
+                ],
+                "synonyms": [
+                    "беспорядок",
+                    "сумятица",
+                    "неразбериха"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Sturm",
@@ -3125,29 +3916,29 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "буря",
+                    "гром",
                     "безумие",
                     "бушевать",
-                    "гром"
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "буря",
-                    "безумие",
                     "бушевать",
-                    "гром"
+                    "гром",
+                    "буря",
+                    "безумие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
+                    "гром",
+                    "кричать",
                     "хаос",
-                    "молния",
-                    "голый",
                     "бушевать"
                 ],
                 "correctIndex": 3
@@ -3155,19 +3946,19 @@
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "голый",
                     "буря",
-                    "кричать",
-                    "гром"
+                    "гром",
+                    "безумие",
+                    "кричать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "буря",
+                    "кричать",
                     "гром",
-                    "голый",
+                    "безумие",
                     "молния"
                 ],
                 "correctIndex": 3
@@ -3175,32 +3966,32 @@
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "гром",
                     "кричать",
-                    "молния",
-                    "буря"
+                    "гром",
+                    "безумие",
+                    "хаос"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "хаос",
-                    "голый",
                     "кричать",
+                    "гром",
+                    "голый",
                     "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
                     "буря",
-                    "бушевать",
-                    "хаос",
-                    "гром"
+                    "гром",
+                    "кричать",
+                    "хаос"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3306,6 +4097,210 @@
     "hut": {
         "title": "Хижина",
         "description": "Акт III: Встреча с Эдгаром",
+        "vocabulary": [
+            {
+                "german": "das Elend",
+                "russian": "нищета",
+                "sentence": "König Lear entdeckt das wahre Elend der Armen als er mit Edgar in der Hütte Zuflucht sucht.",
+                "sentence_translation": "Король Лир обнаруживает истинную нищету бедных когда он ищет убежище с Эдгаром в хижине.",
+                "russian_hint": "крайняя бедность",
+                "transcription": "[дас Э-ленд]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "entdeckt",
+                    "das wahre Elend der Armen",
+                    "als er mit Edgar in der Hütte Zuflucht sucht."
+                ],
+                "synonyms": [
+                    "бедность",
+                    "убожество",
+                    "лишения"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Bettler",
+                "russian": "нищий",
+                "sentence": "Edgar verkleidet als wahnsinniger Bettler Tom lehrt König Lear die Weisheit der völligen Armut.",
+                "sentence_translation": "Эдгар переодетый безумным нищим Томом учит Короля Лира мудрости полной бедности.",
+                "russian_hint": "просящий милостыню",
+                "transcription": "[дер БЕТ-лер]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm",
+                    "nackt",
+                    "verrückt"
+                ],
+                "sentence_parts": [
+                    "Edgar verkleidet als wahnsinniger Bettler Tom",
+                    "lehrt",
+                    "König Lear",
+                    "die Weisheit der völligen Armut."
+                ],
+                "synonyms": [
+                    "попрошайка",
+                    "бедняк",
+                    "оборванец"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "arm",
+                "russian": "бедный",
+                "sentence": "Der einst reiche König Lear wird arm wie die Ärmsten und versteht endlich ihr Leiden.",
+                "sentence_translation": "Некогда богатый Король Лир становится бедным как беднейшие и наконец понимает их страдания.",
+                "russian_hint": "не имеющий средств",
+                "transcription": "[АРМ]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "arm"
+                ],
+                "sentence_parts": [
+                    "Der einst reiche König Lear",
+                    "wird arm wie die Ärmsten",
+                    "und versteht endlich",
+                    "ihr Leiden."
+                ],
+                "synonyms": [
+                    "неимущий",
+                    "нищий",
+                    "обездоленный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "frieren",
+                "russian": "мёрзнуть",
+                "sentence": "König Lear und der Narr frieren bitterlich in der kalten Hütte während draußen der Sturm wütet.",
+                "sentence_translation": "Король Лир и Шут горько мёрзнут в холодной хижине в то время как снаружи бушует буря.",
+                "russian_hint": "страдать от холода",
+                "transcription": "[ФРИ-рен]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Freundschaft",
+                    "Sturm",
+                    "Wahnsinn",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "König Lear und der Narr",
+                    "frieren bitterlich",
+                    "in der kalten Hütte",
+                    "während draußen der Sturm wütet."
+                ],
+                "synonyms": [
+                    "зябнуть",
+                    "коченеть",
+                    "дрожать от холода"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hütte",
+                "russian": "хижина",
+                "sentence": "In der armseligen Hütte findet König Lear mehr Menschlichkeit als in seinen prächtigen Palästen.",
+                "sentence_translation": "В убогой хижине Король Лир находит больше человечности чем в своих роскошных дворцах.",
+                "russian_hint": "бедное жилище",
+                "transcription": "[ди ХЮ-те]",
+                "themes": [
+                    "Elend",
+                    "Erkenntnis",
+                    "Sturm",
+                    "arm",
+                    "frieren",
+                    "leiden"
+                ],
+                "sentence_parts": [
+                    "In der armseligen Hütte",
+                    "findet König Lear",
+                    "mehr Menschlichkeit",
+                    "als in seinen prächtigen Palästen."
+                ],
+                "synonyms": [
+                    "лачуга",
+                    "хибара",
+                    "домик"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leiden",
+                "russian": "страдать",
+                "sentence": "König Lear sieht wie die Armen leiden und bereut dass er als König ihre Not ignorierte.",
+                "sentence_translation": "Король Лир видит как бедные страдают и сожалеет что он как король игнорировал их нужду.",
+                "russian_hint": "испытывать боль",
+                "transcription": "[ЛАЙ-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear sieht",
+                    "wie die Armen leiden",
+                    "und bereut dass er als König",
+                    "ihre Not ignorierte."
+                ],
+                "synonyms": [
+                    "мучиться",
+                    "терпеть",
+                    "испытывать боль"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Narr",
+                "russian": "шут",
+                "sentence": "Der treue Narr bleibt bei König Lear in der Hütte und tröstet ihn mit bitteren Wahrheiten.",
+                "sentence_translation": "Верный Шут остаётся с Королём Лиром в хижине и утешает его горькими истинами.",
+                "russian_hint": "придворный комик",
+                "transcription": "[дер НАР]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der treue Narr",
+                    "bleibt bei König Lear in der Hütte",
+                    "und tröstet ihn",
+                    "mit bitteren Wahrheiten."
+                ],
+                "synonyms": [
+                    "дурак",
+                    "скоморох",
+                    "блазень"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Erkenntnis",
+                "russian": "познание",
+                "sentence": "Die schmerzhafte Erkenntnis seiner Blindheit kommt zu König Lear erst nachdem er alles verloren hat.",
+                "sentence_translation": "Болезненное познание своей слепоты приходит к Королю Лиру только после того как он потерял всё.",
+                "russian_hint": "понимание истины",
+                "transcription": "[ди ер-КЕНТ-нис]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die schmerzhafte Erkenntnis",
+                    "seiner Blindheit",
+                    "kommt zu König Lear erst",
+                    "nachdem er alles verloren hat."
+                ],
+                "synonyms": [
+                    "прозрение",
+                    "осознание",
+                    "понимание"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "das Elend",
@@ -3554,19 +4549,19 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "мёрзнуть",
-                    "нищий",
+                    "бедный",
                     "нищета",
-                    "бедный"
+                    "мёрзнуть",
+                    "нищий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
                     "мёрзнуть",
-                    "нищета",
                     "бедный",
+                    "нищета",
                     "нищий"
                 ],
                 "correctIndex": 3
@@ -3574,39 +4569,39 @@
             {
                 "question": "Что означает немецкое слово «arm»?",
                 "choices": [
-                    "бедный",
                     "мёрзнуть",
-                    "нищий",
-                    "хижина"
+                    "страдать",
+                    "бедный",
+                    "нищий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
+                    "хижина",
+                    "познание",
                     "мёрзнуть",
-                    "нищета",
-                    "нищий",
-                    "шут"
+                    "бедный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "мёрзнуть",
-                    "познание",
                     "нищета",
-                    "хижина"
+                    "страдать",
+                    "хижина",
+                    "бедный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "нищий",
-                    "нищета",
+                    "мёрзнуть",
                     "шут",
+                    "нищий",
                     "страдать"
                 ],
                 "correctIndex": 3
@@ -3614,22 +4609,22 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "нищета",
+                    "бедный",
                     "хижина",
-                    "шут",
-                    "нищий"
+                    "мёрзнуть",
+                    "шут"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "страдать",
+                    "бедный",
+                    "мёрзнуть",
                     "познание",
-                    "шут",
-                    "мёрзнуть"
+                    "хижина"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3735,6 +4730,205 @@
     "dover": {
         "title": "Дувр",
         "description": "Акт IV: Встреча с Корделией",
+        "vocabulary": [
+            {
+                "german": "erkennen",
+                "russian": "узнавать",
+                "sentence": "König Lear erkennt endlich seine treue Tochter Cordelia wieder nach seinem langen Wahnsinn in Dover.",
+                "sentence_translation": "Король Лир наконец узнаёт свою верную дочь Корделию снова после своего долгого безумия в Дувре.",
+                "russian_hint": "видеть знакомое",
+                "transcription": "[эр-КЕ-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "erkennt endlich",
+                    "seine treue Tochter Cordelia wieder",
+                    "nach seinem langen Wahnsinn in Dover."
+                ],
+                "synonyms": [
+                    "опознавать",
+                    "распознавать",
+                    "признавать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verstehen",
+                "russian": "понимать",
+                "sentence": "König Lear versteht zu spät dass nur Cordelia ihn wirklich liebte ohne Falschheit oder Lüge.",
+                "sentence_translation": "Король Лир понимает слишком поздно что только Корделия действительно любила его без фальши или лжи.",
+                "russian_hint": "осознавать смысл",
+                "transcription": "[фер-ШТЕ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "versteht zu spät",
+                    "dass nur Cordelia ihn wirklich liebte",
+                    "ohne Falschheit oder Lüge."
+                ],
+                "synonyms": [
+                    "постигать",
+                    "осознавать",
+                    "уразумевать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Wahrheit",
+                "russian": "правда",
+                "sentence": "Cordelia sprach die reine Wahrheit über ihre Liebe während ihre Schwestern König Lear belogen.",
+                "sentence_translation": "Корделия говорила чистую правду о своей любви в то время как её сёстры лгали Королю Лиру.",
+                "russian_hint": "истина без лжи",
+                "transcription": "[ди ВАР-хайт]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Cordelia",
+                    "sprach die reine Wahrheit",
+                    "über ihre Liebe",
+                    "während ihre Schwestern König Lear belogen."
+                ],
+                "synonyms": [
+                    "истина",
+                    "правдивость",
+                    "достоверность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Reue",
+                "russian": "раскаяние",
+                "sentence": "Die tiefe Reue über seine Blindheit quält König Lear als er vor Cordelia niederkniet.",
+                "sentence_translation": "Глубокое раскаяние в своей слепоте мучает Короля Лира когда он опускается на колени перед Корделией.",
+                "russian_hint": "сожаление о содеянном",
+                "transcription": "[ди РОЙ-е]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die tiefe Reue",
+                    "über seine Blindheit",
+                    "quält König Lear",
+                    "als er vor Cordelia niederkniet."
+                ],
+                "synonyms": [
+                    "покаяние",
+                    "сожаление",
+                    "угрызение совести"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Weisheit",
+                "russian": "мудрость",
+                "sentence": "Die bittere Weisheit kommt zu König Lear erst nachdem er durch Wahnsinn und Leiden gegangen ist.",
+                "sentence_translation": "Горькая мудрость приходит к Королю Лиру только после того как он прошёл через безумие и страдания.",
+                "russian_hint": "глубокое понимание",
+                "transcription": "[ди ВАЙС-хайт]",
+                "themes": [
+                    "Erbe",
+                    "Herrschaft",
+                    "Narr",
+                    "Neuanfang",
+                    "Trauer",
+                    "Weisheit",
+                    "Zukunft",
+                    "erkennen",
+                    "verstehen",
+                    "überleben"
+                ],
+                "sentence_parts": [
+                    "Die bittere Weisheit",
+                    "kommt zu König Lear erst",
+                    "nachdem er",
+                    "durch Wahnsinn und Leiden gegangen ist."
+                ],
+                "synonyms": [
+                    "премудрость",
+                    "разумность",
+                    "благоразумие"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vergeben",
+                "russian": "прощать",
+                "sentence": "Cordelia vergibt ihrem reuigen Vater König Lear sofort mit Tränen der Liebe und des Mitleids.",
+                "sentence_translation": "Корделия прощает своего кающегося отца Короля Лира сразу со слезами любви и сострадания.",
+                "russian_hint": "отпускать вину",
+                "transcription": "[фер-ГЕ-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Cordelia",
+                    "vergibt sofort",
+                    "ihrem reuigen Vater König Lear",
+                    "mit Tränen der Liebe und des Mitleids."
+                ],
+                "synonyms": [
+                    "извинять",
+                    "отпускать грехи",
+                    "миловать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Einsicht",
+                "russian": "прозрение",
+                "sentence": "Die späte Einsicht in seine tragischen Fehler kommt zu König Lear beim Wiedersehen mit Cordelia.",
+                "sentence_translation": "Позднее прозрение своих трагических ошибок приходит к Королю Лиру при встрече с Корделией.",
+                "russian_hint": "внезапное понимание",
+                "transcription": "[ди АЙН-зихт]",
+                "themes": [
+                    "Weisheit",
+                    "erkennen",
+                    "verstehen"
+                ],
+                "sentence_parts": [
+                    "Die späte Einsicht",
+                    "in seine tragischen Fehler",
+                    "kommt zu König Lear",
+                    "beim Wiedersehen mit Cordelia."
+                ],
+                "synonyms": [
+                    "озарение",
+                    "осознание",
+                    "просветление"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schuldig",
+                "russian": "виновный",
+                "sentence": "König Lear fühlt sich tief schuldig weil er Cordelia verstoßen und seinen falschen Töchtern vertraut hatte.",
+                "sentence_translation": "Король Лир чувствует себя глубоко виновным потому что отверг Корделию и доверился своим фальшивым дочерям.",
+                "russian_hint": "несущий вину",
+                "transcription": "[ШУЛЬ-диг]",
+                "themes": [
+                    "Weisheit",
+                    "erkennen",
+                    "verstehen"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "fühlt sich tief schuldig",
+                    "weil er Cordelia verstoßen",
+                    "und seinen falschen Töchtern vertraut hatte."
+                ],
+                "synonyms": [
+                    "повинный",
+                    "виноватый",
+                    "грешный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "erkennen",
@@ -3978,79 +5172,79 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "узнавать",
                     "правда",
                     "раскаяние",
-                    "понимать",
-                    "узнавать"
+                    "понимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
                     "правда",
-                    "раскаяние",
+                    "узнавать",
                     "понимать",
-                    "узнавать"
+                    "раскаяние"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "мудрость",
-                    "понимать",
+                    "прозрение",
+                    "узнавать",
                     "правда",
-                    "прозрение"
+                    "прощать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "прощать",
+                    "виновный",
                     "раскаяние",
-                    "понимать",
-                    "узнавать"
+                    "узнавать",
+                    "правда"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "виновный",
-                    "понимать",
-                    "мудрость",
-                    "раскаяние"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vergeben»?",
-                "choices": [
                     "узнавать",
-                    "прощать",
-                    "понимать",
-                    "мудрость"
+                    "мудрость",
+                    "виновный",
+                    "правда"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Einsicht»?",
+                "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "прозрение",
                     "прощать",
-                    "раскаяние",
-                    "виновный"
+                    "узнавать",
+                    "виновный",
+                    "мудрость"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Einsicht»?",
+                "choices": [
+                    "мудрость",
+                    "понимать",
+                    "правда",
+                    "прозрение"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
-                    "раскаяние",
                     "правда",
-                    "мудрость",
+                    "прощать",
+                    "узнавать",
                     "виновный"
                 ],
                 "correctIndex": 3
@@ -4159,6 +5353,209 @@
     "prison": {
         "title": "Тюрьма",
         "description": "Акт V: Финал трагедии",
+        "vocabulary": [
+            {
+                "german": "verzeihen",
+                "russian": "прощать",
+                "sentence": "König Lear und Cordelia verzeihen einander alles in ihrer letzten gemeinsamen Stunde im Gefängnis.",
+                "sentence_translation": "Король Лир и Корделия прощают друг другу всё в их последний совместный час в тюрьме.",
+                "russian_hint": "давать прощение",
+                "transcription": "[фер-ЦАЙ-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear und Cordelia",
+                    "verzeihen einander alles",
+                    "in ihrer letzten gemeinsamen Stunde",
+                    "im Gefängnis."
+                ],
+                "synonyms": [
+                    "извинять",
+                    "отпускать",
+                    "миловать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Tod",
+                "russian": "смерть",
+                "sentence": "Der grausame Tod nimmt Cordelia von König Lear kurz bevor sie beide gerettet werden könnten.",
+                "sentence_translation": "Жестокая смерть забирает Корделию у Короля Лира незадолго до того как они оба могли быть спасены.",
+                "russian_hint": "конец жизни",
+                "transcription": "[дер ТОД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Der grausame Tod",
+                    "nimmt Cordelia von König Lear",
+                    "kurz bevor sie beide",
+                    "gerettet werden könnten."
+                ],
+                "synonyms": [
+                    "кончина",
+                    "гибель",
+                    "уход"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "sterben",
+                "russian": "умирать",
+                "sentence": "König Lear stirbt vor Kummer als er seine tote Tochter Cordelia in seinen Armen hält.",
+                "sentence_translation": "Король Лир умирает от горя когда держит свою мёртвую дочь Корделию в своих руках.",
+                "russian_hint": "прекращать жить",
+                "transcription": "[ШТЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lear",
+                    "stirbt vor Kummer",
+                    "als er seine tote Tochter Cordelia",
+                    "in seinen Armen hält."
+                ],
+                "synonyms": [
+                    "погибать",
+                    "скончаться",
+                    "почить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Ende",
+                "russian": "конец",
+                "sentence": "Das tragische Ende von König Lear kommt als er neben seiner geliebten Cordelia zusammenbricht.",
+                "sentence_translation": "Трагический конец Короля Лира наступает когда он падает рядом со своей любимой Корделией.",
+                "russian_hint": "завершение всего",
+                "transcription": "[дас ЕН-де]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Das tragische Ende",
+                    "von König Lear kommt",
+                    "als er neben seiner geliebten Cordelia",
+                    "zusammenbricht."
+                ],
+                "synonyms": [
+                    "финал",
+                    "завершение",
+                    "исход"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Herz",
+                "russian": "сердце",
+                "sentence": "König Lears gebrochenes Herz kann den Verlust seiner einzigen wahren Tochter Cordelia nicht ertragen.",
+                "sentence_translation": "Разбитое сердце Короля Лира не может вынести потерю его единственной истинной дочери Корделии.",
+                "russian_hint": "орган чувств",
+                "transcription": "[дас ХЕРЦ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "König Lears gebrochenes Herz",
+                    "kann nicht ertragen",
+                    "den Verlust",
+                    "seiner einzigen wahren Tochter Cordelia."
+                ],
+                "synonyms": [
+                    "душа",
+                    "сердечко",
+                    "средоточие чувств"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Trauer",
+                "russian": "скорбь",
+                "sentence": "Die unendliche Trauer überwältigt König Lear als er Cordelias leblose Gestalt an sich drückt.",
+                "sentence_translation": "Бесконечная скорбь охватывает Короля Лира когда он прижимает к себе безжизненное тело Корделии.",
+                "russian_hint": "глубокая печаль",
+                "transcription": "[ди ТРАУ-ер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Die unendliche Trauer",
+                    "überwältigt König Lear",
+                    "als er Cordelias leblose Gestalt",
+                    "an sich drückt."
+                ],
+                "synonyms": [
+                    "печаль",
+                    "горе",
+                    "траур"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Abschied",
+                "russian": "прощание",
+                "sentence": "Der letzte Abschied zwischen König Lear und Cordelia wird zur herzzerreißendsten Szene der Tragödie.",
+                "sentence_translation": "Последнее прощание между Королём Лиром и Корделией становится самой душераздирающей сценой трагедии.",
+                "russian_hint": "последнее расставание",
+                "transcription": "[дер АБ-шид]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "Ungerechtigkeit",
+                    "Verbannung",
+                    "Zorn",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "Der letzte Abschied",
+                    "zwischen König Lear und Cordelia",
+                    "wird zur herzzerreißendsten Szene",
+                    "der Tragödie."
+                ],
+                "synonyms": [
+                    "расставание",
+                    "разлука",
+                    "прощальный час"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ewig",
+                "russian": "вечный",
+                "sentence": "König Lear glaubt dass ihre Liebe ewig bestehen wird selbst nach dem Tod im Jenseits.",
+                "sentence_translation": "Король Лир верит что их любовь вечно будет существовать даже после смерти в загробной жизни.",
+                "russian_hint": "без конца",
+                "transcription": "[Э-виг]",
+                "themes": [
+                    "Abschied",
+                    "Ende",
+                    "Opfer",
+                    "Tod",
+                    "ewig",
+                    "ewige Treue",
+                    "sterben",
+                    "verzeihen"
+                ],
+                "sentence_parts": [
+                    "König Lear glaubt",
+                    "dass ihre Liebe ewig bestehen wird",
+                    "selbst nach dem Tod",
+                    "im Jenseits."
+                ],
+                "synonyms": [
+                    "бесконечный",
+                    "непреходящий",
+                    "бессмертный"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "verzeihen",
@@ -4416,48 +5813,48 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "смерть",
                     "конец",
                     "умирать",
-                    "прощать"
+                    "прощать",
+                    "смерть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "прощать",
                     "конец",
-                    "умирать",
-                    "смерть"
+                    "прощать",
+                    "смерть",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "конец",
-                    "сердце",
                     "умирать",
+                    "прощание",
                     "прощать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "скорбь",
-                    "смерть",
                     "конец",
-                    "вечный"
+                    "прощание",
+                    "скорбь",
+                    "сердце"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
                     "вечный",
-                    "конец",
+                    "скорбь",
                     "сердце",
                     "умирать"
                 ],
@@ -4466,32 +5863,32 @@
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "скорбь",
-                    "вечный",
-                    "прощать",
-                    "прощание"
+                    "конец",
+                    "сердце",
+                    "умирать",
+                    "скорбь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "скорбь",
+                    "сердце",
                     "прощание",
-                    "смерть",
-                    "прощать"
+                    "вечный",
+                    "умирать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "вечный",
+                    "прощание",
                     "скорбь",
-                    "умирать",
-                    "сердце"
+                    "вечный",
+                    "умирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4600,6 +5997,9 @@ const characterId = "king_lear";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "преданность", "послушание", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["преданность", "послушание", "служить", "слуга"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["служить", "раболепный", "покорный", "преданность"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["слуга", "управляющий", "служить", "исполнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["исполнять", "послушание", "управляющий", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["управляющий", "послушание", "исполнять", "покорный"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["исполнять", "послушание", "раболепный", "покорный"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["раболепный", "преданность", "исполнять", "управляющий"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "гонец", "поручение", "спешка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["поручение", "спешка", "гонец", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["гонец", "спешка", "торопиться", "послание"], "correct_index": 1}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "поручение", "послание", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "передавать", "торопиться", "поручение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "передавать", "спешка", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["спешка", "гонец", "торопиться", "спешить"], "correct_index": 2}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["неуважение", "оскорбление", "оскорблять", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "неуважение", "оскорбление", "трусость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "оскорбление", "дерзкий", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["неуважение", "оскорбление", "оскорблять", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["неуважение", "трусливый", "высмеивать", "дерзкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «frech»?", "choices": ["неуважение", "высмеивать", "трусость", "дерзкий"], "correct_index": 3}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["трусливый", "трусость", "неуважение", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусливый", "оскорблять", "пренебрегать", "оскорбление"], "correct_index": 0}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпион", "скрытность", "предательство", "шпионить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "шпионить", "шпион", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпионить", "скрытность", "шпион", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["вынюхивать", "шпион", "подслушивать", "шпионить"], "correct_index": 3}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["выдавать", "подслушивать", "шпионить", "вынюхивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["шпионить", "подслушивать", "выдавать", "шпион"], "correct_index": 2}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "выдавать", "шпионить", "предательство"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "план", "коварство", "ковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["интрига", "коварство", "план", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["хитрый", "ловушка", "коварство", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварство", "обманывать", "ковать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["обманывать", "план", "хитрый", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварный", "обманывать", "интрига", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["план", "коварство", "интрига", "хитрый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["коварство", "ловушка", "ковать", "коварный"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследование", "гнаться", "преследовать", "охота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["охота", "преследовать", "гнаться", "преследование"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["выслеживать", "преследование", "охота", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["травить", "гнаться", "добыча", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["преследовать", "травить", "выслеживать", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["травить", "добыча", "преследование", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследовать", "добыча", "преследование", "выслеживать"], "correct_index": 1}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["поражение", "падать", "смерть", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "смерть", "трусость", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["проигрывать", "поражение", "жалкий", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "проигрывать", "жалкий", "трусость"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["падать", "поражение", "трусость", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["умолять", "поражение", "хныкать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["поражение", "умолять", "падать", "хныкать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["жалкий", "трусость", "умолять", "смерть"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["преданность", "слуга", "служить", "послушание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "преданность", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["преданность", "служить", "послушание", "исполнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["служить", "покорный", "послушание", "исполнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["управляющий", "послушание", "служить", "покорный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["исполнять", "служить", "покорный", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["раболепный", "покорный", "управляющий", "преданность"], "correct_index": 0}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["управляющий", "исполнять", "послушание", "служить"], "correct_index": 1}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["гонец", "спешка", "поручение", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["передавать", "поручение", "спешка", "гонец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешка", "гонец", "спешить", "поручение"], "correct_index": 0}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["спешка", "гонец", "поручение", "передавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешка", "передавать", "спешить", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "передавать", "спешить", "спешка"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["спешить", "передавать", "торопиться", "поручение"], "correct_index": 2}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорблять", "трусость", "оскорбление", "неуважение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["трусость", "неуважение", "оскорблять", "оскорбление"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["оскорбление", "трусливый", "трусость", "оскорблять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["оскорбление", "высмеивать", "оскорблять", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["неуважение", "трусость", "пренебрегать", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["дерзкий", "оскорбление", "пренебрегать", "высмеивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["пренебрегать", "неуважение", "оскорбление", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «feige»?", "choices": ["оскорблять", "трусливый", "трусость", "пренебрегать"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["скрытность", "предательство", "шпион", "шпионить"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпионить", "скрытность", "предательство", "шпион"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["скрытность", "выдавать", "шпион", "вынюхивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "шпион", "выдавать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["шпион", "выдавать", "подслушивать", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["подслушивать", "выдавать", "предательство", "скрытность"], "correct_index": 1}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["шпион", "вынюхивать", "выдавать", "подслушивать"], "correct_index": 1}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["коварство", "план", "ковать", "интрига"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "план", "коварство", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["обманывать", "коварство", "ловушка", "хитрый"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["обманывать", "ловушка", "ковать", "хитрый"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["интрига", "обманывать", "ковать", "ловушка"], "correct_index": 1}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["ловушка", "интрига", "коварство", "коварный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ковать", "ловушка", "хитрый", "коварный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ковать", "ловушка", "интрига", "план"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["гнаться", "преследовать", "преследование", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "охота", "преследовать", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "выслеживать", "гнаться", "травить"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["охота", "добыча", "преследование", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["преследование", "выслеживать", "преследовать", "травить"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["охота", "добыча", "выслеживать", "травить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["охота", "добыча", "травить", "преследование"], "correct_index": 1}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["трусость", "падать", "смерть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "падать", "смерть", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["трусость", "хныкать", "поражение", "умолять"], "correct_index": 2}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["поражение", "падать", "жалкий", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["проигрывать", "падать", "жалкий", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["хныкать", "трусость", "умолять", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["жалкий", "поражение", "умолять", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["смерть", "жалкий", "падать", "проигрывать"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,29 +662,29 @@
             <div class="quiz-phase-container active" data-phase="steward">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
@@ -694,31 +694,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
                             
@@ -726,31 +710,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
                             
@@ -758,33 +742,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,31 +797,15 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
                             
@@ -829,31 +813,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торопиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
                             
@@ -861,8 +877,24 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
@@ -877,38 +909,6 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торопиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                 
                 <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
             </div>
@@ -916,17 +916,17 @@
             <div class="quiz-phase-container" data-phase="insult">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -936,27 +936,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                             
@@ -968,77 +968,77 @@
                         <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «feige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «feige»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,63 +1051,15 @@
             <div class="quiz-phase-container" data-phase="spy">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
                             
@@ -1115,31 +1067,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
                             
@@ -1147,17 +1083,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,61 +1170,13 @@
             <div class="quiz-phase-container" data-phase="schemer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
@@ -1234,15 +1186,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
                             
@@ -1250,33 +1250,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1286,13 +1286,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,15 +1305,15 @@
             <div class="quiz-phase-container" data-phase="pursuer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
@@ -1321,15 +1321,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
@@ -1337,65 +1337,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1405,13 +1405,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1428,27 +1428,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1456,31 +1440,95 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
@@ -1488,65 +1536,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1568,6 +1568,174 @@
     "steward": {
         "title": "Управляющий",
         "description": "Акт I: Верный слуга Гонерильи",
+        "vocabulary": [
+            {
+                "german": "der Diener",
+                "russian": "слуга",
+                "sentence": "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus. Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "В зале госпожи Освальд выравнивает серебряные блюда вдоль длинного стола. Я черчу слово «слуга» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер ДИ-нер]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im Saal der Herrin richtet Oswald die silbernen Teller entlang der langen Tafel aus.",
+                    "Ich zeichne das Wort „der Diener“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "слуга"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Gehorsam",
+                "russian": "послушание",
+                "sentence": "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids. Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Перед зеркалом Освальд проверяет безупречную посадку дворецкого наряда. Я держу слово «послушание» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[дер ге-ХОР-зам]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Vor dem Spiegel prüft Oswald den makellosen Sitz des Dienerkleids.",
+                    "Ich halte das Wort „der Gehorsam“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "послушание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Ergebenheit",
+                "russian": "преданность",
+                "sentence": "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein. Ich presse das Wort „die Ergebenheit“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Среди бухгалтерских книг Освальд записывает каждую бочку вина. Я стискиваю слово «преданность» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ер-ГЕ-бен-хайт]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Zwischen Rechnungsbüchern notiert Oswald jedes Fass Wein.",
+                    "Ich presse das Wort „die Ergebenheit“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "преданность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "dienen",
+                "russian": "служить",
+                "sentence": "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords. Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen.",
+                "sentence_translation": "У входа во двор Освальд сдержанно кивает прибывающим лордам. Как тихая молитва слово «служить» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ДИ-нен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am Hofeingang begrüßt Oswald mit steifem Nicken die ankommenden Lords.",
+                    "Wie ein stilles Gebet legt sich das Wort „dienen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "служить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Verwalter",
+                "russian": "управляющий",
+                "sentence": "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle. Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten.",
+                "sentence_translation": "Под внимательным взглядом Гонерильи Освальд раздаёт дневные распоряжения. Твёрдым голосом я клянусь себе: слово «управляющий» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[дер фер-ВАЛЬ-тер]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Unter den wachsamen Augen Gonerils verteilt Oswald die Tagesbefehle.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „der Verwalter“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "управляющий"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ergeben",
+                "russian": "покорный",
+                "sentence": "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte. Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На кухонном пандусе Освальд проверяет свежие припасы. Эхо слова «покорный» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ер-ГЕ-бен]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Auf der Küchenrampe kontrolliert Oswald die frischen Vorräte.",
+                    "Das Echo des Wortes „ergeben“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "покорный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unterwürfig",
+                "russian": "раболепный",
+                "sentence": "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort. Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "Рядом с галереей предков Освальд смахивает последние пылинки. Я обнимаю слово «раболепный», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[УН-тер-вюр-фиг]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Neben der Ahnengalerie wischt Oswald letzte Staubkörner fort.",
+                    "Ich umarme das Wort „unterwürfig“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "раболепный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "befolgen",
+                "russian": "исполнять",
+                "sentence": "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz. Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus.",
+                "sentence_translation": "В конторе Освальд тщательно запечатывает королевскую корреспонденцию. Я глубоко вдыхаю и выпускаю только слово «исполнять».",
+                "russian_hint": "",
+                "transcription": "[бе-ФОЛЬ-ген]",
+                "themes": [
+                    "Diener",
+                    "Ergebenheit",
+                    "Gehorsam"
+                ],
+                "sentence_parts": [
+                    "Im Kontor versiegelt Oswald sorgsam die königliche Korrespondenz.",
+                    "Ich atme tief ein und lasse nur das Wort „befolgen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "исполнять",
+                    "erfüllen — тоже «исполнять»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Diener",
@@ -1783,82 +1951,82 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
+                    "преданность",
                     "слуга",
-                    "преданность",
-                    "послушание",
-                    "служить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Gehorsam»?",
-                "choices": [
-                    "преданность",
-                    "послушание",
                     "служить",
-                    "слуга"
+                    "послушание"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Gehorsam»?",
+                "choices": [
+                    "послушание",
+                    "преданность",
+                    "служить",
+                    "слуга"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
+                    "преданность",
                     "служить",
-                    "раболепный",
-                    "покорный",
-                    "преданность"
+                    "послушание",
+                    "исполнять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "слуга",
-                    "управляющий",
                     "служить",
+                    "покорный",
+                    "послушание",
                     "исполнять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "исполнять",
-                    "послушание",
                     "управляющий",
-                    "слуга"
+                    "послушание",
+                    "служить",
+                    "покорный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
-                    "управляющий",
-                    "послушание",
                     "исполнять",
-                    "покорный"
+                    "служить",
+                    "покорный",
+                    "послушание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "исполнять",
-                    "послушание",
                     "раболепный",
-                    "покорный"
+                    "покорный",
+                    "управляющий",
+                    "преданность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
-                    "раболепный",
-                    "преданность",
+                    "управляющий",
                     "исполнять",
-                    "управляющий"
+                    "послушание",
+                    "служить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -1949,6 +2117,154 @@
     "messenger": {
         "title": "Гонец",
         "description": "Акт I-II: Передаёт приказы",
+        "vocabulary": [
+            {
+                "german": "der Bote",
+                "russian": "гонец",
+                "sentence": "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir.",
+                "sentence_translation": "На пыльных дорогах Освальд подгоняет коня к большей скорости. Буря за окнами усиливает клятву: слово «гонец» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[дер БО-те]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf staubigen Straßen peitscht Oswald das Pferd zu größerer Eile.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „der Bote“ gehört mir."
+                ],
+                "synonyms": [
+                    "гонец",
+                    "посланник"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Auftrag",
+                "russian": "поручение",
+                "sentence": "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben. Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Перед закрытыми воротами Освальд предъявляет письмо, запечатанное воском. Холодный свет заставляет слово «поручение» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер АУФ-траг]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "Vor verschlossenen Toren zeigt Oswald das mit Wachs versiegelte Schreiben.",
+                    "Das kalte Licht lässt das Wort „der Auftrag“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "поручение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Eile",
+                "russian": "спешка",
+                "sentence": "In der Nacht rast Oswald mit einer Laterne als einzigem Stern. Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern.",
+                "sentence_translation": "Ночью Освальд мчится, освещаемый одной лишь латерной. Даже если мир распадается, слово «спешка» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди АЙ-ле]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "In der Nacht rast Oswald mit einer Laterne als einzigem Stern.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Eile“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "спешка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "überbringen",
+                "russian": "передавать",
+                "sentence": "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln. Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На пограничной заставе Освальд вручает приказ с высокомерной улыбкой. Эхо слова «передавать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ю-бер-БРИН-ген]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "Am Grenzposten überreicht Oswald den Befehl mit überheblichem Lächeln.",
+                    "Das Echo des Wortes „überbringen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "передавать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hasten",
+                "russian": "спешить",
+                "sentence": "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen. Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen.",
+                "sentence_translation": "Среди порванных знамён Освальд прикрывает письмо от дождя. Я шепчу стражам судьбы: слово «спешить» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ХАС-тен]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerrissenen Bannern schützt Oswald die Nachricht vor dem Regen.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „hasten“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "спешить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Botschaft",
+                "russian": "послание",
+                "sentence": "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult. Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На дворе Лира Освальд возвышает голос над шумом. Эхо слова «послание» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди БОТ-шафт]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hofe Lear erhebt Oswald die Stimme über den Tumult.",
+                    "Das Echo des Wortes „die Botschaft“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "послание"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "eilen",
+                "russian": "торопиться",
+                "sentence": "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen. Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten.",
+                "sentence_translation": "В тени конюшен Освальд тайно меняет запечатанные свитки. Твёрдым голосом я клянусь себе: слово «торопиться» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[АЙ-лен]",
+                "themes": [
+                    "Auftrag",
+                    "Bote",
+                    "Eile"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Stallungen tauscht Oswald heimlich versiegelte Rollen.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „eilen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "торопиться"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Bote",
@@ -2136,70 +2452,70 @@
             {
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
-                    "передавать",
                     "гонец",
-                    "поручение",
-                    "спешка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Auftrag»?",
-                "choices": [
-                    "поручение",
                     "спешка",
-                    "гонец",
+                    "поручение",
                     "передавать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Eile»?",
+                "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
-                    "гонец",
+                    "передавать",
+                    "поручение",
                     "спешка",
-                    "торопиться",
-                    "послание"
+                    "гонец"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «überbringen»?",
+                "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "передавать",
-                    "поручение",
-                    "послание",
-                    "торопиться"
+                    "спешка",
+                    "гонец",
+                    "спешить",
+                    "поручение"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «überbringen»?",
+                "choices": [
+                    "спешка",
+                    "гонец",
+                    "поручение",
+                    "передавать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
-                    "спешить",
+                    "спешка",
                     "передавать",
-                    "торопиться",
-                    "поручение"
+                    "спешить",
+                    "торопиться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
                     "послание",
                     "передавать",
-                    "спешка",
-                    "торопиться"
+                    "спешить",
+                    "спешка"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "спешка",
-                    "гонец",
+                    "спешить",
+                    "передавать",
                     "торопиться",
-                    "спешить"
+                    "поручение"
                 ],
                 "correctIndex": 2
             }
@@ -2281,6 +2597,181 @@
     "insult": {
         "title": "Оскорбитель",
         "description": "Акт II: Оскорбляет Лира",
+        "vocabulary": [
+            {
+                "german": "die Beleidigung",
+                "russian": "оскорбление",
+                "sentence": "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig. Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Перед постаревшим королём Освальд кланяется лишь на долю меньше. Эхо слова «оскорбление» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди бе-ЛАЙ-ди-гунг]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
+                "sentence_parts": [
+                    "Vor dem gealterten König verneigt sich Oswald nur einen Hauch zu wenig.",
+                    "Das Echo des Wortes „die Beleidigung“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "оскорбление"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Respektlosigkeit",
+                "russian": "неуважение",
+                "sentence": "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab. Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "В проёме ворот Освальд преграждает путь поднятым жезлом. Я держу слово «неуважение» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди рес-ПЕКТ-ло-зиг-кайт]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
+                "sentence_parts": [
+                    "Am Torbogen blockiert Oswald den Weg mit erhobenem Stab.",
+                    "Ich halte das Wort „die Respektlosigkeit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "неуважение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Feigheit",
+                "russian": "трусость",
+                "sentence": "Zwischen entrüsteten Rittern rollt Oswald mit den Augen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig.",
+                "sentence_translation": "Среди возмущённых рыцарей Освальд закатывает глаза. Каждой клеткой тела я обещаю: слово «трусость» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди ФАЙГ-хайт]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Niederlage",
+                    "Respektlosigkeit",
+                    "Tod"
+                ],
+                "sentence_parts": [
+                    "Zwischen entrüsteten Rittern rollt Oswald mit den Augen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Feigheit“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "трусость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "beleidigen",
+                "russian": "оскорблять",
+                "sentence": "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel. Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На лестнице Освальд стряхивает воображаемую пыль с плаща Лира. Я держу слово «оскорблять» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[бе-ЛАЙ-ди-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der Treppe wischt Oswald imaginären Staub von Lears Mantel.",
+                    "Ich halte das Wort „beleidigen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "оскорблять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verhöhnen",
+                "russian": "высмеивать",
+                "sentence": "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung. Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Рядом с холодным взглядом Гонерильи Освальд шепчет едкое замечание. Холодный свет заставляет слово «высмеивать» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[фер-ХЁ-нен]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Neben Gonerils kühlen Blick flüstert Oswald eine spitze Bemerkung.",
+                    "Das kalte Licht lässt das Wort „verhöhnen“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "высмеивать",
+                    "насмехаться",
+                    "spotten — тоже «насмехаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "frech",
+                "russian": "дерзкий",
+                "sentence": "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr. Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern.",
+                "sentence_translation": "На дворе Освальд скрестив руки сопротивляется любой просьбе. Даже если мир распадается, слово «дерзкий» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ФРЕХ]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
+                "sentence_parts": [
+                    "Auf dem Hof setzt Oswald sich mit verschränkten Armen gegen jede Bitte zur Wehr.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „frech“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "дерзкий"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "missachten",
+                "russian": "пренебрегать",
+                "sentence": "Im Flur stößt Oswald den alten König absichtlich zur Seite. Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig.",
+                "sentence_translation": "В коридоре Освальд нарочно отталкивает старого короля в сторону. Каждой клеткой тела я обещаю: слово «пренебрегать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[МИС-ах-тен]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
+                "sentence_parts": [
+                    "Im Flur stößt Oswald den alten König absichtlich zur Seite.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „missachten“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "пренебрегать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "feige",
+                "russian": "трусливый",
+                "sentence": "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit. Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На балконе Освальд громко смеётся над беспомощностью Лира. Я держу слово «трусливый» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ФАЙ-ге]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon lacht Oswald laut über Lears Hilflosigkeit.",
+                    "Ich halte das Wort „feige“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "трусливый"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Beleidigung",
@@ -2501,40 +2992,40 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "неуважение",
-                    "оскорбление",
                     "оскорблять",
-                    "трусость"
+                    "трусость",
+                    "оскорбление",
+                    "неуважение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорблять",
+                    "трусость",
                     "неуважение",
-                    "оскорбление",
-                    "трусость"
+                    "оскорблять",
+                    "оскорбление"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "трусость",
                     "оскорбление",
-                    "дерзкий",
+                    "трусливый",
+                    "трусость",
                     "оскорблять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
-                    "неуважение",
                     "оскорбление",
+                    "высмеивать",
                     "оскорблять",
-                    "пренебрегать"
+                    "трусость"
                 ],
                 "correctIndex": 2
             },
@@ -2542,41 +3033,41 @@
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
                     "неуважение",
-                    "трусливый",
-                    "высмеивать",
-                    "дерзкий"
+                    "трусость",
+                    "пренебрегать",
+                    "высмеивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frech»?",
                 "choices": [
-                    "неуважение",
-                    "высмеивать",
-                    "трусость",
-                    "дерзкий"
+                    "дерзкий",
+                    "оскорбление",
+                    "пренебрегать",
+                    "высмеивать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "трусливый",
-                    "трусость",
+                    "пренебрегать",
                     "неуважение",
-                    "пренебрегать"
+                    "оскорбление",
+                    "оскорблять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "трусливый",
                     "оскорблять",
-                    "пренебрегать",
-                    "оскорбление"
+                    "трусливый",
+                    "трусость",
+                    "пренебрегать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2666,6 +3157,156 @@
     "spy": {
         "title": "Шпион",
         "description": "Акт III: Шпионит за всеми",
+        "vocabulary": [
+            {
+                "german": "der Spion",
+                "russian": "шпион",
+                "sentence": "Im Dunkel des Treppenhauses hält Oswald den Atem an, um Gespräche zu belauschen. Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen.",
+                "sentence_translation": "В темноте лестницы Освальд задерживает дыхание, подслушивая разговоры. Как тихая молитва слово «шпион» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[дер шпи-ОН]",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
+                "sentence_parts": [
+                    "Im Dunkel des Treppenhauses hält Oswald den Atem an,",
+                    "um Gespräche zu belauschen.",
+                    "Wie ein stilles Gebet legt sich das Wort „der Spion“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "шпион"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Verrat",
+                "russian": "предательство",
+                "sentence": "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort. Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "За тяжёлыми портьерами Освальд записывает каждое прошептанное слово. Холодный свет заставляет слово «предательство» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[дер фер-РАТ]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Hinter schweren Vorhängen notiert Oswald jedes geflüsterte Wort.",
+                    "Das kalte Licht lässt das Wort „der Verrat“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "предательство",
+                    "измена"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Heimlichkeit",
+                "russian": "скрытность",
+                "sentence": "Auf den Mauern späht Oswald nach Reitern am Horizont. Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "На стенах Освальд высматривает всадников на горизонте. Я держу слово «скрытность» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ХАЙМ-лих-кайт]",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
+                "sentence_parts": [
+                    "Auf den Mauern späht Oswald nach Reitern am Horizont.",
+                    "Ich halte das Wort „die Heimlichkeit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "скрытность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "spionieren",
+                "russian": "шпионить",
+                "sentence": "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke. Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Среди кухонных служанок Освальд обменивает слухи на медяки. Я держу слово «шпионить» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[шпи-о-НИ-рен]",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
+                "sentence_parts": [
+                    "Zwischen Küchenmägden tauscht Oswald Gerüchte gegen Kupferstücke.",
+                    "Ich halte das Wort „spionieren“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "шпионить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "lauschen",
+                "russian": "подслушивать",
+                "sentence": "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir.",
+                "sentence_translation": "При свете свечи Освальд вычерчивает тайные пути на пергаменте. Буря за окнами усиливает клятву: слово «подслушивать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ЛАУ-шен]",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
+                "sentence_parts": [
+                    "Im Kerzenlicht zeichnet Oswald geheime Wege auf Pergament.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „lauschen“ gehört mir."
+                ],
+                "synonyms": [
+                    "подслушивать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verraten",
+                "russian": "выдавать",
+                "sentence": "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus. Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Под окном Реганы Освальд глубоко склоняется в ночную тьму. Я вывожу слово «выдавать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[фер-РА-тен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter dem Fenster von Regan beugt Oswald sich tief in die Nacht hinaus.",
+                    "Ich zeichne das Wort „verraten“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "предавать",
+                    "выдавать",
+                    "ausliefern — тоже «выдавать»",
+                    "verheiraten — тоже «выдавать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schnüffeln",
+                "russian": "вынюхивать",
+                "sentence": "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten. Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Перед покоями Гонерильи Освальд шёпотом передаёт собранные вести. Я черчу слово «вынюхивать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ШНЮФ-фельн]",
+                "themes": [
+                    "Heimlichkeit",
+                    "Spion",
+                    "Verrat"
+                ],
+                "sentence_parts": [
+                    "Vor Gonerils Gemach übergibt Oswald flüsternd die gesammelten Nachrichten.",
+                    "Ich zeichne das Wort „schnüffeln“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "вынюхивать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Spion",
@@ -2857,72 +3498,72 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
-                    "шпион",
                     "скрытность",
                     "предательство",
+                    "шпион",
                     "шпионить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "скрытность",
-                    "шпионить",
-                    "шпион",
-                    "предательство"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Heimlichkeit»?",
-                "choices": [
                     "шпионить",
                     "скрытность",
-                    "шпион",
-                    "предательство"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «spionieren»?",
-                "choices": [
-                    "вынюхивать",
-                    "шпион",
-                    "подслушивать",
-                    "шпионить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «lauschen»?",
-                "choices": [
-                    "выдавать",
-                    "подслушивать",
-                    "шпионить",
-                    "вынюхивать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verraten»?",
-                "choices": [
-                    "шпионить",
-                    "подслушивать",
-                    "выдавать",
+                    "предательство",
                     "шпион"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «schnüffeln»?",
+                "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "вынюхивать",
+                    "скрытность",
                     "выдавать",
+                    "шпион",
+                    "вынюхивать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «spionieren»?",
+                "choices": [
                     "шпионить",
+                    "шпион",
+                    "выдавать",
                     "предательство"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «lauschen»?",
+                "choices": [
+                    "шпион",
+                    "выдавать",
+                    "подслушивать",
+                    "предательство"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verraten»?",
+                "choices": [
+                    "подслушивать",
+                    "выдавать",
+                    "предательство",
+                    "скрытность"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schnüffeln»?",
+                "choices": [
+                    "шпион",
+                    "вынюхивать",
+                    "выдавать",
+                    "подслушивать"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3003,6 +3644,186 @@
     "schemer": {
         "title": "Интриган",
         "description": "Акт IV: Плетёт интриги",
+        "vocabulary": [
+            {
+                "german": "die Intrige",
+                "russian": "интрига",
+                "sentence": "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften. Ich presse das Wort „die Intrige“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В писчей комнате Освальд плетёт сеть противоречивых посланий. Я стискиваю слово «интрига» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ин-ТРИ-ге]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "In der Schreibstube entwirft Oswald ein Netz aus widersprüchlichen Botschaften.",
+                    "Ich presse das Wort „die Intrige“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "интрига",
+                    "die Affäre — тоже «интрига»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Plan",
+                "russian": "план",
+                "sentence": "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament. Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Рядом с ложем Гонерильи Освальд тайком выводит два имени на пергаменте. Я черчу слово «план» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[дер ПЛАН]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "beschuldigen",
+                    "fälschen",
+                    "intrigieren"
+                ],
+                "sentence_parts": [
+                    "Neben Gonerils Lager zeichnet Oswald heimlich zwei Namen auf ein Pergament.",
+                    "Ich zeichne das Wort „der Plan“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "план"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Hinterlist",
+                "russian": "коварство",
+                "sentence": "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken. Ich presse das Wort „die Hinterlist“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На садовой террасе Освальд сжигает улики в бронзовой чаше. Я стискиваю слово «коварство» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ХИН-тер-лист]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
+                "sentence_parts": [
+                    "Auf der Gartenterrasse verbrennt Oswald Beweise im bronzezeitigen Becken.",
+                    "Ich presse das Wort „die Hinterlist“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "коварство"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "schmieden",
+                "russian": "ковать",
+                "sentence": "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter. Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В конюшне Освальд шепчет ложные приказы в уши всадников. Я обнимаю слово «ковать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ШМИ-ден]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
+                "sentence_parts": [
+                    "Im Stall flüstert Oswald falsche Befehle in die Ohren der Reiter.",
+                    "Ich umarme das Wort „schmieden“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "ковать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hintergehen",
+                "russian": "обманывать",
+                "sentence": "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde. Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "Перед слугами Реганы Освальд прячет письма в корме лошадей. Эхо слова «обманывать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ХИН-тер-ге-ен]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
+                "sentence_parts": [
+                    "Vor Regans Dienern versteckt Oswald die Briefe im Futter der Pferde.",
+                    "Das Echo des Wortes „hintergehen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "обманывать",
+                    "betrügen — тоже «обманывать»",
+                    "täuschen — тоже «обманывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "tückisch",
+                "russian": "коварный",
+                "sentence": "Unter der Laube formt Oswald aus Wachs ein neues Siegel. Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern.",
+                "sentence_translation": "Под беседкой Освальд отливает из воска новую печать. Даже если мир распадается, слово «коварный» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ТЮ-киш]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
+                "sentence_parts": [
+                    "Unter der Laube formt Oswald aus Wachs ein neues Siegel.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „tückisch“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "коварный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verschlagen",
+                "russian": "хитрый",
+                "sentence": "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen. Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "В полночный перерыв Освальд раздаёт зашифрованные записки. Эхо слова «хитрый» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[фер-ШЛАГ-ен]",
+                "themes": [
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan"
+                ],
+                "sentence_parts": [
+                    "In der Mitternachtspause verteilt Oswald verschlüsselte Notizen.",
+                    "Das Echo des Wortes „verschlagen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "хитрый"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Falle",
+                "russian": "ловушка",
+                "sentence": "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen. Ich presse das Wort „die Falle“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "На столе с картами Освальд переставляет фигурки, будто это живые люди. Я стискиваю слово «ловушка» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ФА-ле]",
+                "themes": [
+                    "Brief",
+                    "Hinterlist",
+                    "Intrige",
+                    "Plan",
+                    "glauben",
+                    "täuschen"
+                ],
+                "sentence_parts": [
+                    "Auf dem Kartentisch verschiebt Oswald Figuren, als wären es echte Menschen.",
+                    "Ich presse das Wort „die Falle“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "ловушка"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Intrige",
@@ -3229,80 +4050,80 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "интрига",
-                    "план",
                     "коварство",
-                    "ковать"
+                    "план",
+                    "ковать",
+                    "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "интрига",
-                    "коварство",
+                    "ковать",
                     "план",
-                    "ковать"
+                    "коварство",
+                    "интрига"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "хитрый",
-                    "ловушка",
+                    "обманывать",
                     "коварство",
-                    "ковать"
+                    "ловушка",
+                    "хитрый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "коварство",
                     "обманывать",
+                    "ловушка",
                     "ковать",
-                    "интрига"
+                    "хитрый"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
+                    "интрига",
                     "обманывать",
-                    "план",
-                    "хитрый",
+                    "ковать",
                     "ловушка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "коварный",
-                    "обманывать",
+                    "ловушка",
                     "интрига",
-                    "план"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verschlagen»?",
-                "choices": [
-                    "план",
                     "коварство",
-                    "интрига",
-                    "хитрый"
+                    "коварный"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verschlagen»?",
+                "choices": [
+                    "ковать",
+                    "ловушка",
+                    "хитрый",
+                    "коварный"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "коварство",
-                    "ловушка",
                     "ковать",
-                    "коварный"
+                    "ловушка",
+                    "интрига",
+                    "план"
                 ],
                 "correctIndex": 1
             }
@@ -3397,6 +4218,157 @@
     "pursuer": {
         "title": "Преследователь",
         "description": "Акт IV: Преследует Глостера",
+        "vocabulary": [
+            {
+                "german": "die Verfolgung",
+                "russian": "преследование",
+                "sentence": "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder. Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig.",
+                "sentence_translation": "С натянутым арбалетом Освальд прочёсывает ночные поля. Каждой клеткой тела я обещаю: слово «преследование» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ди фер-ФОЛЬ-гунг]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
+                "sentence_parts": [
+                    "Mit gespannter Armbrust durchstreift Oswald die nächtlichen Felder.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „die Verfolgung“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "преследование"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Jagd",
+                "russian": "охота",
+                "sentence": "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen. Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На прибрежной тропе Освальд высматривает следы бегущего графа. Эхо слова «охота» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди ЯГДТ]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
+                "sentence_parts": [
+                    "Auf dem Küstenpfad späht Oswald nach Spuren des fliehenden Grafen.",
+                    "Das Echo des Wortes „die Jagd“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "охота"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verfolgen",
+                "russian": "преследовать",
+                "sentence": "Zwischen Dornenhecken zückt Oswald das versteckte Messer. Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Среди колючих кустов Освальд выхватывает спрятанный нож. Моё дыхание рисует слово «преследовать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-ФОЛЬ-ген]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen Dornenhecken zückt Oswald das versteckte Messer.",
+                    "Mein Atem zeichnet das Wort „verfolgen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "преследовать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "jagen",
+                "russian": "гнаться",
+                "sentence": "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir.",
+                "sentence_translation": "У болотной ямы Освальд проверяет глубину наконечником копья. Буря за окнами усиливает клятву: слово «гнаться» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[Я-ген]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung",
+                    "bereuen",
+                    "verfluchen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Am Moorloch testet Oswald die Tiefe mit der Spitze der Lanze.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „jagen“ gehört mir."
+                ],
+                "synonyms": [
+                    "гнаться",
+                    "гнать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "aufspüren",
+                "russian": "выслеживать",
+                "sentence": "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde. Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen.",
+                "sentence_translation": "У заброшенного двора Освальд прислушивается к сопению коней. Как тихая молитва слово «выслеживать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[АУФ-шпю-рен]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
+                "sentence_parts": [
+                    "Vor einem verlassenen Hof horcht Oswald auf das Schnaufen der Pferde.",
+                    "Wie ein stilles Gebet legt sich das Wort „aufspüren“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "выслеживать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hetzen",
+                "russian": "травить",
+                "sentence": "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd. Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Под знаменем Реганы Освальд подгоняет солдат к более быстрой охоте. Я держу слово «травить» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ХЕ-цен]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
+                "sentence_parts": [
+                    "Unter Regans Banner motiviert Oswald die Soldaten zu schnellerer Jagd.",
+                    "Ich halte das Wort „hetzen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "травить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Beute",
+                "russian": "добыча",
+                "sentence": "Auf den Klippen über Dover späht Oswald in die graue Ferne. Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten.",
+                "sentence_translation": "На скалах над Дувром Освальд вглядывается в серую даль. Твёрдым голосом я клянусь себе: слово «добыча» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди БОЙ-те]",
+                "themes": [
+                    "Gefahr",
+                    "Jagd",
+                    "Verfolgung"
+                ],
+                "sentence_parts": [
+                    "Auf den Klippen über Dover späht Oswald in die graue Ferne.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Beute“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "добыча"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Verfolgung",
@@ -3589,70 +4561,70 @@
             {
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
-                    "преследование",
                     "гнаться",
                     "преследовать",
+                    "преследование",
                     "охота"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
+                    "гнаться",
                     "охота",
                     "преследовать",
-                    "гнаться",
-                    "преследование"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verfolgen»?",
-                "choices": [
-                    "выслеживать",
-                    "преследование",
-                    "охота",
-                    "преследовать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «jagen»?",
-                "choices": [
-                    "травить",
-                    "гнаться",
-                    "добыча",
                     "преследование"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «aufspüren»?",
+                "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "преследовать",
-                    "травить",
                     "выслеживать",
-                    "преследование"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «hetzen»?",
-                "choices": [
-                    "травить",
-                    "добыча",
-                    "преследование",
-                    "преследовать"
+                    "гнаться",
+                    "травить"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Beute»?",
+                "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "преследовать",
+                    "охота",
                     "добыча",
                     "преследование",
-                    "выслеживать"
+                    "гнаться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «aufspüren»?",
+                "choices": [
+                    "преследование",
+                    "выслеживать",
+                    "преследовать",
+                    "травить"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «hetzen»?",
+                "choices": [
+                    "охота",
+                    "добыча",
+                    "выслеживать",
+                    "травить"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Beute»?",
+                "choices": [
+                    "охота",
+                    "добыча",
+                    "травить",
+                    "преследование"
                 ],
                 "correctIndex": 1
             }
@@ -3734,6 +4706,184 @@
     "coward_death": {
         "title": "Смерть труса",
         "description": "Акт IV: Убит Эдгаром",
+        "vocabulary": [
+            {
+                "german": "der Tod",
+                "russian": "смерть",
+                "sentence": "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts. Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В туманном лесу Освальд падает навзничь перед клинком Эдгара. Моё дыхание рисует слово «смерть» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дер ТОД]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Im dunstigen Wald stürzt Oswald vor Edgars Klinge rückwärts.",
+                    "Mein Atem zeichnet das Wort „der Tod“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "смерть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Feigheit",
+                "russian": "трусость",
+                "sentence": "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade. Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У трухлявого дерева Освальд вздымает руки, умоляя о пощаде. Я держу слово «трусость» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди ФАЙГ-хайт]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Niederlage",
+                    "Respektlosigkeit",
+                    "Tod"
+                ],
+                "sentence_parts": [
+                    "Neben einem morschen Baum bittet Oswald mit erhobenen Händen um Gnade.",
+                    "Ich halte das Wort „die Feigheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "трусость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Niederlage",
+                "russian": "поражение",
+                "sentence": "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert. Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Лежа на земле, Освальд тщетно ищет потерянный меч. Я держу слово «поражение» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди НИ-дер-ла-ге]",
+                "themes": [
+                    "Duell",
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "bereuen",
+                    "fallen"
+                ],
+                "sentence_parts": [
+                    "Am Boden liegend tastet Oswald vergeblich nach dem verlorenen Schwert.",
+                    "Ich halte das Wort „die Niederlage“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "поражение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "fallen",
+                "russian": "падать",
+                "sentence": "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus. Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen.",
+                "sentence_translation": "Перед суровым взглядом Эдгара Освальд скользит на мокрой листве. Как тихая молитва слово «падать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ФА-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Vor Edgars ernster Miene rutscht Oswald im nassen Laub aus.",
+                    "Wie ein stilles Gebet legt sich das Wort „fallen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "падать",
+                    "stürzen — тоже «падать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "unterliegen",
+                "russian": "проигрывать",
+                "sentence": "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte. Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Под холодным дождём Освальд лепечет последние оправдания. Моё дыхание рисует слово «проигрывать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ун-тер-ЛИ-ген]",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
+                "sentence_parts": [
+                    "Unter einem kalten Regen stammelt Oswald letzte Ausflüchte.",
+                    "Mein Atem zeichnet das Wort „unterliegen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "проигрывать",
+                    "verlieren — тоже «проигрывать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "wimmern",
+                "russian": "хныкать",
+                "sentence": "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung. Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter.",
+                "sentence_translation": "В тени деревьев Освальд слишком поздно осознаёт справедливое возмездие. Я обнимаю слово «хныкать», будто это единственный союзник.",
+                "russian_hint": "",
+                "transcription": "[ВИМ-мерн]",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der Bäume erkennt Oswald zu spät die gerechte Vergeltung.",
+                    "Ich umarme das Wort „wimmern“, als wäre es mein einziger Verbündeter."
+                ],
+                "synonyms": [
+                    "хныкать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "betteln",
+                "russian": "умолять",
+                "sentence": "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache. Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На лесной земле дыхание Освальд гаснет без почётного караула. Я черчу слово «умолять» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[БЕ-тельн]",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod",
+                    "Verzweiflung",
+                    "verlassen",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Auf dem Waldboden erlischt Oswalds Atem ohne Ehrenwache.",
+                    "Ich zeichne das Wort „betteln“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "умолять",
+                    "просить",
+                    "bitten — тоже «просить»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erbärmlich",
+                "russian": "жалкий",
+                "sentence": "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm. Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Рядом с оброненным письмом Освальд неподвижно лежит в грязи. Холодный свет заставляет слово «жалкий» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ер-БЕРМ-лих]",
+                "themes": [
+                    "Feigheit",
+                    "Niederlage",
+                    "Tod"
+                ],
+                "sentence_parts": [
+                    "Neben dem fallengelassenen Brief liegt Oswald reglos im Schlamm.",
+                    "Das kalte Licht lässt das Wort „erbärmlich“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "жалкий"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "der Tod",
@@ -3962,82 +5112,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "поражение",
+                    "трусость",
                     "падать",
                     "смерть",
-                    "трусость"
+                    "поражение"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
+                    "трусость",
                     "падать",
                     "смерть",
-                    "трусость",
                     "поражение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "проигрывать",
-                    "поражение",
-                    "жалкий",
-                    "падать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «fallen»?",
-                "choices": [
-                    "падать",
-                    "проигрывать",
-                    "жалкий",
-                    "трусость"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «unterliegen»?",
-                "choices": [
-                    "падать",
-                    "поражение",
                     "трусость",
-                    "проигрывать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «wimmern»?",
-                "choices": [
-                    "умолять",
-                    "поражение",
                     "хныкать",
-                    "смерть"
+                    "поражение",
+                    "умолять"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «betteln»?",
+                "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
                     "поражение",
-                    "умолять",
                     "падать",
-                    "хныкать"
+                    "жалкий",
+                    "смерть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «erbärmlich»?",
+                "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
+                    "проигрывать",
+                    "падать",
                     "жалкий",
-                    "трусость",
-                    "умолять",
-                    "смерть"
+                    "поражение"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «wimmern»?",
+                "choices": [
+                    "хныкать",
+                    "трусость",
+                    "умолять",
+                    "поражение"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «betteln»?",
+                "choices": [
+                    "жалкий",
+                    "поражение",
+                    "умолять",
+                    "трусость"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «erbärmlich»?",
+                "choices": [
+                    "смерть",
+                    "жалкий",
+                    "падать",
+                    "проигрывать"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4130,6 +5280,9 @@ const characterId = "oswald";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["состязаться", "фальшь", "притворяться", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "фальшь", "притворяться", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["выманивать", "состязаться", "фальшь", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["фальшь", "хитрость", "разыгрывать", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["состязаться", "разыгрывать", "притворяться", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "превосходить", "фальшь", "алчность"], "correct_index": 0}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["алчность", "хитрость", "превосходить", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "превосходить", "выманивать", "притворяться"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["делить", "планировать", "заговорить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["делить", "заговорить", "союз", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «planen»?", "choices": ["сговор", "заговорить", "союз", "планировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["планировать", "договариваться", "заговорить", "делить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["сговор", "планировать", "стратегия", "заговорить"], "correct_index": 0}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["заговорить", "договариваться", "союз", "стратегия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "сговор", "договариваться", "заговорить"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "насмехаться", "пытать", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["пытать", "насмехаться", "злоба", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["пытать", "злоба", "отвергать", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жёсткость", "пытать", "злоба", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["унижать", "отвергать", "злоба", "жестоко обращаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "жестоко обращаться", "жёсткость", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["злоба", "насмехаться", "жестоко обращаться", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["унижать", "жестоко обращаться", "жестокость", "злоба"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["наслаждаться", "ослеплять", "садизм", "выкалывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "садизм", "наслаждаться", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["выкалывать", "брутальность", "наслаждаться", "растаптывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "выкалывать", "садизм", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "пытка", "брутальность", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["пытка", "беспощадный", "выкалывать", "брутальность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["выкалывать", "садизм", "растаптывать", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "растаптывать", "беспощадный", "ослеплять"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вожделение", "вдова", "вожделеть", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "вожделеть", "соблазнять", "вдова"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вдова", "вожделение", "соблазнять", "похоть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["соблазнять", "добиваться", "вожделение", "заманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "вожделение", "вдова", "похоть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "соблазнять", "вдова", "заманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «werben»?", "choices": ["похоть", "вожделеть", "вдова", "добиваться"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["ненавидеть", "угрожать", "соревноваться", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["соперничество", "ненавидеть", "соревноваться", "угрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соревноваться", "подозревать", "бороться", "угрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["не доверять", "соревноваться", "бороться", "соперничество"], "correct_index": 3}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["соперничество", "подозревать", "бороться", "соревноваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["ненавидеть", "угрожать", "подозревать", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["подозревать", "ненавидеть", "бороться", "угрожать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["страдать", "мучение", "отравленный", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "издыхать", "страдать", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклинать", "издыхать", "рок", "мучение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["расплачиваться", "издыхать", "проклинать", "мучение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["рок", "издыхать", "страдать", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["издыхать", "расплачиваться", "мучение", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["расплачиваться", "издыхать", "рок", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклятый", "издыхать", "мучение", "отравленный"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "фальшь", "состязаться", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["состязаться", "притворяться", "превосходить", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["фальшь", "разыгрывать", "состязаться", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["состязаться", "притворяться", "фальшь", "алчность"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["алчность", "выманивать", "фальшь", "разыгрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "выманивать", "превосходить", "разыгрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["алчность", "фальшь", "превосходить", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["алчность", "превосходить", "выманивать", "хитрость"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["заговорить", "делить", "союз", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["заговорить", "планировать", "союз", "делить"], "correct_index": 3}, {"question": "Что означает немецкое слово «planen»?", "choices": ["стратегия", "планировать", "делить", "договариваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "стратегия", "делить", "договариваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["договариваться", "планировать", "сговор", "делить"], "correct_index": 2}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "сговор", "союз", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "сговор", "делить", "заговорить"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "насмехаться", "унижать", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["насмехаться", "унижать", "пытать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["унижать", "жестоко обращаться", "насмехаться", "жёсткость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["отвергать", "злоба", "унижать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестокость", "пытать", "жестоко обращаться", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "жестоко обращаться", "отвергать", "жёсткость"], "correct_index": 3}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["отвергать", "жестокость", "злоба", "пытать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["злоба", "отвергать", "пытать", "жестокость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "наслаждаться", "выкалывать", "садизм"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["наслаждаться", "выкалывать", "ослеплять", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["брутальность", "ослеплять", "пытка", "наслаждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["беспощадный", "выкалывать", "брутальность", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "наслаждаться", "садизм", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["выкалывать", "наслаждаться", "садизм", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["брутальность", "выкалывать", "наслаждаться", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["наслаждаться", "растаптывать", "пытка", "брутальность"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделение", "соблазнять", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соблазнять", "вдова", "вожделеть", "вожделение"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вожделеть", "добиваться", "вдова", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделеть", "заманивать", "вожделение", "вдова"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["вожделение", "добиваться", "заманивать", "похоть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделение", "похоть", "вдова", "заманивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «werben»?", "choices": ["вожделение", "похоть", "заманивать", "добиваться"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "ненавидеть", "угрожать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "ненавидеть", "соревноваться", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["подозревать", "ненавидеть", "угрожать", "не доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соперничество", "не доверять", "соревноваться", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["соперничество", "соревноваться", "подозревать", "бороться"], "correct_index": 3}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["не доверять", "бороться", "соревноваться", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соперничество", "бороться", "соревноваться", "подозревать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "издыхать", "отравленный", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "мучение", "отравленный", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклинать", "издыхать", "мучение", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["расплачиваться", "страдать", "мучение", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["мучение", "расплачиваться", "проклятый", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["рок", "расплачиваться", "проклинать", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["страдать", "отравленный", "расплачиваться", "мучение"], "correct_index": 2}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["рок", "страдать", "расплачиваться", "проклятый"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,15 +662,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
                             
@@ -678,31 +678,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                             
@@ -710,33 +710,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -748,11 +748,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -764,7 +764,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                             
@@ -784,7 +784,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,63 +797,31 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
                             
@@ -861,33 +829,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -901,7 +901,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
                             
@@ -916,7 +916,7 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
@@ -924,55 +924,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
@@ -980,65 +980,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,49 +1051,49 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1103,61 +1103,61 @@
                         <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1167,13 +1167,13 @@
                         <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1186,40 +1186,8 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
@@ -1228,7 +1196,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1238,27 +1238,27 @@
                         <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «locken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
@@ -1266,13 +1266,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                             
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
                             
@@ -1305,15 +1305,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
@@ -1325,43 +1325,11 @@
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
@@ -1369,31 +1337,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
                             
@@ -1401,17 +1353,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1428,6 +1428,22 @@
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
@@ -1435,22 +1451,6 @@
                             <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1464,25 +1464,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1492,11 +1492,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
@@ -1504,49 +1504,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1568,6 +1568,183 @@
     "throne": {
         "title": "Притворная любовь",
         "description": "Акт I: Соревнование в лести",
+        "vocabulary": [
+            {
+                "german": "vortäuschen",
+                "russian": "притворяться",
+                "sentence": "Regan steht unter dem glühenden Kronleuchter des Thronsaals. Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "Регана стоит под пылающей люстрой тронного зала. Моё дыхание рисует слово «притворяться» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ФОР-той-шен]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Regan steht unter dem glühenden Kronleuchter des Thronsaals.",
+                    "Mein Atem zeichnet das Wort „vortäuschen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "притворяться",
+                    "vorgeben — тоже «притворяться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "übertreffen",
+                "russian": "превосходить",
+                "sentence": "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch. Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig.",
+                "sentence_translation": "У развернутой карты королевства Регана склоняется над тяжёлым столом Лира. Каждой клеткой тела я обещаю: слово «превосходить» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ю-бер-ТРЕ-фен]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Neben der ausgerollten Reichskarte beugt sich Regan über Lears schweren Tisch.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „übertreffen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "превосходить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "wetteifern",
+                "russian": "состязаться",
+                "sentence": "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken. Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen.",
+                "sentence_translation": "Перед каменными статуями предков Регана сцепляет руки за спиной. Я шепчу стражам судьбы: слово «состязаться» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ВЕТ-ай-ферн]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Vor den steinernen Ahnenstatuen verschränkt Regan die Hände hinter dem Rücken.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „wetteifern“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "состязаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Falschheit",
+                "russian": "фальшь",
+                "sentence": "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden. Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten.",
+                "sentence_translation": "Между шепчущимися придворными Регана скользит по холодному мраморному полу. Твёрдым голосом я клянусь себе: слово «фальшь» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди ФАЛЬШ-хайт]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Zwischen flüsternden Höflingen gleitet Regan über den kalten Marmorboden.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Falschheit“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "фальшь"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vorspielen",
+                "russian": "разыгрывать",
+                "sentence": "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs. Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На краю пурпурного ковра Регана ждёт знака от короля. Эхо слова «разыгрывать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ФОР-шпи-лен]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Am Rand des purpurnen Teppichs wartet Regan auf ein Zeichen des Königs.",
+                    "Das Echo des Wortes „vorspielen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "разыгрывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die List",
+                "russian": "хитрость",
+                "sentence": "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen.",
+                "sentence_translation": "Под развевающимися штандартами сестёр Регана на миг опускает взгляд. Я шепчу стражам судьбы: слово «хитрость» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди ЛИСТ]",
+                "themes": [
+                    "Klippe",
+                    "List",
+                    "Rückkehr",
+                    "Verkleidung",
+                    "blind",
+                    "führen",
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Unter wehenden Standarten der Schwestern senkt Regan kurz den Blick.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die List“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "хитрость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erschleichen",
+                "russian": "выманивать",
+                "sentence": "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes. Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen.",
+                "sentence_translation": "За позолоченной балюстрадой Регана наблюдает за напряжёнными лицами двора. Как тихая молитва слово «выманивать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ер-ШЛАЙ-хен]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Hinter der vergoldeten Balustrade beobachtet Regan das gespannte Antlitz des Hofes.",
+                    "Wie ein stilles Gebet legt sich das Wort „erschleichen“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "выманивать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Habgier",
+                "russian": "алчность",
+                "sentence": "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir.",
+                "sentence_translation": "В отблесках открытых жаровен Регана медленно поднимает голос. Буря за окнами усиливает клятву: слово «алчность» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ди ХАБ-гир]",
+                "themes": [
+                    "vortäuschen",
+                    "wetteifern",
+                    "übertreffen"
+                ],
+                "sentence_parts": [
+                    "Im Schein der offenen Feuerbecken erhebt Regan langsam die Stimme.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „die Habgier“ gehört mir."
+                ],
+                "synonyms": [
+                    "алчность"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "vortäuschen",
@@ -1790,60 +1967,60 @@
             {
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
-                    "состязаться",
-                    "фальшь",
                     "притворяться",
+                    "фальшь",
+                    "состязаться",
                     "превосходить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
-                    "превосходить",
-                    "фальшь",
+                    "состязаться",
                     "притворяться",
-                    "состязаться"
+                    "превосходить",
+                    "фальшь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
-                    "выманивать",
-                    "состязаться",
                     "фальшь",
+                    "разыгрывать",
+                    "состязаться",
                     "притворяться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
+                    "состязаться",
+                    "притворяться",
                     "фальшь",
-                    "хитрость",
-                    "разыгрывать",
-                    "превосходить"
+                    "алчность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "состязаться",
-                    "разыгрывать",
-                    "притворяться",
-                    "хитрость"
+                    "алчность",
+                    "выманивать",
+                    "фальшь",
+                    "разыгрывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
                     "хитрость",
+                    "выманивать",
                     "превосходить",
-                    "фальшь",
-                    "алчность"
+                    "разыгрывать"
                 ],
                 "correctIndex": 0
             },
@@ -1851,7 +2028,7 @@
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
                     "алчность",
-                    "хитрость",
+                    "фальшь",
                     "превосходить",
                     "выманивать"
                 ],
@@ -1863,7 +2040,7 @@
                     "алчность",
                     "превосходить",
                     "выманивать",
-                    "притворяться"
+                    "хитрость"
                 ],
                 "correctIndex": 0
             }
@@ -1955,6 +2132,154 @@
     "goneril": {
         "title": "Раздел власти",
         "description": "Акт I-II: Союз с сестрой",
+        "vocabulary": [
+            {
+                "german": "das Bündnis",
+                "russian": "союз",
+                "sentence": "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten. Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В гулком проёме ворот замка Гонерильи Регана замирает среди нагруженных ящиков. Моё дыхание рисует слово «союз» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[дас БЮНД-нис]",
+                "themes": [
+                    "Bündnis",
+                    "Macht",
+                    "erobern",
+                    "planen",
+                    "teilen",
+                    "verbünden"
+                ],
+                "sentence_parts": [
+                    "Im hallenden Torbogen von Gonerils Burg verharrt Regan zwischen gepackten Kisten.",
+                    "Mein Atem zeichnet das Wort „das Bündnis“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "союз"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "teilen",
+                "russian": "делить",
+                "sentence": "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter. Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten.",
+                "sentence_translation": "На продуваемой ветром лестнице Регана смотрит вниз на молчаливый двор. Твёрдым голосом я клянусь себе: слово «делить» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ТАЙ-лен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf der windigen Freitreppe blickt Regan zum schweigenden Hof hinunter.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „teilen“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "делить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "planen",
+                "russian": "планировать",
+                "sentence": "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger. Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig.",
+                "sentence_translation": "Среди оставленных слуг Регана плотнее запахивает дорожный плащ. Каждой клеткой тела я обещаю: слово «планировать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[ПЛА-нен]",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
+                "sentence_parts": [
+                    "Zwischen zurückgelassenen Dienern schließt Regan den Reisemantel enger.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „planen“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "планировать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verschwören",
+                "russian": "заговорить",
+                "sentence": "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne. Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У тёмного конюшенного ряда Регана гладит гриву нервного коня. Я держу слово «заговорить» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[фер-ШВЁ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Am dunklen Pferdestall streicht Regan einem nervösen Tier über die Mähne.",
+                    "Ich halte das Wort „verschwören“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "заговорить"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Absprache",
+                "russian": "сговор",
+                "sentence": "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor. Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen.",
+                "sentence_translation": "Перед скрипящим подъёмным мостом Регана в последний раз касается родной двери. Я шепчу стражам судьбы: слово «сговор» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ди АБ-шпра-хе]",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
+                "sentence_parts": [
+                    "Vor dem knarrenden Fallgatter tastet Regan ein letztes Mal nach dem Haustor.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „die Absprache“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "сговор"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "vereinbaren",
+                "russian": "договариваться",
+                "sentence": "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand. Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig.",
+                "sentence_translation": "Среди разбросанных свитков Регана вертит кольцо на пальце. Каждой клеткой тела я обещаю: слово «договариваться» останется живым.",
+                "russian_hint": "",
+                "transcription": "[фер-АЙН-ба-рен]",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
+                "sentence_parts": [
+                    "Zwischen verstreuten Schriftrollen dreht Regan den Ring an der Hand.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „vereinbaren“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "договариваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Strategie",
+                "russian": "стратегия",
+                "sentence": "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen. Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У пустого банкетного стола Регана пересчитывает гаснущие свечи. Эхо слова «стратегия» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[ди штра-те-ГИ]",
+                "themes": [
+                    "Bündnis",
+                    "planen",
+                    "teilen"
+                ],
+                "sentence_parts": [
+                    "Am leeren Bankettisch zählt Regan die verlöschenden Kerzen.",
+                    "Das Echo des Wortes „die Strategie“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "стратегия"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "das Bündnis",
@@ -2145,69 +2470,69 @@
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "делить",
-                    "планировать",
                     "заговорить",
-                    "союз"
+                    "делить",
+                    "союз",
+                    "планировать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
-                    "делить",
                     "заговорить",
+                    "планировать",
                     "союз",
-                    "планировать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «planen»?",
-                "choices": [
-                    "сговор",
-                    "заговорить",
-                    "союз",
-                    "планировать"
+                    "делить"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «planen»?",
+                "choices": [
+                    "стратегия",
+                    "планировать",
+                    "делить",
+                    "договариваться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «verschwören»?",
                 "choices": [
-                    "планировать",
-                    "договариваться",
                     "заговорить",
+                    "стратегия",
+                    "делить",
+                    "договариваться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Absprache»?",
+                "choices": [
+                    "договариваться",
+                    "планировать",
+                    "сговор",
                     "делить"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Absprache»?",
-                "choices": [
-                    "сговор",
-                    "планировать",
-                    "стратегия",
-                    "заговорить"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
-                    "заговорить",
                     "договариваться",
+                    "сговор",
                     "союз",
-                    "стратегия"
+                    "планировать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
                     "стратегия",
                     "сговор",
-                    "договариваться",
+                    "делить",
                     "заговорить"
                 ],
                 "correctIndex": 0
@@ -2290,6 +2615,206 @@
     "regan": {
         "title": "Жестокость в замке",
         "description": "Акт II: Унижение отца",
+        "vocabulary": [
+            {
+                "german": "foltern",
+                "russian": "пытать",
+                "sentence": "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde. Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В продуваемом ветром боковом крыле Регана слушает вой прибрежного ветра. Моё дыхание рисует слово «пытать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ФОЛЬ-терн]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Im zugigen Seitenflügel lauscht Regan dem Heulen der Küstenwinde.",
+                    "Mein Atem zeichnet das Wort „foltern“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "пытать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erniedrigen",
+                "russian": "унижать",
+                "sentence": "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir.",
+                "sentence_translation": "Перед дымным камином замка Регана складывает измятый лист. Буря за окнами усиливает клятву: слово «унижать» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ер-НИД-ри-ген]",
+                "themes": [
+                    "Strafe",
+                    "Ungerechtigkeit",
+                    "Zorn",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Vor dem rauchigen Kamin der Burg faltet Regan einen zerknitterten Brief.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „erniedrigen“ gehört mir."
+                ],
+                "synonyms": [
+                    "унижать",
+                    "demütigen — тоже «унижать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verhöhnen",
+                "russian": "насмехаться",
+                "sentence": "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab. Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Под выцветшими гобеленами Регана беспокойно меряет шагами зал. Я держу слово «насмехаться» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[фер-ХЁ-нен]",
+                "themes": [
+                    "Beleidigung",
+                    "Feigheit",
+                    "Respektlosigkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Unter farblosen Wandteppichen schreitet Regan rastlos auf und ab.",
+                    "Ich halte das Wort „verhöhnen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "высмеивать",
+                    "насмехаться",
+                    "spotten — тоже «насмехаться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Bosheit",
+                "russian": "злоба",
+                "sentence": "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof. Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "У узкой бойницы Регана считает факелы на дворе. Я держу слово «злоба» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди БОС-хайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "An der schmalen Fensterluke zählt Regan die Fackeln auf dem Hof.",
+                    "Ich halte das Wort „die Bosheit“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "злоба"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "misshandeln",
+                "russian": "жестоко обращаться",
+                "sentence": "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften. Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig.",
+                "sentence_translation": "Среди дорожных сундуков послов Регана ищет свежие вести. Каждой клеткой тела я обещаю: слово «жестоко обращаться» останется живым.",
+                "russian_hint": "",
+                "transcription": "[МИС-хан-дельн]",
+                "themes": [
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Zwischen Reisekoffern der Gesandten sucht Regan nach frischen Botschaften.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „misshandeln“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "жестоко",
+                    "обращаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Härte",
+                "russian": "жёсткость",
+                "sentence": "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur. Ich presse das Wort „die Härte“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "В тихой капелле Регана преклоняет колени перед холодной каменной фигурой. Я стискиваю слово «жёсткость» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ХЕР-те]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Im stillen Kapellenraum kniet Regan vor der kalten Steinfigur.",
+                    "Ich presse das Wort „die Härte“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "суровость",
+                    "жёсткость"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "abweisen",
+                "russian": "отвергать",
+                "sentence": "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest. Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "На балконе, омываемом морскими брызгами, Регана крепко держит фонарь. Моё дыхание рисует слово «отвергать» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[АБ-вай-зен]",
+                "themes": [
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen"
+                ],
+                "sentence_parts": [
+                    "Auf dem Balkon, den das Meer besprüht, hält Regan die Laterne fest.",
+                    "Mein Atem zeichnet das Wort „abweisen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "отвергать",
+                    "verstoßen — тоже «отвергать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Grausamkeit",
+                "russian": "жестокость",
+                "sentence": "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort. Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "В тени высоких стен Регана пишет лихорадочный ответ. Моё дыхание рисует слово «жестокость» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[ди ГРАУ-зам-кайт]",
+                "themes": [
+                    "Bosheit",
+                    "Ehe",
+                    "Grausamkeit",
+                    "Verzweiflung",
+                    "blenden",
+                    "erniedrigen",
+                    "foltern",
+                    "verhöhnen",
+                    "verlassen",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Im Schatten der hohen Burgmauern schreibt Regan eine fiebrige Antwort.",
+                    "Mein Atem zeichnet das Wort „die Grausamkeit“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "жестокость"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "foltern",
@@ -2538,80 +3063,80 @@
                 "choices": [
                     "злоба",
                     "насмехаться",
-                    "пытать",
-                    "унижать"
+                    "унижать",
+                    "пытать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "пытать",
                     "насмехаться",
-                    "злоба",
-                    "унижать"
+                    "унижать",
+                    "пытать",
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "пытать",
-                    "злоба",
-                    "отвергать",
-                    "насмехаться"
+                    "унижать",
+                    "жестоко обращаться",
+                    "насмехаться",
+                    "жёсткость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "жёсткость",
-                    "пытать",
+                    "отвергать",
                     "злоба",
+                    "унижать",
                     "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
-                    "унижать",
-                    "отвергать",
-                    "злоба",
-                    "жестоко обращаться"
+                    "жестокость",
+                    "пытать",
+                    "жестоко обращаться",
+                    "злоба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "злоба",
+                    "жестокость",
                     "жестоко обращаться",
-                    "жёсткость",
-                    "жестокость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «abweisen»?",
-                "choices": [
-                    "злоба",
-                    "насмехаться",
-                    "жестоко обращаться",
-                    "отвергать"
+                    "отвергать",
+                    "жёсткость"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «abweisen»?",
+                "choices": [
+                    "отвергать",
+                    "жестокость",
+                    "злоба",
+                    "пытать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "унижать",
-                    "жестоко обращаться",
-                    "жестокость",
-                    "злоба"
+                    "злоба",
+                    "отвергать",
+                    "пытать",
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2702,6 +3227,188 @@
     "storm": {
         "title": "Ослепление Глостера",
         "description": "Акт III: Садистское удовольствие",
+        "vocabulary": [
+            {
+                "german": "blenden",
+                "russian": "ослеплять",
+                "sentence": "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind. Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen.",
+                "sentence_translation": "Посреди хлещущей дождём пустоши Регана упирается в ветер. Я шепчу стражам судьбы: слово «ослеплять» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[БЛЕН-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Mitten auf der vom Regen gepeitschten Heide stemmt sich Regan gegen den Wind.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „blenden“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "ослеплять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "der Sadismus",
+                "russian": "садизм",
+                "sentence": "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen. Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig.",
+                "sentence_translation": "Под разорванным знаменем Регана прикрывает глаза от молний. Каждой клеткой тела я обещаю: слово «садизм» останется живым.",
+                "russian_hint": "",
+                "transcription": "[дер за-ДИС-мус]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Unter einem zerrissenen Banner schützt Regan die Augen vor den Blitzen.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „der Sadismus“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "садизм"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "genießen",
+                "russian": "наслаждаться",
+                "sentence": "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir.",
+                "sentence_translation": "У поваленного дерева Регана ищет укрытия от грома. Буря за окнами усиливает клятву: слово «наслаждаться» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[ге-НИ-сен]",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Am Rand eines umgestürzten Baumes sucht Regan Deckung vor dem Donner.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „genießen“ gehört mir."
+                ],
+                "synonyms": [
+                    "наслаждаться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "ausstechen",
+                "russian": "выкалывать",
+                "sentence": "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm. Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus.",
+                "sentence_translation": "Между пенящимися лужами Регана пробирается через грязь. Я глубоко вдыхаю и выпускаю только слово «выкалывать».",
+                "russian_hint": "",
+                "transcription": "[АУС-ште-хен]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Zwischen schäumenden Wassergräben stolpert Regan durch den Schlamm.",
+                    "Ich atme tief ein und lasse nur das Wort „ausstechen“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "выкалывать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Folter",
+                "russian": "пытка",
+                "sentence": "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an. Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "На фоне вспыхивающего неба Регана упрямо поднимает руки. Я черчу слово «пытка» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[ди ФОЛЬ-тер]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Schmerz",
+                    "blenden",
+                    "genießen",
+                    "verraten"
+                ],
+                "sentence_parts": [
+                    "Vor einem zuckenden Himmel hebt Regan die Arme trotzig an.",
+                    "Ich zeichne das Wort „die Folter“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "пытка"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "erbarmungslos",
+                "russian": "беспощадный",
+                "sentence": "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte. Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen.",
+                "sentence_translation": "Под промокшим плащом Регана прижимает дыхание к груди, спасаясь от холода. Я шепчу стражам судьбы: слово «беспощадный» не должно исчезнуть.",
+                "russian_hint": "",
+                "transcription": "[ер-БАР-мунгс-лос]",
+                "themes": [
+                    "Grausamkeit",
+                    "Sadismus",
+                    "Sturm",
+                    "blenden",
+                    "genießen",
+                    "gnadenlos",
+                    "verraten",
+                    "verstoßen"
+                ],
+                "sentence_parts": [
+                    "Unter dem durchtränkten Umhang presst Regan den Atem gegen die Kälte.",
+                    "Ich flüstere den Wächtern des Schicksals zu: Das Wort „erbarmungslos“ darf nicht vergehen."
+                ],
+                "synonyms": [
+                    "беспощадный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Brutalität",
+                "russian": "брутальность",
+                "sentence": "Am kläglichen Feuerrest wärmt Regan zitternde Finger. Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "У жалких огненных углей Регана греет дрожащие пальцы. Холодный свет заставляет слово «брутальность» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[ди бру-та-ли-ТЕТ]",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Am kläglichen Feuerrest wärmt Regan zitternde Finger.",
+                    "Das kalte Licht lässt das Wort „die Brutalität“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "брутальность"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "zertreten",
+                "russian": "растаптывать",
+                "sentence": "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an. Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig.",
+                "sentence_translation": "Среди воющих псов Регана перекрикивает беснующуюся бурю. Каждой клеткой тела я обещаю: слово «растаптывать» останется живым.",
+                "russian_hint": "",
+                "transcription": "[цер-ТРЕ-тен]",
+                "themes": [
+                    "Sadismus",
+                    "blenden",
+                    "genießen"
+                ],
+                "sentence_parts": [
+                    "Zwischen heulenden Hunden ruft Regan gegen den tosenden Sturm an.",
+                    "Mit jeder Faser meines Körpers verspreche ich: Das Wort „zertreten“ bleibt lebendig."
+                ],
+                "synonyms": [
+                    "растаптывать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "blenden",
@@ -2939,80 +3646,80 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "наслаждаться",
                     "ослеплять",
-                    "садизм",
-                    "выкалывать"
+                    "наслаждаться",
+                    "выкалывать",
+                    "садизм"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "выкалывать",
-                    "садизм",
                     "наслаждаться",
-                    "ослеплять"
+                    "выкалывать",
+                    "ослеплять",
+                    "садизм"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "выкалывать",
                     "брутальность",
-                    "наслаждаться",
-                    "растаптывать"
+                    "ослеплять",
+                    "пытка",
+                    "наслаждаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "ослеплять",
+                    "беспощадный",
                     "выкалывать",
-                    "садизм",
-                    "пытка"
+                    "брутальность",
+                    "наслаждаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "садизм",
                     "пытка",
-                    "брутальность",
-                    "ослеплять"
+                    "наслаждаться",
+                    "садизм",
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "пытка",
-                    "беспощадный",
                     "выкалывать",
-                    "брутальность"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Brutalität»?",
-                "choices": [
-                    "выкалывать",
+                    "наслаждаться",
                     "садизм",
-                    "растаптывать",
-                    "брутальность"
+                    "беспощадный"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Brutalität»?",
+                "choices": [
+                    "брутальность",
+                    "выкалывать",
+                    "наслаждаться",
+                    "беспощадный"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
-                    "пытка",
+                    "наслаждаться",
                     "растаптывать",
-                    "беспощадный",
-                    "ослеплять"
+                    "пытка",
+                    "брутальность"
                 ],
                 "correctIndex": 1
             }
@@ -3104,6 +3811,161 @@
     "hut": {
         "title": "Вдовство и похоть",
         "description": "Акт IV: Смерть Корнуолла",
+        "vocabulary": [
+            {
+                "german": "die Witwe",
+                "russian": "вдова",
+                "sentence": "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze. Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern.",
+                "sentence_translation": "В тёмном шатре полевых лекарей Регана сидит у мерцающей свечи. Даже если мир распадается, слово «вдова» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ди ВИТ-ве]",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Im dunklen Zelt der Feldärzte sitzt Regan bei der flackernden Kerze.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „die Witwe“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "вдова"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "begehren",
+                "russian": "вожделеть",
+                "sentence": "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen. Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir.",
+                "sentence_translation": "Среди помятых доспехов Регана гладит старый герб. Буря за окнами усиливает клятву: слово «вожделеть» принадлежит мне.",
+                "russian_hint": "",
+                "transcription": "[бе-ГЕ-рен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen zerbeulten Rüstungen streicht Regan über ein altes Wappen.",
+                    "Der Sturm vor den Fenstern verstärkt den Schwur: Das Wort „begehren“ gehört mir."
+                ],
+                "synonyms": [
+                    "вожделеть",
+                    "желать",
+                    "verlangen — тоже «желать»",
+                    "wünschen — тоже «желать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verführen",
+                "russian": "соблазнять",
+                "sentence": "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf. Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns.",
+                "sentence_translation": "О низкую балку хижины Регана едва не ударяется головой. Моё дыхание рисует слово «соблазнять» в холодном воздухе между нами.",
+                "russian_hint": "",
+                "transcription": "[фер-ФЮ-рен]",
+                "themes": [
+                    "Macht",
+                    "Witwe",
+                    "begehren",
+                    "erobern",
+                    "verbünden",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Am niedrigen Dachbalken der Hütte stößt Regan fast den Kopf.",
+                    "Mein Atem zeichnet das Wort „verführen“ in die kalte Luft zwischen uns."
+                ],
+                "synonyms": [
+                    "соблазнять"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Begierde",
+                "russian": "вожделение",
+                "sentence": "Neben der schlafenden Wache flüstert Regan in die schwere Nacht. Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "Рядом со спящим стражем Регана шепчет в тяжёлую ночь. Я держу слово «вожделение» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[ди бе-ГИР-де]",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Neben der schlafenden Wache flüstert Regan in die schwere Nacht.",
+                    "Ich halte das Wort „die Begierde“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "вожделение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "locken",
+                "russian": "заманивать",
+                "sentence": "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten. Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen.",
+                "sentence_translation": "Перед грубой походной койкой Регана разглядывает шрамы прошлых битв. Как тихая молитва слово «заманивать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[ЛО-кен]",
+                "themes": [
+                    "Witwe",
+                    "begehren",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Vor dem einfachen Feldbett betrachtet Regan die Narben vergangener Schlachten.",
+                    "Wie ein stilles Gebet legt sich das Wort „locken“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "заманивать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Lust",
+                "russian": "похоть",
+                "sentence": "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite. Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten.",
+                "sentence_translation": "В запахе влажной соломы Регана откладывает плащ в сторону. Твёрдым голосом я клянусь себе: слово «похоть» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ди ЛУСТ]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "Witwe",
+                    "begehren",
+                    "spielen",
+                    "verführen"
+                ],
+                "sentence_parts": [
+                    "Im Geruch von feuchtem Stroh legt Regan den Mantel zur Seite.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „die Lust“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "похоть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "werben",
+                "russian": "добиваться",
+                "sentence": "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe. Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten.",
+                "sentence_translation": "На шатком деревянном столе Регана раскладывает зачитанные письма. Твёрдым голосом я клянусь себе: слово «добиваться» сегодня не будет предано.",
+                "russian_hint": "",
+                "transcription": "[ВЕР-бен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem wackligen Holztisch ordnet Regan zerlesene Briefe.",
+                    "Mit fester Stimme schwöre ich mir: Das Wort „werben“ wird heute nicht verraten."
+                ],
+                "synonyms": [
+                    "добиваться",
+                    "вербовать"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "die Witwe",
@@ -3300,69 +4162,69 @@
             {
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
-                    "вожделение",
                     "вдова",
-                    "вожделеть",
-                    "соблазнять"
+                    "вожделение",
+                    "соблазнять",
+                    "вожделеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "вожделение",
-                    "вожделеть",
                     "соблазнять",
-                    "вдова"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verführen»?",
-                "choices": [
                     "вдова",
-                    "вожделение",
-                    "соблазнять",
-                    "похоть"
+                    "вожделеть",
+                    "вожделение"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «verführen»?",
+                "choices": [
+                    "вожделеть",
+                    "добиваться",
+                    "вдова",
+                    "соблазнять"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
-                    "соблазнять",
-                    "добиваться",
+                    "вожделеть",
+                    "заманивать",
                     "вожделение",
-                    "заманивать"
+                    "вдова"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "заманивать",
                     "вожделение",
-                    "вдова",
+                    "добиваться",
+                    "заманивать",
                     "похоть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
+                    "вожделение",
                     "похоть",
-                    "соблазнять",
                     "вдова",
                     "заманивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
+                    "вожделение",
                     "похоть",
-                    "вожделеть",
-                    "вдова",
+                    "заманивать",
                     "добиваться"
                 ],
                 "correctIndex": 3
@@ -3445,6 +4307,162 @@
     "dover": {
         "title": "Соперничество сестёр",
         "description": "Акт V: Борьба за Эдмунда",
+        "vocabulary": [
+            {
+                "german": "wettkämpfen",
+                "russian": "соревноваться",
+                "sentence": "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal. Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern.",
+                "sentence_translation": "На белых скалах Дувра Регана смотрит в вздыбленный пролив. Даже если мир распадается, слово «соревноваться» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[ВЕТ-кемп-фен]",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Auf den weißen Klippen von Dover blickt Regan in den aufgewühlten Kanal.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „wettkämpfen“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "соревноваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "hassen",
+                "russian": "ненавидеть",
+                "sentence": "Zwischen flatternden Feldzeichen richtet Regan den Helm. Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Среди хлопающих штандартов Регана поправляет шлем. Я вывожу слово «ненавидеть» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ХА-сен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Zwischen flatternden Feldzeichen richtet Regan den Helm.",
+                    "Ich zeichne das Wort „hassen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "ненавидеть"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bedrohen",
+                "russian": "угрожать",
+                "sentence": "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand. Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "У французского костра Регана рисует в песке путь марша. Эхо слова «угрожать» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[бе-ДРО-ен]",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Am Lagerfeuer der Franzosen zeichnet Regan Marschrouten in den Sand.",
+                    "Das Echo des Wortes „bedrohen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "угрожать",
+                    "drohen — тоже «угрожать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Rivalität",
+                "russian": "соперничество",
+                "sentence": "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel. Ich presse das Wort „die Rivalität“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "У перевязанных провиантных ящиков Регана проверяет печати. Я стискиваю слово «соперничество» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[ди ри-ва-ли-ТЕТ]",
+                "themes": [
+                    "Liebschaft",
+                    "Rivalität",
+                    "bedrohen",
+                    "hassen",
+                    "spielen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Neben verschnürten Versorgungskisten kontrolliert Regan das Siegel.",
+                    "Ich presse das Wort „die Rivalität“ zwischen die Zähne,",
+                    "damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "соперничество"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "bekämpfen",
+                "russian": "бороться",
+                "sentence": "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer. Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Перед шёлковым шатром полководцев Регана слушает глухой шум моря. Я вывожу слово «бороться» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[бе-КЕМП-фен]",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Vor dem Seidenzelt der Heerführer lauscht Regan dem dumpfen Meer.",
+                    "Ich zeichne das Wort „bekämpfen“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "бороться",
+                    "kämpfen — тоже «бороться»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "misstrauen",
+                "russian": "не доверять",
+                "sentence": "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts. Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge.",
+                "sentence_translation": "На песчаном плацу Регана отрабатывает выхват меча. Эхо слова «не доверять» заглушает шёпот придворных.",
+                "russian_hint": "",
+                "transcription": "[МИС-трау-ен]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Auf dem sandigen Trainingsplatz übt Regan das Ziehen des Schwerts.",
+                    "Das Echo des Wortes „misstrauen“ übertönt das Flüstern der Höflinge."
+                ],
+                "synonyms": [
+                    "не",
+                    "ahnungslos — тоже «не»",
+                    "доверять",
+                    "trauen — тоже «доверять»",
+                    "vertrauen — тоже «доверять»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "argwöhnen",
+                "russian": "подозревать",
+                "sentence": "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung. Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals.",
+                "sentence_translation": "Под гул барабанов Регана поднимает знамя надежды. Я черчу слово «подозревать» в мыслях поверх линий судьбы.",
+                "russian_hint": "",
+                "transcription": "[АРГ-вё-нен]",
+                "themes": [
+                    "bedrohen",
+                    "hassen",
+                    "wettkämpfen"
+                ],
+                "sentence_parts": [
+                    "Zwischen pochenden Trommeln hebt Regan das Banner der Hoffnung.",
+                    "Ich zeichne das Wort „argwöhnen“ in Gedanken über die Linien des Schicksals."
+                ],
+                "synonyms": [
+                    "подозревать",
+                    "verdächtigen — тоже «подозревать»"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "wettkämpfen",
@@ -3637,72 +4655,72 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
+                    "соревноваться",
                     "ненавидеть",
                     "угрожать",
-                    "соревноваться",
                     "соперничество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "соперничество",
+                    "угрожать",
                     "ненавидеть",
                     "соревноваться",
-                    "угрожать"
+                    "соперничество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "соревноваться",
                     "подозревать",
-                    "бороться",
-                    "угрожать"
+                    "ненавидеть",
+                    "угрожать",
+                    "не доверять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
+                    "соперничество",
                     "не доверять",
                     "соревноваться",
-                    "бороться",
-                    "соперничество"
+                    "бороться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
                     "соперничество",
+                    "соревноваться",
                     "подозревать",
-                    "бороться",
-                    "соревноваться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «misstrauen»?",
-                "choices": [
-                    "ненавидеть",
-                    "угрожать",
-                    "подозревать",
-                    "не доверять"
+                    "бороться"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «argwöhnen»?",
+                "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
-                    "подозревать",
-                    "ненавидеть",
+                    "не доверять",
                     "бороться",
-                    "угрожать"
+                    "соревноваться",
+                    "соперничество"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «argwöhnen»?",
+                "choices": [
+                    "соперничество",
+                    "бороться",
+                    "соревноваться",
+                    "подозревать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3783,6 +4801,183 @@
     "prison": {
         "title": "Смерть от яда",
         "description": "Акт V: Отравление сестрой",
+        "vocabulary": [
+            {
+                "german": "vergiftet",
+                "russian": "отравленный",
+                "sentence": "Im feuchten Kerker stützt Regan sich an den tropfenden Stein. Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus.",
+                "sentence_translation": "В сыром подземелье Регана опирается на сочащийся камень. Я глубоко вдыхаю и выпускаю только слово «отравленный».",
+                "russian_hint": "",
+                "transcription": "[фер-ГИФ-тет]",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Im feuchten Kerker stützt Regan sich an den tropfenden Stein.",
+                    "Ich atme tief ein und lasse nur das Wort „vergiftet“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "отравленный"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "leiden",
+                "russian": "страдать",
+                "sentence": "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette. Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche.",
+                "sentence_translation": "Под мутным фонарём Регана пересчитывает железные кольца цепи. Я вывожу слово «страдать» невидимыми чернилами на ладони.",
+                "russian_hint": "",
+                "transcription": "[ЛАЙ-ден]",
+                "themes": [
+                    "король лир"
+                ],
+                "sentence_parts": [
+                    "Unter der trüben Laterne zählt Regan die eisernen Ringe der Kette.",
+                    "Ich zeichne das Wort „leiden“ mit unsichtbarer Tinte auf meine Handfläche."
+                ],
+                "synonyms": [
+                    "страдать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verenden",
+                "russian": "издыхать",
+                "sentence": "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen. Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen.",
+                "sentence_translation": "У тяжёлой двери Регана прислушивается к далёким рыданиям. Как тихая молитва слово «издыхать» ложится на мои губы.",
+                "russian_hint": "",
+                "transcription": "[фер-ЕН-ден]",
+                "themes": [
+                    "Ende",
+                    "Tod",
+                    "Vergeltung",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Neben der schweren Holztür horcht Regan auf entferntes Schluchzen.",
+                    "Wie ein stilles Gebet legt sich das Wort „verenden“ auf meine Lippen."
+                ],
+                "synonyms": [
+                    "издыхать"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "die Qual",
+                "russian": "мучение",
+                "sentence": "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern. Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus.",
+                "sentence_translation": "На холодной каменной скамье Регана плотнее кутается в плащ. Я глубоко вдыхаю и выпускаю только слово «мучение».",
+                "russian_hint": "",
+                "transcription": "[ди КВАЛЬ]",
+                "themes": [
+                    "Blut",
+                    "Folter",
+                    "Sadismus",
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Auf der kalten Steinbank zieht Regan den Mantel enger um die Schultern.",
+                    "Ich atme tief ein und lasse nur das Wort „die Qual“ wieder hinaus."
+                ],
+                "synonyms": [
+                    "мука",
+                    "мучение"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verwünschen",
+                "russian": "проклинать",
+                "sentence": "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht. Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht.",
+                "sentence_translation": "Между тенями решёток Регана поднимает лицо к свету. Я стискиваю слово «проклинать» зубами, чтобы не вырвалось сомнение.",
+                "russian_hint": "",
+                "transcription": "[фер-ВЮН-шен]",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Zwischen Schatten der Gitterstäbe hebt Regan das Gesicht zum Licht.",
+                    "Ich presse das Wort „verwünschen“ zwischen die Zähne, damit kein Zweifel entweicht."
+                ],
+                "synonyms": [
+                    "проклинать",
+                    "fluchen — тоже «проклинать»",
+                    "verfluchen — тоже «проклинать»"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "das Verhängnis",
+                "russian": "рок",
+                "sentence": "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen. Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern.",
+                "sentence_translation": "У ржавого ведра с водой Регана на мгновение видит отражение глаз. Даже если мир распадается, слово «рок» остаётся моим северным светом.",
+                "russian_hint": "",
+                "transcription": "[дас фер-ХЕНГ-нис]",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Am rostigen Wassereimer spiegelt Regan kurz die eigenen Augen.",
+                    "Selbst wenn die Welt zerfällt, bleibt das Wort „das Verhängnis“ mein Nordstern."
+                ],
+                "synonyms": [
+                    "рок"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "büßen",
+                "russian": "расплачиваться",
+                "sentence": "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen. Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen.",
+                "sentence_translation": "В глухом эхе шагов Регана отсчитывает ритм часовых. Я держу слово «расплачиваться» как факел у сердца.",
+                "russian_hint": "",
+                "transcription": "[БЮ-сен]",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Im dumpfen Hall der Schritte zählt Regan den Rhythmus der Wachen.",
+                    "Ich halte das Wort „büßen“ wie eine Fackel vor meinem Herzen."
+                ],
+                "synonyms": [
+                    "расплачиваться"
+                ],
+                "visual_hint": "📚"
+            },
+            {
+                "german": "verflucht",
+                "russian": "проклятый",
+                "sentence": "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub. Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen.",
+                "sentence_translation": "Перед заколоченным окном Регана чертит круги в пыли. Холодный свет заставляет слово «проклятый» сиять словно расплавленное золото.",
+                "russian_hint": "",
+                "transcription": "[фер-ФЛУХТ]",
+                "themes": [
+                    "leiden",
+                    "verenden",
+                    "vergiftet"
+                ],
+                "sentence_parts": [
+                    "Vor dem verriegelten Fenster zeichnet Regan Kreise in den Staub.",
+                    "Das kalte Licht lässt das Wort „verflucht“ wie geschmolzenes Gold erscheinen."
+                ],
+                "synonyms": [
+                    "проклятый"
+                ],
+                "visual_hint": "📚"
+            }
+        ],
         "words": [
             {
                 "word": "vergiftet",
@@ -4007,30 +5202,30 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "страдать",
                     "мучение",
+                    "издыхать",
                     "отравленный",
-                    "издыхать"
+                    "страдать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
                     "страдать",
-                    "отравленный"
+                    "мучение",
+                    "отравленный",
+                    "издыхать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
                     "проклинать",
                     "издыхать",
-                    "рок",
-                    "мучение"
+                    "мучение",
+                    "страдать"
                 ],
                 "correctIndex": 1
             },
@@ -4038,18 +5233,18 @@
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
                     "расплачиваться",
-                    "издыхать",
-                    "проклинать",
-                    "мучение"
+                    "страдать",
+                    "мучение",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "рок",
-                    "издыхать",
-                    "страдать",
+                    "мучение",
+                    "расплачиваться",
+                    "проклятый",
                     "проклинать"
                 ],
                 "correctIndex": 3
@@ -4057,32 +5252,32 @@
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
-                    "издыхать",
+                    "рок",
                     "расплачиваться",
-                    "мучение",
-                    "рок"
+                    "проклинать",
+                    "издыхать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
+                    "страдать",
+                    "отравленный",
                     "расплачиваться",
-                    "издыхать",
-                    "рок",
-                    "страдать"
+                    "мучение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
-                    "проклятый",
-                    "издыхать",
-                    "мучение",
-                    "отравленный"
+                    "рок",
+                    "страдать",
+                    "расплачиваться",
+                    "проклятый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4175,6 +5370,9 @@ const characterId = "regan";
 const STORAGE_PREFIX = 'liraJourney';
 const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;
 const quizStateCache = {};
+
+window.phaseData = phaseVocabularies;
+window.phaseKeys = Object.keys(phaseVocabularies);
 
 
 let currentPhaseIndex = 0;


### PR DESCRIPTION
## Summary
- expose each journey phase's vocabulary details to the browser by serializing german/russian context data
- assign the serialized payload to `window.phaseData`/`window.phaseKeys` so the new drag-and-drop and context exercises can read it
- regenerate the journey pages so they include the updated data blocks for every character

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cec19a354483209e0660c4dc920407