### PR TITLE
Fix article exercise layout overflow

### DIFF
--- a/output/static/css/exercises.css
+++ b/output/static/css/exercises.css
@@ -31,8 +31,11 @@
     border: 2px solid #e0e0e0;
     border-radius: 8px;
     padding: 15px;
-    min-height: 120px;
+    min-height: 150px;
     transition: all 0.3s;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .article-column[data-article="der"] {
@@ -66,11 +69,15 @@
 }
 
 .article-drop-zone {
-    min-height: 80px;
+    min-height: 120px;
     border: 2px dashed #ddd;
     border-radius: 6px;
     padding: 10px;
     transition: all 0.3s;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1 1 auto;
 }
 
 .article-drop-zone.drag-over {
@@ -152,7 +159,11 @@
     display: flex;
     gap: 10px;
     justify-content: center;
-    margin: 20px 0;
+    margin: 30px 0 0;
+}
+
+.article-drop-zone .article-word-card {
+    width: 100%;
 }
 
 .check-articles-btn,

--- a/output/static/js/exercises.js
+++ b/output/static/js/exercises.js
@@ -131,6 +131,22 @@
         const resetBtn = container.querySelector('.reset-articles-btn');
         const feedback = container.querySelector('.articles-feedback');
         const wordsContainer = container.querySelector('.words-to-sort');
+        const contentElement = container.classList.contains('relations-content')
+            ? container
+            : container.closest('.relations-content');
+
+        function updateArticlesLayout() {
+            window.requestAnimationFrame(() => {
+                if (!contentElement) return;
+
+                const relationSection = contentElement.closest('.relation-section');
+                if (relationSection && !relationSection.classList.contains('expanded')) {
+                    return;
+                }
+
+                contentElement.style.maxHeight = contentElement.scrollHeight + 'px';
+            });
+        }
         
         // Сохраняем начальные позиции для сброса
         const initialParent = cards[0]?.parentElement;
@@ -144,9 +160,10 @@
                 card.dataset.dragArticle = card.dataset.article;
                 card.dataset.dragWord = card.dataset.word;
             });
-            
+
             card.addEventListener('dragend', () => {
                 card.classList.remove('dragging');
+                updateArticlesLayout();
             });
             
             // КЛИК для мобильных
@@ -178,14 +195,15 @@
             zone.addEventListener('drop', (e) => {
                 e.preventDefault();
                 zone.classList.remove('drag-over');
-                
+
                 const draggingCard = container.querySelector('.dragging');
                 if (draggingCard) {
                     zone.appendChild(draggingCard);
                     draggingCard.classList.remove('correct', 'incorrect');
+                    updateArticlesLayout();
                 }
             });
-            
+
             // Клик по зоне для мобильных
             zone.addEventListener('click', function(e) {
                 e.stopPropagation();
@@ -193,9 +211,37 @@
                 if (selected) {
                     this.appendChild(selected);
                     selected.classList.remove('selected', 'correct', 'incorrect');
+                    updateArticlesLayout();
                 }
             });
         });
+
+        if (wordsContainer) {
+            wordsContainer.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+            });
+
+            wordsContainer.addEventListener('drop', (e) => {
+                e.preventDefault();
+                const draggingCard = container.querySelector('.dragging');
+                if (draggingCard) {
+                    wordsContainer.appendChild(draggingCard);
+                    draggingCard.classList.remove('correct', 'incorrect');
+                    updateArticlesLayout();
+                }
+            });
+
+            wordsContainer.addEventListener('click', function(e) {
+                e.stopPropagation();
+                const selected = container.querySelector('.article-word-card.selected');
+                if (selected && selected.parentElement !== wordsContainer) {
+                    wordsContainer.appendChild(selected);
+                    selected.classList.remove('selected', 'correct', 'incorrect');
+                    updateArticlesLayout();
+                }
+            });
+        }
         
         // Проверка ответов
         checkBtn?.addEventListener('click', () => {
@@ -236,8 +282,10 @@
                     feedback.className = 'articles-feedback partial';
                 }
             }
+
+            updateArticlesLayout();
         });
-        
+
         // Сброс
         resetBtn?.addEventListener('click', () => {
             cards.forEach(card => {
@@ -246,12 +294,16 @@
                     initialParent.appendChild(card);
                 }
             });
-            
+
             if (feedback) {
                 feedback.innerHTML = '';
                 feedback.className = 'articles-feedback';
             }
+
+            updateArticlesLayout();
         });
+
+        updateArticlesLayout();
     }
 
     // ==========================================

--- a/static/css/exercises.css
+++ b/static/css/exercises.css
@@ -31,8 +31,11 @@
     border: 2px solid #e0e0e0;
     border-radius: 8px;
     padding: 15px;
