### PR TITLE
Simplify index hero layout

### DIFF
--- a/generators/index_gen.py
+++ b/generators/index_gen.py
@@ -1,5 +1,4 @@
 """Index page generator with character cards"""
-import json
 
 from .base import BaseGenerator
 
@@ -25,16 +24,11 @@ class IndexGenerator(BaseGenerator):
         }
 
         cards = []
-        phase_total = 0
-        vocabulary_total = 0
 
         for char_file in character_files:
             character = self.load_character(char_file)
             char_id = char_file.stem
             journey_phases = character.get("journey_phases", [])
-
-            phase_total += len(journey_phases)
-            vocabulary_total += sum(len(phase.get("vocabulary", [])) for phase in journey_phases)
 
             first_icon = journey_phases[0]["icon"] if journey_phases else "👤"
             role = role_descriptions.get(char_id, character.get("title", "Персонаж"))
@@ -53,7 +47,4 @@ class IndexGenerator(BaseGenerator):
         return self.render_template(
             "index.html",
             cards=cards,
-            character_count=len(cards),
-            phase_total=phase_total,
-            vocabulary_total=vocabulary_total,
         )

--- a/output/index.html
+++ b/output/index.html
@@ -154,26 +154,11 @@
 </head>
 <body>
     <div class="container">
-        <header class="header">
-            <h1>👑 Путешествие Короля Лира</h1>
-            <p class="subtitle">
-                Изучаем немецкий через трагедию Шекспира<br>
-                Интерактивное путешествие с 12 персонажами
-            </p>
-            <div class="stats">
-                <div class="stat">
-                    <span class="stat-number">12</span>
-                    <span class="stat-label">Персонажей</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number">84</span>
-                    <span class="stat-label">Фазы пути</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number">651</span>
-                    <span class="stat-label">Слов B1</span>
-                </div>
-            </div>
+        <header class="main-header">
+            <h1 class="main-title">
+                <span class="crown-icon">👑</span>
+                Путешествие Короля Лира
+            </h1>
         </header>
 
         <!-- Раздел Повторить сегодня (динамический из localStorage) -->

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -18,51 +18,28 @@ body {
     padding: 20px;
 }
 
-.header {
+.main-header {
     text-align: center;
     color: white;
-    padding: 60px 20px 40px;
+    padding: 60px 20px 30px;
     animation: fadeInDown 0.8s ease;
 }
 
-.header h1 {
-    font-size: 4em;
+.main-title {
+    font-size: 3.75em;
     font-weight: 900;
     text-shadow: 3px 3px 6px rgba(0, 0, 0, 0.3);
-    margin-bottom: 20px;
     letter-spacing: -2px;
+    display: inline-flex;
+    align-items: center;
+    gap: 16px;
 }
 
-.header .subtitle {
-    font-size: 1.4em;
-    opacity: 0.95;
-    max-width: 700px;
-    margin: 0 auto 30px;
-    line-height: 1.6;
-}
-
-.stats {
-    display: flex;
+.crown-icon {
+    font-size: 1.2em;
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
-    gap: 40px;
-    margin-top: 30px;
-}
-
-.stat {
-    text-align: center;
-}
-
-.stat-number {
-    font-size: 2.5em;
-    font-weight: 700;
-    display: block;
-}
-
-.stat-label {
-    font-size: 0.9em;
-    opacity: 0.9;
-    text-transform: uppercase;
-    letter-spacing: 1px;
 }
 
 .review-section {
@@ -416,8 +393,9 @@ body {
 }
 
 @media (max-width: 768px) {
-    .header h1 {
+    .main-title {
         font-size: 2.5em;
+        gap: 12px;
     }
 
     .review-section {
@@ -445,14 +423,10 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .stats {
-        flex-direction: column;
-        gap: 20px;
-    }
 }
 
 @media (max-width: 480px) {
-    .header h1 {
+    .main-title {
         font-size: 2.2em;
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -154,26 +154,11 @@
 </head>
 <body>
     <div class="container">
-        <header class="header">
-            <h1>👑 Путешествие Короля Лира</h1>
-            <p class="subtitle">
-                Изучаем немецкий через трагедию Шекспира<br>
-                Интерактивное путешествие с {{ character_count }} персонажами
-            </p>
-            <div class="stats">
-                <div class="stat">
-                    <span class="stat-number">{{ character_count }}</span>
-                    <span class="stat-label">Персонажей</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number">{{ phase_total }}</span>
-                    <span class="stat-label">Фазы пути</span>
-                </div>
-                <div class="stat">
-                    <span class="stat-number">{{ vocabulary_total }}</span>
-                    <span class="stat-label">Слов B1</span>
-                </div>
-            </div>
+        <header class="main-header">
+            <h1 class="main-title">
+                <span class="crown-icon">👑</span>
+                Путешествие Короля Лира
+            </h1>
         </header>
 
         <!-- Раздел Повторить сегодня (динамический из localStorage) -->


### PR DESCRIPTION
## Summary
- remove descriptive subtitle and statistics from the index hero section
- update generator and template to drop unused counters for characters, phases, and vocabulary
- refresh index styles for the streamlined hero header presentation

## Testing
- python -m compileall generators/index_gen.py

------
https://chatgpt.com/codex/tasks/task_e_68ced1fae2d88320b3668f3036be94f2