-    min-height: 120px;
+    min-height: 150px;
     transition: all 0.3s;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .article-column[data-article="der"] {
@@ -66,11 +69,15 @@
 }
 
 .article-drop-zone {
-    min-height: 80px;
+    min-height: 120px;
     border: 2px dashed #ddd;
     border-radius: 6px;
     padding: 10px;
     transition: all 0.3s;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1 1 auto;
 }
 
 .article-drop-zone.drag-over {
@@ -152,7 +159,11 @@
     display: flex;
     gap: 10px;
     justify-content: center;
-    margin: 20px 0;
+    margin: 30px 0 0;
+}
+
+.article-drop-zone .article-word-card {
+    width: 100%;
 }
 
 .check-articles-btn,

--- a/static/js/exercises.js
+++ b/static/js/exercises.js
@@ -131,6 +131,22 @@
         const resetBtn = container.querySelector('.reset-articles-btn');
         const feedback = container.querySelector('.articles-feedback');
         const wordsContainer = container.querySelector('.words-to-sort');
+        const contentElement = container.classList.contains('relations-content')
+            ? container
+            : container.closest('.relations-content');
+
+        function updateArticlesLayout() {
+            window.requestAnimationFrame(() => {
+                if (!contentElement) return;
+
+                const relationSection = contentElement.closest('.relation-section');
+                if (relationSection && !relationSection.classList.contains('expanded')) {
+                    return;
+                }
+
+                contentElement.style.maxHeight = contentElement.scrollHeight + 'px';
+            });
+        }
         
         // Сохраняем начальные позиции для сброса
         const initialParent = cards[0]?.parentElement;
@@ -144,9 +160,10 @@
                 card.dataset.dragArticle = card.dataset.article;
                 card.dataset.dragWord = card.dataset.word;
             });
-            
+
             card.addEventListener('dragend', () => {
                 card.classList.remove('dragging');
+                updateArticlesLayout();
             });
             
             // КЛИК для мобильных
@@ -178,14 +195,15 @@
             zone.addEventListener('drop', (e) => {
                 e.preventDefault();
                 zone.classList.remove('drag-over');
-                
+
                 const draggingCard = container.querySelector('.dragging');
                 if (draggingCard) {
                     zone.appendChild(draggingCard);
                     draggingCard.classList.remove('correct', 'incorrect');
+                    updateArticlesLayout();
                 }
             });
-            
+
             // Клик по зоне для мобильных
             zone.addEventListener('click', function(e) {
                 e.stopPropagation();
@@ -193,9 +211,37 @@
                 if (selected) {
                     this.appendChild(selected);
                     selected.classList.remove('selected', 'correct', 'incorrect');
+                    updateArticlesLayout();
                 }
             });
         });
+
+        if (wordsContainer) {
+            wordsContainer.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+            });
+
+            wordsContainer.addEventListener('drop', (e) => {
+                e.preventDefault();
+                const draggingCard = container.querySelector('.dragging');
+                if (draggingCard) {
+                    wordsContainer.appendChild(draggingCard);
+                    draggingCard.classList.remove('correct', 'incorrect');
+                    updateArticlesLayout();
+                }
+            });
+
+            wordsContainer.addEventListener('click', function(e) {
+                e.stopPropagation();
+                const selected = container.querySelector('.article-word-card.selected');
+                if (selected && selected.parentElement !== wordsContainer) {
+                    wordsContainer.appendChild(selected);
+                    selected.classList.remove('selected', 'correct', 'incorrect');
+                    updateArticlesLayout();
+                }
+            });
+        }
         
         // Проверка ответов
         checkBtn?.addEventListener('click', () => {
@@ -236,8 +282,10 @@
                     feedback.className = 'articles-feedback partial';
                 }
             }
+
+            updateArticlesLayout();
         });
-        
+
         // Сброс
         resetBtn?.addEventListener('click', () => {
             cards.forEach(card => {
@@ -246,12 +294,16 @@
                     initialParent.appendChild(card);
                 }
             });
-            
+
             if (feedback) {
                 feedback.innerHTML = '';
                 feedback.className = 'articles-feedback';
             }
+
+            updateArticlesLayout();
         });
+
+        updateArticlesLayout();
     }
 
     // ==========================================


### PR DESCRIPTION
## Summary
- let article columns grow with their contents and keep consistent spacing before the control buttons
- recalculate the relations panel height after drag-and-drop, feedback, and resets to keep the buttons visible
- allow words to be dragged or tapped back to the source list while preserving layout updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cece0d8cac8320b17137aa9f06d5da