### PR TITLE
Remove study word limit and enhance study list UI

### DIFF
--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["терпеть", "брак", "слабость", "молчание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["слабость", "брак", "терпеть", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["молчание", "колебаться", "слабость", "брак"], "correct_index": 3}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["пассивный", "колебаться", "молчание", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "молчание", "уступать", "слабость"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["колебаться", "молчание", "терпеть", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["уступать", "мягкий", "колебаться", "терпеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «mild»?", "choices": ["мягкий", "уступать", "молчание", "колебаться"], "correct_index": 0}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["сомнение", "совесть", "беспокойство", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["беспокойство", "подвергать сомнению", "совесть", "сомнение"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["сомнение", "тревожить", "размышлять", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["тревожить", "неуверенный", "размышлять", "подвергать сомнению"], "correct_index": 3}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["подвергать сомнению", "беспокойство", "сомнение", "тревожить"], "correct_index": 3}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["беспокойство", "неуверенный", "совесть", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["размышлять", "подвергать сомнению", "беспокойство", "совесть"], "correct_index": 0}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "ужас", "понимать", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["понимать", "ужас", "осознание", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["ужас", "пробуждаться", "понимать", "просыпаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["осознание", "понимать", "пробуждаться", "превращение"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "ужас", "просыпаться", "превращение"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["понимать", "просыпаться", "осознание", "превращение"], "correct_index": 1}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["пробуждаться", "осознание", "ясно видеть", "просыпаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["пугаться", "понимать", "просыпаться", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["мужество", "противостоять", "сопротивление", "спор"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["спор", "противостоять", "мужество", "сопротивление"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["сопротивление", "защищаться", "обвинять", "противостоять"], "correct_index": 0}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["мужество", "сопротивление", "противостоять", "обвинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["защищаться", "противостоять", "обвинять", "восставать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["спор", "защищаться", "мужество", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["сопротивление", "защищаться", "восставать", "противостоять"], "correct_index": 2}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["справедливость", "решение", "выбирать", "мораль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "выбирать", "справедливость", "решение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["праведный", "решение", "благородный", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["праведный", "благородный", "принцип", "выбирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["благородный", "принцип", "праведный", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["выбирать", "праведный", "принцип", "мораль"], "correct_index": 2}, {"question": "Что означает немецкое слово «edel»?", "choices": ["справедливость", "выбирать", "благородный", "добродетель"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["добродетель", "праведный", "решение", "выбирать"], "correct_index": 0}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "доброта", "борьба", "право"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["доброта", "борьба", "наказывать", "право"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["доброта", "защищать", "борьба", "вмешиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["право", "доброта", "судить", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «richten»?", "choices": ["доброта", "вмешиваться", "судить", "право"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["право", "защищать", "борьба", "вмешиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["доброта", "право", "вмешиваться", "защищать"], "correct_index": 2}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["мудрость", "направлять", "новое начало", "правление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "направлять", "правление", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["обновлять", "примирять", "направлять", "новое начало"], "correct_index": 3}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["правление", "направлять", "мудрость", "обновлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "правление", "направлять", "примирять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["строить", "обновлять", "примирять", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["направлять", "новое начало", "мудрость", "примирять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["строить", "мир", "обновлять", "примирять"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "слабость", "брак", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["терпеть", "брак", "слабость", "молчание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["слабость", "мягкий", "уступать", "брак"], "correct_index": 3}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["колебаться", "молчание", "мягкий", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["брак", "мягкий", "пассивный", "слабость"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "молчание", "колебаться", "брак"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["терпеть", "мягкий", "колебаться", "пассивный"], "correct_index": 2}, {"question": "Что означает немецкое слово «mild»?", "choices": ["слабость", "пассивный", "молчание", "мягкий"], "correct_index": 3}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["беспокойство", "подвергать сомнению", "сомнение", "совесть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["беспокойство", "подвергать сомнению", "сомнение", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["неуверенный", "совесть", "беспокойство", "тревожить"], "correct_index": 2}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["неуверенный", "подвергать сомнению", "совесть", "сомнение"], "correct_index": 1}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["подвергать сомнению", "тревожить", "беспокойство", "неуверенный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["неуверенный", "тревожить", "беспокойство", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["совесть", "неуверенный", "подвергать сомнению", "размышлять"], "correct_index": 3}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["ужас", "понимать", "осознание", "пробуждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["пробуждаться", "осознание", "понимать", "ужас"], "correct_index": 3}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "просыпаться", "осознание", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["пугаться", "ясно видеть", "осознание", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["понимать", "пробуждаться", "пугаться", "превращение"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["просыпаться", "ясно видеть", "превращение", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["превращение", "ясно видеть", "осознание", "просыпаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["превращение", "понимать", "пугаться", "просыпаться"], "correct_index": 0}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "противостоять", "мужество", "сопротивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "противостоять", "сопротивление", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["спор", "сопротивление", "обвинять", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["противостоять", "сопротивление", "спор", "защищаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["восставать", "защищаться", "спор", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["мужество", "сопротивление", "защищаться", "противостоять"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["восставать", "мужество", "спор", "сопротивление"], "correct_index": 0}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["выбирать", "мораль", "решение", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "решение", "выбирать", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["выбирать", "принцип", "справедливость", "решение"], "correct_index": 3}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["выбирать", "праведный", "добродетель", "принцип"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["добродетель", "благородный", "праведный", "мораль"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "праведный", "мораль", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["добродетель", "справедливость", "благородный", "принцип"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["принцип", "добродетель", "мораль", "решение"], "correct_index": 1}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "право", "доброта", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["право", "доброта", "борьба", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["наказывать", "право", "доброта", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["борьба", "судить", "право", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «richten»?", "choices": ["защищать", "наказывать", "судить", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["судить", "вмешиваться", "право", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["вмешиваться", "наказывать", "право", "защищать"], "correct_index": 0}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["направлять", "новое начало", "мудрость", "правление"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["новое начало", "мир", "направлять", "обновлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["мудрость", "новое начало", "примирять", "направлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "обновлять", "новое начало", "направлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["обновлять", "мир", "правление", "примирять"], "correct_index": 0}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["правление", "направлять", "примирять", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мудрость", "правление", "мир", "строить"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,8 +662,24 @@
             <div class="quiz-phase-container active" data-phase="passive_duke">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
@@ -678,31 +694,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
@@ -714,11 +714,11 @@
                         <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                             
@@ -726,15 +726,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                             
@@ -742,17 +742,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,29 +762,29 @@
                         <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,27 +797,59 @@
             <div class="quiz-phase-container" data-phase="first_doubts">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
                             
@@ -829,81 +861,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,29 +916,13 @@
             <div class="quiz-phase-container" data-phase="awakening">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
@@ -948,56 +932,24 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
@@ -1006,21 +958,69 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                             
@@ -1028,17 +1028,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,24 +1051,8 @@
             <div class="quiz-phase-container" data-phase="confrontation">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
@@ -1083,81 +1067,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,29 +1170,45 @@
             <div class="quiz-phase-container" data-phase="moral_stand">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
@@ -1202,33 +1218,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1238,29 +1238,29 @@
                         <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1270,29 +1270,29 @@
                         <div class="quiz-question">Что означает немецкое слово «edel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,49 +1305,49 @@
             <div class="quiz-phase-container" data-phase="justice_seeker">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1357,11 +1357,11 @@
                         <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                             
@@ -1373,43 +1373,43 @@
                         <div class="quiz-question">Что означает немецкое слово «richten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
@@ -1424,7 +1424,7 @@
             <div class="quiz-phase-container" data-phase="new_ruler">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                         <div class="quiz-choices">
                             
@@ -1432,39 +1432,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                             
@@ -1472,17 +1440,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1494,9 +1494,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                             
@@ -1504,13 +1520,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
                             
@@ -1520,33 +1536,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1952,29 +1952,29 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "терпеть",
-                    "брак",
-                    "слабость",
-                    "молчание"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Schwäche»?",
-                "choices": [
+                    "молчание",
                     "слабость",
                     "брак",
-                    "терпеть",
-                    "молчание"
+                    "терпеть"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Schwäche»?",
+                "choices": [
+                    "терпеть",
+                    "брак",
+                    "слабость",
+                    "молчание"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
-                    "молчание",
-                    "колебаться",
                     "слабость",
+                    "мягкий",
+                    "уступать",
                     "брак"
                 ],
                 "correctIndex": 3
@@ -1982,9 +1982,9 @@
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
-                    "пассивный",
                     "колебаться",
                     "молчание",
+                    "мягкий",
                     "терпеть"
                 ],
                 "correctIndex": 3
@@ -1992,42 +1992,42 @@
             {
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
+                    "брак",
+                    "мягкий",
                     "пассивный",
-                    "молчание",
-                    "уступать",
                     "слабость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
-                    "колебаться",
+                    "уступать",
                     "молчание",
-                    "терпеть",
-                    "уступать"
+                    "колебаться",
+                    "брак"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "уступать",
+                    "терпеть",
                     "мягкий",
                     "колебаться",
-                    "терпеть"
+                    "пассивный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
-                    "мягкий",
-                    "уступать",
+                    "слабость",
+                    "пассивный",
                     "молчание",
-                    "колебаться"
+                    "мягкий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2454,72 +2454,72 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "сомнение",
-                    "совесть",
                     "беспокойство",
-                    "подвергать сомнению"
+                    "подвергать сомнению",
+                    "сомнение",
+                    "совесть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
                     "беспокойство",
                     "подвергать сомнению",
-                    "совесть",
-                    "сомнение"
+                    "сомнение",
+                    "совесть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "сомнение",
-                    "тревожить",
-                    "размышлять",
-                    "беспокойство"
+                    "неуверенный",
+                    "совесть",
+                    "беспокойство",
+                    "тревожить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
-                    "тревожить",
                     "неуверенный",
-                    "размышлять",
-                    "подвергать сомнению"
+                    "подвергать сомнению",
+                    "совесть",
+                    "сомнение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
                     "подвергать сомнению",
+                    "тревожить",
                     "беспокойство",
-                    "сомнение",
-                    "тревожить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «unsicher»?",
-                "choices": [
-                    "беспокойство",
-                    "неуверенный",
-                    "совесть",
-                    "размышлять"
+                    "неуверенный"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «grübeln»?",
+                "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "размышлять",
-                    "подвергать сомнению",
+                    "неуверенный",
+                    "тревожить",
                     "беспокойство",
                     "совесть"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «grübeln»?",
+                "choices": [
+                    "совесть",
+                    "неуверенный",
+                    "подвергать сомнению",
+                    "размышлять"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2979,82 +2979,82 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "осознание",
                     "ужас",
                     "понимать",
-                    "пробуждаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Entsetzen»?",
-                "choices": [
-                    "понимать",
-                    "ужас",
                     "осознание",
                     "пробуждаться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erwachen»?",
-                "choices": [
-                    "ужас",
-                    "пробуждаться",
-                    "понимать",
-                    "просыпаться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «begreifen»?",
-                "choices": [
-                    "осознание",
-                    "понимать",
-                    "пробуждаться",
-                    "превращение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erschrecken»?",
-                "choices": [
-                    "пугаться",
-                    "ужас",
-                    "просыпаться",
-                    "превращение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «aufwachen»?",
-                "choices": [
-                    "понимать",
-                    "просыпаться",
-                    "осознание",
-                    "превращение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «klar sehen»?",
-                "choices": [
-                    "пробуждаться",
-                    "осознание",
-                    "ясно видеть",
-                    "просыпаться"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Verwandlung»?",
+                "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
-                    "пугаться",
+                    "пробуждаться",
+                    "осознание",
                     "понимать",
-                    "просыпаться",
-                    "превращение"
+                    "ужас"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «erwachen»?",
+                "choices": [
+                    "понимать",
+                    "просыпаться",
+                    "осознание",
+                    "пробуждаться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «begreifen»?",
+                "choices": [
+                    "пугаться",
+                    "ясно видеть",
+                    "осознание",
+                    "понимать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «erschrecken»?",
+                "choices": [
+                    "понимать",
+                    "пробуждаться",
+                    "пугаться",
+                    "превращение"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «aufwachen»?",
+                "choices": [
+                    "просыпаться",
+                    "ясно видеть",
+                    "превращение",
+                    "осознание"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «klar sehen»?",
+                "choices": [
+                    "превращение",
+                    "ясно видеть",
+                    "осознание",
+                    "просыпаться"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Verwandlung»?",
+                "choices": [
+                    "превращение",
+                    "понимать",
+                    "пугаться",
+                    "просыпаться"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3482,72 +3482,72 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "мужество",
-                    "противостоять",
-                    "сопротивление",
-                    "спор"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Mut»?",
-                "choices": [
                     "спор",
                     "противостоять",
                     "мужество",
                     "сопротивление"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Widerstand»?",
+                "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
+                    "мужество",
+                    "противостоять",
                     "сопротивление",
-                    "защищаться",
-                    "обвинять",
-                    "противостоять"
+                    "спор"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «konfrontieren»?",
-                "choices": [
-                    "мужество",
-                    "сопротивление",
-                    "противостоять",
-                    "обвинять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «anklagen»?",
-                "choices": [
-                    "защищаться",
-                    "противостоять",
-                    "обвинять",
-                    "восставать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «sich wehren»?",
+                "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
                     "спор",
-                    "защищаться",
-                    "мужество",
-                    "обвинять"
+                    "сопротивление",
+                    "обвинять",
+                    "мужество"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «aufbegehren»?",
+                "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
+                    "противостоять",
+                    "сопротивление",
+                    "спор",
+                    "защищаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «anklagen»?",
+                "choices": [
+                    "восставать",
+                    "защищаться",
+                    "спор",
+                    "обвинять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «sich wehren»?",
+                "choices": [
+                    "мужество",
                     "сопротивление",
                     "защищаться",
-                    "восставать",
                     "противостоять"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «aufbegehren»?",
+                "choices": [
+                    "восставать",
+                    "мужество",
+                    "спор",
+                    "сопротивление"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4011,82 +4011,82 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "справедливость",
-                    "решение",
                     "выбирать",
-                    "мораль"
+                    "мораль",
+                    "решение",
+                    "справедливость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "мораль",
-                    "выбирать",
-                    "справедливость",
-                    "решение"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Entscheidung»?",
-                "choices": [
-                    "праведный",
                     "решение",
-                    "благородный",
-                    "мораль"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «wählen»?",
-                "choices": [
-                    "праведный",
-                    "благородный",
-                    "принцип",
-                    "выбирать"
+                    "выбирать",
+                    "справедливость"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Entscheidung»?",
+                "choices": [
+                    "выбирать",
+                    "принцип",
+                    "справедливость",
+                    "решение"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «wählen»?",
+                "choices": [
+                    "выбирать",
+                    "праведный",
+                    "добродетель",
+                    "принцип"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
+                    "добродетель",
                     "благородный",
-                    "принцип",
                     "праведный",
-                    "выбирать"
+                    "мораль"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
-                    "выбирать",
-                    "праведный",
                     "принцип",
-                    "мораль"
+                    "праведный",
+                    "мораль",
+                    "справедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
+                    "добродетель",
                     "справедливость",
-                    "выбирать",
                     "благородный",
-                    "добродетель"
+                    "принцип"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
+                    "принцип",
                     "добродетель",
-                    "праведный",
-                    "решение",
-                    "выбирать"
+                    "мораль",
+                    "решение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4511,38 +4511,38 @@
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "наказывать",
+                    "право",
                     "доброта",
-                    "борьба",
-                    "право"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Recht»?",
-                "choices": [
-                    "доброта",
-                    "борьба",
-                    "наказывать",
-                    "право"
+                    "борьба"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Güte»?",
+                "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
+                    "право",
                     "доброта",
-                    "защищать",
                     "борьба",
-                    "вмешиваться"
+                    "наказывать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «strafen»?",
+                "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
+                    "наказывать",
                     "право",
                     "доброта",
+                    "защищать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «strafen»?",
+                "choices": [
+                    "борьба",
                     "судить",
+                    "право",
                     "наказывать"
                 ],
                 "correctIndex": 3
@@ -4550,32 +4550,32 @@
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
-                    "доброта",
-                    "вмешиваться",
+                    "защищать",
+                    "наказывать",
                     "судить",
-                    "право"
+                    "борьба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
+                    "судить",
+                    "вмешиваться",
                     "право",
-                    "защищать",
-                    "борьба",
-                    "вмешиваться"
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "доброта",
-                    "право",
                     "вмешиваться",
+                    "наказывать",
+                    "право",
                     "защищать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5066,80 +5066,80 @@
                 "choices": [
                     "мудрость",
                     "направлять",
-                    "новое начало",
-                    "правление"
+                    "правление",
+                    "новое начало"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "новое начало",
                     "направлять",
-                    "правление",
-                    "мудрость"
+                    "новое начало",
+                    "мудрость",
+                    "правление"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "обновлять",
-                    "примирять",
+                    "новое начало",
+                    "мир",
                     "направлять",
-                    "новое начало"
+                    "обновлять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
-                    "правление",
-                    "направлять",
                     "мудрость",
-                    "обновлять"
+                    "новое начало",
+                    "примирять",
+                    "направлять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
                     "строить",
-                    "правление",
-                    "направлять",
-                    "примирять"
+                    "обновлять",
+                    "новое начало",
+                    "направлять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "строить",
                     "обновлять",
-                    "примирять",
-                    "мудрость"
+                    "мир",
+                    "правление",
+                    "примирять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
+                    "правление",
                     "направлять",
-                    "новое начало",
-                    "мудрость",
-                    "примирять"
+                    "примирять",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "строить",
+                    "мудрость",
+                    "правление",
                     "мир",
-                    "обновлять",
-                    "примирять"
+                    "строить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5244,6 +5244,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5528,36 +5729,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6070,6 +6257,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6093,97 +6284,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7101,6 +7258,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["власть", "правда", "церемония", "провозглашать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["провозглашать", "церемония", "правда", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "повиноваться", "церемония", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["повиноваться", "церемония", "долг", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["правда", "долг", "торжественный", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["власть", "торжественный", "долг", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["долг", "правда", "повиноваться", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["провозглашать", "церемония", "повиноваться", "верность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["наказание", "изгонять", "покидать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "наказание", "изгонять", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["принимать", "наказание", "изгонять", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["надежда", "чужой", "наказание", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["наказание", "приданое", "принимать", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["приданое", "чужой", "надежда", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["изгонять", "покидать", "чужой", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["гнев", "чужой", "надежда", "наказание"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["известие", "забота", "одиночество", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "забота", "известие", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["страх", "известие", "забота", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страх", "забота", "одиночество", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["молиться", "защищать", "страдать", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["страх", "известие", "защищать", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["известие", "молиться", "забота", "тоска"], "correct_index": 3}, {"question": "Что означает немецкое слово «beten»?", "choices": ["забота", "молиться", "страх", "известие"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["спасать", "возвращаться", "борьба", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["битва", "возвращаться", "спасать", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["возвращаться", "армия", "справедливость", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["битва", "спасать", "армия", "храбрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "битва", "борьба", "армия"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["спасать", "побеждать", "храбрый", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["спасать", "битва", "борьба", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["справедливость", "армия", "битва", "храбрый"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["обнимать", "слёзы", "прощать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["слёзы", "узнавать", "прощать", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["исцелять", "обнимать", "слёзы", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["нежный", "прощение", "слёзы", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["прощать", "слёзы", "узнавать", "исцелять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["прощать", "слёзы", "нежный", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["исцелять", "нежный", "узнавать", "прощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["прощение", "слёзы", "нежный", "исцелять"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["тюрьма", "пленный", "утешать", "достоинство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "тюрьма", "утешать", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["судьба", "достоинство", "отважный", "честь"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "достоинство", "честь", "пленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["судьба", "честь", "отважный", "пленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["утешать", "отважный", "смирение", "пленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["смирение", "утешать", "судьба", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["пленный", "судьба", "утешать", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "душа", "жертва", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "жертва", "умирать", "душа"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["вечный", "жертва", "умирать", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["прощание", "умирать", "жертва", "душа"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "вечный", "душа", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["душа", "вечный", "жертва", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["спасение", "душа", "умирать", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["конец", "смерть", "спасение", "вечный"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "власть", "правда", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["власть", "правда", "церемония", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "повиноваться", "церемония", "провозглашать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["власть", "торжественный", "долг", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "власть", "провозглашать", "долг"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["правда", "верность", "провозглашать", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["правда", "церемония", "повиноваться", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["торжественный", "верность", "провозглашать", "власть"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "покидать", "наказание", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["изгонять", "наказание", "гнев", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "приданое", "надежда", "принимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "покидать", "наказание", "приданое"], "correct_index": 2}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["принимать", "чужой", "гнев", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["гнев", "покидать", "приданое", "принимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["изгонять", "надежда", "гнев", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["надежда", "наказание", "чужой", "гнев"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["забота", "страх", "одиночество", "известие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["известие", "забота", "одиночество", "страх"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["одиночество", "тоска", "известие", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страх", "защищать", "известие", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["известие", "страх", "защищать", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "страх", "известие", "молиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["забота", "тоска", "одиночество", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «beten»?", "choices": ["страх", "молиться", "забота", "страдать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "битва", "борьба", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["битва", "спасать", "борьба", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "армия", "борьба", "храбрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["справедливость", "битва", "армия", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["возвращаться", "храбрый", "спасать", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["битва", "армия", "справедливость", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["битва", "спасать", "борьба", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["побеждать", "справедливость", "армия", "борьба"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["обнимать", "слёзы", "прощать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["узнавать", "прощать", "обнимать", "слёзы"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["нежный", "прощение", "узнавать", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "узнавать", "нежный", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["прощать", "слёзы", "исцелять", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["исцелять", "прощение", "раскаяние", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["прощать", "нежный", "раскаяние", "прощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "прощение", "прощать", "узнавать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "тюрьма", "достоинство", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "пленный", "тюрьма", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["пленный", "тюрьма", "достоинство", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["честь", "судьба", "смирение", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["честь", "отважный", "тюрьма", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["смирение", "честь", "пленный", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["смирение", "отважный", "утешать", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["смирение", "судьба", "тюрьма", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["душа", "умирать", "жертва", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "душа", "жертва", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["смерть", "жертва", "спасение", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["конец", "душа", "прощание", "жертва"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "душа", "спасение", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["конец", "душа", "вечный", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "жертва", "прощание", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["смерть", "спасение", "вечный", "конец"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,8 +662,24 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
@@ -673,22 +689,6 @@
                             <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -710,40 +710,8 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
@@ -752,7 +720,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,9 +762,9 @@
                         <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
                             
@@ -774,17 +774,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,15 +797,15 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
@@ -817,11 +817,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
@@ -829,17 +829,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -849,45 +849,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -899,9 +899,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
                             
@@ -909,17 +909,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">надежда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,8 +932,24 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
@@ -948,33 +964,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -986,9 +986,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
@@ -996,29 +996,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
@@ -1028,17 +1012,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1048,13 +1048,13 @@
                         <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,47 +1067,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                             
@@ -1115,15 +1083,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
                             
@@ -1131,33 +1115,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1167,9 +1167,9 @@
                         <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                             
@@ -1179,17 +1179,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1218,15 +1218,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
@@ -1234,15 +1250,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
@@ -1250,23 +1266,7 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
                         <div class="quiz-choices">
                             
@@ -1274,25 +1274,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1302,11 +1302,11 @@
                         <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">нежный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                             
@@ -1314,17 +1314,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1337,113 +1337,113 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1453,11 +1453,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
@@ -1472,33 +1472,33 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1508,29 +1508,29 @@
                         <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1542,59 +1542,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2054,22 +2054,22 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "церемония",
+                    "власть",
+                    "правда",
+                    "провозглашать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Zeremonie»?",
+                "choices": [
                     "власть",
                     "правда",
                     "церемония",
                     "провозглашать"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Zeremonie»?",
-                "choices": [
-                    "провозглашать",
-                    "церемония",
-                    "правда",
-                    "власть"
-                ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
@@ -2084,38 +2084,38 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "повиноваться",
-                    "церемония",
+                    "власть",
+                    "торжественный",
                     "долг",
-                    "власть"
+                    "церемония"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gehorchen»?",
                 "choices": [
-                    "правда",
-                    "долг",
-                    "торжественный",
-                    "повиноваться"
+                    "повиноваться",
+                    "власть",
+                    "провозглашать",
+                    "долг"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "власть",
-                    "торжественный",
-                    "долг",
-                    "провозглашать"
+                    "правда",
+                    "верность",
+                    "провозглашать",
+                    "долг"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
-                    "долг",
                     "правда",
+                    "церемония",
                     "повиноваться",
                     "торжественный"
                 ],
@@ -2124,12 +2124,12 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
+                    "торжественный",
+                    "верность",
                     "провозглашать",
-                    "церемония",
-                    "повиноваться",
-                    "верность"
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2663,19 +2663,19 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "наказание",
                     "изгонять",
                     "покидать",
+                    "наказание",
                     "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "гнев",
-                    "наказание",
                     "изгонять",
+                    "наказание",
+                    "гнев",
                     "покидать"
                 ],
                 "correctIndex": 3
@@ -2683,49 +2683,49 @@
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "принимать",
-                    "наказание",
-                    "изгонять",
-                    "гнев"
+                    "гнев",
+                    "приданое",
+                    "надежда",
+                    "принимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "надежда",
-                    "чужой",
+                    "гнев",
+                    "покидать",
                     "наказание",
-                    "изгонять"
+                    "приданое"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
-                    "наказание",
-                    "приданое",
                     "принимать",
-                    "чужой"
+                    "чужой",
+                    "гнев",
+                    "покидать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
+                    "гнев",
+                    "покидать",
                     "приданое",
-                    "чужой",
-                    "надежда",
-                    "гнев"
+                    "принимать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
                     "изгонять",
-                    "покидать",
-                    "чужой",
+                    "надежда",
+                    "гнев",
                     "принимать"
                 ],
                 "correctIndex": 3
@@ -2733,12 +2733,12 @@
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "гнев",
-                    "чужой",
                     "надежда",
-                    "наказание"
+                    "наказание",
+                    "чужой",
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3268,39 +3268,39 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
+                    "забота",
+                    "страх",
+                    "одиночество",
+                    "известие"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Einsamkeit»?",
+                "choices": [
                     "известие",
                     "забота",
                     "одиночество",
                     "страх"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Einsamkeit»?",
-                "choices": [
-                    "страх",
-                    "забота",
-                    "известие",
-                    "одиночество"
-                ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
-                    "страх",
+                    "одиночество",
+                    "тоска",
                     "известие",
-                    "забота",
-                    "одиночество"
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
                     "страх",
-                    "забота",
-                    "одиночество",
+                    "защищать",
+                    "известие",
                     "страдать"
                 ],
                 "correctIndex": 0
@@ -3308,40 +3308,40 @@
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "молиться",
-                    "защищать",
-                    "страдать",
-                    "одиночество"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «beschützen»?",
-                "choices": [
-                    "страх",
                     "известие",
+                    "страх",
                     "защищать",
                     "страдать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Sehnsucht»?",
-                "choices": [
-                    "известие",
-                    "молиться",
-                    "забота",
-                    "тоска"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «beten»?",
+                "question": "Что означает немецкое слово «beschützen»?",
+                "choices": [
+                    "защищать",
+                    "страх",
+                    "известие",
+                    "молиться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
                     "забота",
-                    "молиться",
+                    "тоска",
+                    "одиночество",
+                    "молиться"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «beten»?",
+                "choices": [
                     "страх",
-                    "известие"
+                    "молиться",
+                    "забота",
+                    "страдать"
                 ],
                 "correctIndex": 1
             }
@@ -3870,68 +3870,68 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "спасать",
                     "возвращаться",
+                    "битва",
                     "борьба",
-                    "битва"
+                    "спасать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "битва",
-                    "возвращаться",
                     "спасать",
-                    "борьба"
+                    "борьба",
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "возвращаться",
-                    "армия",
-                    "справедливость",
-                    "спасать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Schlacht»?",
-                "choices": [
-                    "битва",
                     "спасать",
                     "армия",
+                    "борьба",
                     "храбрый"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Schlacht»?",
+                "choices": [
+                    "справедливость",
+                    "битва",
+                    "армия",
+                    "борьба"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
+                    "возвращаться",
                     "храбрый",
-                    "битва",
-                    "борьба",
-                    "армия"
+                    "спасать",
+                    "битва"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "спасать",
-                    "побеждать",
-                    "храбрый",
-                    "справедливость"
+                    "битва",
+                    "армия",
+                    "справедливость",
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "спасать",
                     "битва",
+                    "спасать",
                     "борьба",
                     "побеждать"
                 ],
@@ -3940,12 +3940,12 @@
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
+                    "побеждать",
                     "справедливость",
                     "армия",
-                    "битва",
-                    "храбрый"
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4497,59 +4497,59 @@
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
-                    "слёзы",
                     "узнавать",
                     "прощать",
-                    "обнимать"
+                    "обнимать",
+                    "слёзы"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "исцелять",
-                    "обнимать",
-                    "слёзы",
-                    "раскаяние"
+                    "нежный",
+                    "прощение",
+                    "узнавать",
+                    "обнимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "прощать",
+                    "узнавать",
                     "нежный",
-                    "прощение",
-                    "слёзы",
-                    "узнавать"
+                    "раскаяние"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «heilen»?",
                 "choices": [
                     "прощать",
                     "слёзы",
-                    "узнавать",
-                    "исцелять"
+                    "исцелять",
+                    "обнимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "прощать",
-                    "слёзы",
-                    "нежный",
-                    "раскаяние"
+                    "исцелять",
+                    "прощение",
+                    "раскаяние",
+                    "обнимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "исцелять",
+                    "прощать",
                     "нежный",
-                    "узнавать",
+                    "раскаяние",
                     "прощение"
                 ],
                 "correctIndex": 1
@@ -4557,12 +4557,12 @@
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
+                    "обнимать",
                     "прощение",
-                    "слёзы",
-                    "нежный",
-                    "исцелять"
+                    "прощать",
+                    "узнавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5090,79 +5090,79 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "тюрьма",
                     "пленный",
-                    "утешать",
-                    "достоинство"
+                    "тюрьма",
+                    "достоинство",
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
                     "достоинство",
+                    "пленный",
                     "тюрьма",
-                    "утешать",
-                    "пленный"
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
-                    "судьба",
+                    "пленный",
+                    "тюрьма",
                     "достоинство",
-                    "отважный",
-                    "честь"
+                    "судьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "утешать",
-                    "достоинство",
                     "честь",
-                    "пленный"
+                    "судьба",
+                    "смирение",
+                    "утешать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
-                    "судьба",
                     "честь",
                     "отважный",
-                    "пленный"
+                    "тюрьма",
+                    "смирение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
-                    "утешать",
-                    "отважный",
                     "смирение",
-                    "пленный"
+                    "честь",
+                    "пленный",
+                    "утешать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
                     "смирение",
+                    "отважный",
                     "утешать",
-                    "судьба",
-                    "честь"
+                    "судьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "пленный",
+                    "смирение",
                     "судьба",
-                    "утешать",
+                    "тюрьма",
                     "честь"
                 ],
                 "correctIndex": 3
@@ -5727,82 +5727,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "смерть",
                     "душа",
+                    "умирать",
                     "жертва",
-                    "умирать"
+                    "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "смерть",
-                    "жертва",
                     "умирать",
-                    "душа"
+                    "душа",
+                    "жертва",
+                    "смерть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
-                    "вечный",
+                    "смерть",
                     "жертва",
-                    "умирать",
-                    "смерть"
+                    "спасение",
+                    "прощание"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
+                    "конец",
+                    "душа",
                     "прощание",
-                    "умирать",
-                    "жертва",
-                    "душа"
+                    "жертва"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "конец",
-                    "вечный",
                     "душа",
-                    "умирать"
+                    "спасение",
+                    "смерть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
+                    "конец",
                     "душа",
                     "вечный",
-                    "жертва",
-                    "умирать"
+                    "жертва"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "спасение",
-                    "душа",
                     "умирать",
-                    "прощание"
+                    "жертва",
+                    "прощание",
+                    "вечный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "конец",
                     "смерть",
                     "спасение",
-                    "вечный"
+                    "вечный",
+                    "конец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5923,6 +5923,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6207,36 +6408,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6749,6 +6936,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6772,97 +6963,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7780,6 +7937,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["честолюбие", "желать", "стремиться", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "стремиться", "честолюбие", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["захватывать", "честолюбие", "вожделеть", "стремиться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["властолюбие", "желать", "жадный", "захватывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["властолюбие", "желать", "вожделеть", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["властолюбие", "жадность", "жадный", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["честолюбие", "захватывать", "жадность", "властолюбие"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["жадный", "захватывать", "жадность", "желать"], "correct_index": 1}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["одобрять", "поддерживать", "злоба", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жестокость", "одобрять", "злоба", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["поддерживать", "суровость", "одобрять", "поощрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["подстрекать", "поддерживать", "поощрять", "суровость"], "correct_index": 1}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поощрять", "суровость", "подстрекать", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["жестокость", "поощрять", "поддерживать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "суровость", "одобрять", "поощрять"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["страх", "угнетение", "тирания", "подавлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["тирания", "угнетение", "подавлять", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "угнетение", "порабощать", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["тирания", "порабощать", "подавлять", "брутальный"], "correct_index": 2}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "брутальный", "подавлять", "принуждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "произвол", "угнетение", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["угнетение", "порабощать", "подавлять", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["брутальный", "угнетение", "тирания", "страх"], "correct_index": 0}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["карать", "наказывать", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказывать", "наказание", "гнев", "карать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["наказывать", "карать", "мучить", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["наказание", "карать", "гнев", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["наказание", "унижать", "гнев", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["карать", "наказание", "унижать", "мучить"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["мучить", "унижать", "наказывать", "наказание"], "correct_index": 0}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "пытка", "пытать", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "пытать", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["пытка", "садизм", "кровь", "калечить"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["мука", "садизм", "пытать", "калечить"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытать", "калечить", "выкалывать", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["мука", "выкалывать", "ослеплять", "калечить"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["ослеплять", "пытать", "садизм", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["садизм", "мука", "пытка", "калечить"], "correct_index": 1}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["удивление", "рана", "боль", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "боль", "рана", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["раненый", "кровоточить", "боль", "удивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["кровоточить", "раненый", "удивление", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["раненый", "рана", "удивление", "ослаблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["страдать", "ослаблять", "рана", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "ослаблять", "рана", "кровоточить"], "correct_index": 0}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["возмездие", "конец", "умирать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["возмездие", "конец", "умирать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["кара", "конец", "хрипеть", "возмездие"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["хрипеть", "проклинать", "умирать", "возмездие"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["хрипеть", "проклинать", "издыхать", "кара"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "издыхать", "умирать", "хрипеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["умирать", "хрипеть", "смерть", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["кара", "возмездие", "умирать", "хрипеть"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["честолюбие", "стремиться", "жадность", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["стремиться", "желать", "жадность", "честолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «streben»?", "choices": ["жадный", "желать", "вожделеть", "стремиться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["честолюбие", "жадность", "желать", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["властолюбие", "захватывать", "вожделеть", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["властолюбие", "захватывать", "стремиться", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["честолюбие", "захватывать", "властолюбие", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["захватывать", "жадность", "вожделеть", "властолюбие"], "correct_index": 0}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "злоба", "одобрять", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["поддерживать", "одобрять", "злоба", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["одобрять", "суровость", "жестокость", "подстрекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "подстрекать", "одобрять", "суровость"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поддерживать", "подстрекать", "жестокость", "поощрять"], "correct_index": 1}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["поощрять", "одобрять", "поддерживать", "подстрекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["подстрекать", "суровость", "поощрять", "жестокость"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "угнетение", "подавлять", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "угнетение", "тирания", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["произвол", "тирания", "страх", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["принуждать", "подавлять", "тирания", "брутальный"], "correct_index": 1}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["страх", "брутальный", "порабощать", "угнетение"], "correct_index": 2}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["принуждать", "тирания", "угнетение", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["произвол", "принуждать", "страх", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["подавлять", "брутальный", "порабощать", "угнетение"], "correct_index": 1}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказывать", "карать", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["карать", "наказывать", "гнев", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["унижать", "гнев", "карать", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["наказывать", "унижать", "гнев", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["наказывать", "унижать", "мучить", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["гнев", "наказывать", "унижать", "мучить"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "мучить", "наказание", "карать"], "correct_index": 1}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "пытать", "садизм", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["садизм", "пытать", "кровь", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["кровь", "калечить", "пытка", "мука"], "correct_index": 0}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "садизм", "выкалывать", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["мука", "выкалывать", "пытать", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "калечить", "ослеплять", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["калечить", "кровь", "выкалывать", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мука", "садизм", "пытать", "кровь"], "correct_index": 0}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["боль", "кровоточить", "удивление", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "рана", "кровоточить", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["страдать", "раненый", "кровоточить", "удивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["ослаблять", "рана", "удивление", "кровоточить"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["боль", "ослаблять", "раненый", "удивление"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["ослаблять", "удивление", "страдать", "кровоточить"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["рана", "ослаблять", "раненый", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "умирать", "возмездие", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["конец", "умирать", "возмездие", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["издыхать", "хрипеть", "конец", "кара"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "умирать", "проклинать", "хрипеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "хрипеть", "умирать", "кара"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["кара", "проклинать", "смерть", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["умирать", "хрипеть", "издыхать", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["кара", "конец", "умирать", "смерть"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -668,27 +668,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -698,9 +698,9 @@
                         <div class="quiz-question">Что означает немецкое слово «streben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
@@ -710,17 +710,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -732,33 +732,33 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
                         <div class="quiz-choices">
                             
@@ -766,25 +766,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -801,11 +801,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
@@ -817,43 +817,43 @@
                         <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
                             
@@ -861,33 +861,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -897,13 +897,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,24 +916,8 @@
             <div class="quiz-phase-container" data-phase="tyrant">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
@@ -948,31 +932,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
                             
@@ -980,17 +980,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1002,43 +1002,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1055,9 +1055,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -1071,9 +1071,41 @@
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
+                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
+                        <div class="quiz-choices">
+                            
                             <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
@@ -1083,49 +1115,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1135,9 +1135,9 @@
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
@@ -1147,17 +1147,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,81 +1170,81 @@
             <div class="quiz-phase-container" data-phase="torturer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1254,45 +1254,45 @@
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,33 +1305,33 @@
             <div class="quiz-phase-container" data-phase="wounded">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1341,11 +1341,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                             
@@ -1353,47 +1353,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                             
@@ -1401,17 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1428,11 +1428,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1440,15 +1440,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
@@ -1456,47 +1456,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возмездие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                             
@@ -1504,17 +1472,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1528,7 +1528,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
@@ -1542,11 +1542,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1953,27 +1953,27 @@
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
                     "честолюбие",
-                    "желать",
                     "стремиться",
-                    "жадность"
+                    "жадность",
+                    "желать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "жадность",
                     "стремиться",
-                    "честолюбие",
-                    "желать"
+                    "желать",
+                    "жадность",
+                    "честолюбие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
-                    "захватывать",
-                    "честолюбие",
+                    "жадный",
+                    "желать",
                     "вожделеть",
                     "стремиться"
                 ],
@@ -1982,20 +1982,20 @@
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
-                    "властолюбие",
+                    "честолюбие",
+                    "жадность",
                     "желать",
-                    "жадный",
-                    "захватывать"
+                    "вожделеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
                     "властолюбие",
-                    "желать",
+                    "захватывать",
                     "вожделеть",
-                    "стремиться"
+                    "жадность"
                 ],
                 "correctIndex": 2
             },
@@ -2003,31 +2003,31 @@
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
                     "властолюбие",
-                    "жадность",
-                    "жадный",
-                    "стремиться"
+                    "захватывать",
+                    "стремиться",
+                    "жадный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
                     "честолюбие",
                     "захватывать",
-                    "жадность",
-                    "властолюбие"
+                    "властолюбие",
+                    "стремиться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
-                    "жадный",
                     "захватывать",
                     "жадность",
-                    "желать"
+                    "вожделеть",
+                    "властолюбие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2485,9 +2485,9 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "одобрять",
                     "поддерживать",
                     "злоба",
+                    "одобрять",
                     "жестокость"
                 ],
                 "correctIndex": 3
@@ -2495,60 +2495,60 @@
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "жестокость",
+                    "поддерживать",
                     "одобрять",
                     "злоба",
-                    "поддерживать"
+                    "жестокость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
-                    "поддерживать",
-                    "суровость",
                     "одобрять",
-                    "поощрять"
+                    "суровость",
+                    "жестокость",
+                    "подстрекать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unterstützen»?",
                 "choices": [
-                    "подстрекать",
                     "поддерживать",
-                    "поощрять",
+                    "подстрекать",
+                    "одобрять",
                     "суровость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «anstacheln»?",
                 "choices": [
-                    "поощрять",
-                    "суровость",
-                    "подстрекать",
-                    "поддерживать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «ermutigen»?",
-                "choices": [
-                    "жестокость",
-                    "поощрять",
                     "поддерживать",
-                    "злоба"
+                    "подстрекать",
+                    "жестокость",
+                    "поощрять"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «ermutigen»?",
+                "choices": [
+                    "поощрять",
+                    "одобрять",
+                    "поддерживать",
+                    "подстрекать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "жестокость",
+                    "подстрекать",
                     "суровость",
-                    "одобрять",
-                    "поощрять"
+                    "поощрять",
+                    "жестокость"
                 ],
                 "correctIndex": 1
             }
@@ -3010,19 +3010,19 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
-                    "страх",
-                    "угнетение",
                     "тирания",
-                    "подавлять"
+                    "угнетение",
+                    "подавлять",
+                    "страх"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "тирания",
-                    "угнетение",
                     "подавлять",
+                    "угнетение",
+                    "тирания",
                     "страх"
                 ],
                 "correctIndex": 1
@@ -3030,62 +3030,62 @@
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
-                    "страх",
-                    "угнетение",
-                    "порабощать",
-                    "тирания"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «unterdrücken»?",
-                "choices": [
+                    "произвол",
                     "тирания",
-                    "порабощать",
-                    "подавлять",
-                    "брутальный"
+                    "страх",
+                    "угнетение"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «unterdrücken»?",
+                "choices": [
+                    "принуждать",
+                    "подавлять",
+                    "тирания",
+                    "брутальный"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
-                    "порабощать",
+                    "страх",
                     "брутальный",
-                    "подавлять",
-                    "принуждать"
+                    "порабощать",
+                    "угнетение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
                     "принуждать",
-                    "произвол",
+                    "тирания",
                     "угнетение",
-                    "страх"
+                    "подавлять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "угнетение",
-                    "порабощать",
-                    "подавлять",
-                    "произвол"
+                    "произвол",
+                    "принуждать",
+                    "страх",
+                    "тирания"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
+                    "подавлять",
                     "брутальный",
-                    "угнетение",
-                    "тирания",
-                    "страх"
+                    "порабощать",
+                    "угнетение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3533,8 +3533,8 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "карать",
                     "наказывать",
+                    "карать",
                     "гнев",
                     "наказание"
                 ],
@@ -3543,48 +3543,48 @@
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
+                    "карать",
                     "наказывать",
-                    "наказание",
                     "гнев",
-                    "карать"
+                    "наказание"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
-                    "наказывать",
+                    "унижать",
+                    "гнев",
                     "карать",
-                    "мучить",
                     "унижать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
-                    "наказание",
-                    "карать",
+                    "наказывать",
+                    "унижать",
                     "гнев",
-                    "наказывать"
+                    "карать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "наказание",
+                    "наказывать",
                     "унижать",
-                    "гнев",
-                    "наказывать"
+                    "мучить",
+                    "наказание"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "карать",
-                    "наказание",
+                    "гнев",
+                    "наказывать",
                     "унижать",
                     "мучить"
                 ],
@@ -3593,12 +3593,12 @@
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "мучить",
                     "унижать",
-                    "наказывать",
-                    "наказание"
+                    "мучить",
+                    "наказание",
+                    "карать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4098,81 +4098,81 @@
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
                     "кровь",
-                    "пытка",
                     "пытать",
-                    "садизм"
+                    "садизм",
+                    "пытка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "пытка",
-                    "пытать",
                     "садизм",
-                    "кровь"
+                    "пытать",
+                    "кровь",
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
-                    "пытка",
-                    "садизм",
                     "кровь",
-                    "калечить"
+                    "калечить",
+                    "пытка",
+                    "мука"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "мука",
+                    "ослеплять",
                     "садизм",
-                    "пытать",
-                    "калечить"
+                    "выкалывать",
+                    "пытать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "пытать",
-                    "калечить",
+                    "мука",
                     "выкалывать",
-                    "садизм"
+                    "пытать",
+                    "калечить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "мука",
                     "выкалывать",
+                    "калечить",
                     "ослеплять",
-                    "калечить"
+                    "мука"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "ослеплять",
-                    "пытать",
-                    "садизм",
-                    "выкалывать"
+                    "калечить",
+                    "кровь",
+                    "выкалывать",
+                    "мука"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "садизм",
                     "мука",
-                    "пытка",
-                    "калечить"
+                    "садизм",
+                    "пытать",
+                    "кровь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4598,29 +4598,29 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
-                    "удивление",
-                    "рана",
                     "боль",
-                    "кровоточить"
+                    "кровоточить",
+                    "удивление",
+                    "рана"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "удивление",
                     "боль",
                     "рана",
-                    "кровоточить"
+                    "кровоточить",
+                    "удивление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
+                    "страдать",
                     "раненый",
                     "кровоточить",
-                    "боль",
                     "удивление"
                 ],
                 "correctIndex": 3
@@ -4628,42 +4628,42 @@
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
-                    "кровоточить",
-                    "раненый",
+                    "ослаблять",
+                    "рана",
                     "удивление",
-                    "боль"
+                    "кровоточить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
+                    "боль",
+                    "ослаблять",
                     "раненый",
-                    "рана",
-                    "удивление",
-                    "ослаблять"
+                    "удивление"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
-                    "страдать",
                     "ослаблять",
-                    "рана",
+                    "удивление",
+                    "страдать",
                     "кровоточить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "страдать",
-                    "ослаблять",
                     "рана",
-                    "кровоточить"
+                    "ослаблять",
+                    "раненый",
+                    "страдать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5140,9 +5140,9 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "возмездие",
                     "конец",
                     "умирать",
+                    "возмездие",
                     "смерть"
                 ],
                 "correctIndex": 3
@@ -5150,59 +5150,59 @@
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
+                    "конец",
+                    "умирать",
                     "возмездие",
-                    "конец",
-                    "умирать",
                     "смерть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Ende»?",
-                "choices": [
-                    "кара",
-                    "конец",
-                    "хрипеть",
-                    "возмездие"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "хрипеть",
-                    "проклинать",
-                    "умирать",
-                    "возмездие"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verenden»?",
+                "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "хрипеть",
-                    "проклинать",
                     "издыхать",
+                    "хрипеть",
+                    "конец",
                     "кара"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verfluchen»?",
+                "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "проклинать",
-                    "издыхать",
+                    "конец",
                     "умирать",
+                    "проклинать",
                     "хрипеть"
                 ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «verenden»?",
+                "choices": [
+                    "издыхать",
+                    "хрипеть",
+                    "умирать",
+                    "кара"
+                ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verfluchen»?",
+                "choices": [
+                    "кара",
+                    "проклинать",
+                    "смерть",
+                    "издыхать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
                     "умирать",
                     "хрипеть",
-                    "смерть",
+                    "издыхать",
                     "конец"
                 ],
                 "correctIndex": 1
@@ -5211,9 +5211,9 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "кара",
-                    "возмездие",
+                    "конец",
                     "умирать",
-                    "хрипеть"
+                    "смерть"
                 ],
                 "correctIndex": 0
             }
@@ -5321,6 +5321,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5605,36 +5806,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6147,6 +6334,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6170,97 +6361,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7178,6 +7335,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "королевство", "знать", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["королевство", "наследник", "доверять", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["честь", "ничего не подозревающий", "королевство", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["граф", "честь", "доверять", "законный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "знать", "ничего не подозревающий", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "честь", "королевство", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["законный", "знать", "доверять", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["знать", "ничего не подозревающий", "граф", "законный"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["опасность", "преследовать", "предательство", "бежать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "предательство", "опасность", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["бежать", "предательство", "опасность", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["бежать", "обман", "изгнать", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["прятаться", "изгнать", "опасность", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "опасность", "предательство", "изгнать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["бежать", "предательство", "опасность", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["обман", "преследовать", "изгнать", "бежать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["маскировка", "голый", "нищий", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["маскировка", "голый", "безумие", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["маскировка", "голый", "безумие", "безумный"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["безумный", "безумие", "голый", "нищета"], "correct_index": 2}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["нищий", "голый", "бормотать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["голый", "нищета", "бормотать", "дрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["безумие", "голый", "нищета", "бормотать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["бормотать", "безумный", "нищета", "нищий"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "хижина", "страдать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["страдать", "буря", "мёрзнуть", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "сопровождать", "буря", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "гром", "сопровождать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "сопровождать", "мёрзнуть", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["страдать", "молния", "сопровождать", "гром"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "хижина", "сопровождать", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["гром", "буря", "молния", "страдать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["утёс", "обманывать", "вести", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "вести", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["слепой", "спасать", "утёс", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["утёс", "обманывать", "утешать", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["утешать", "спасать", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "обманывать", "утёс", "вести"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "отчаяние", "хитрость", "вести"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["спасать", "утёс", "слепой", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "дуэль", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["бой", "разоблачать", "месть", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["дуэль", "месть", "брат", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["брат", "побеждать", "месть", "разоблачать"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["брат", "справедливость", "дуэль", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "меч", "побеждать", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["разоблачать", "меч", "дуэль", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["дуэль", "брат", "месть", "бой"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["наследовать", "выживать", "будущее", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "будущее", "выживать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["будущее", "новый", "править", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["ответственность", "править", "выживать", "будущее"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "мудрость", "выживать", "новый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["править", "порядок", "наследовать", "ответственность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["ответственность", "будущее", "выживать", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «neu»?", "choices": ["править", "порядок", "новый", "выживать"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["королевство", "наследник", "доверять", "знать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["наследник", "доверять", "знать", "королевство"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["доверять", "законный", "наследник", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["знать", "королевство", "честь", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "королевство", "ничего не подозревающий", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["честь", "законный", "знать", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "доверять", "королевство", "наследник"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["знать", "граф", "ничего не подозревающий", "честь"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["опасность", "предательство", "бежать", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["преследовать", "опасность", "предательство", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["изгнать", "прятаться", "опасность", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["предательство", "изгнать", "прятаться", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["предательство", "преследовать", "обман", "прятаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["предательство", "обман", "интрига", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "предательство", "преследовать", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["опасность", "бежать", "интрига", "изгнать"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["нищий", "безумие", "маскировка", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "голый", "маскировка", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["безумный", "дрожать", "нищий", "маскировка"], "correct_index": 3}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["нищета", "бормотать", "маскировка", "голый"], "correct_index": 3}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["маскировка", "бормотать", "голый", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "маскировка", "нищий", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["голый", "нищета", "безумный", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["бормотать", "безумие", "безумный", "нищий"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["мёрзнуть", "страдать", "буря", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "хижина", "буря", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["сопровождать", "буря", "мёрзнуть", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["молния", "хижина", "сопровождать", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["страдать", "гром", "защищать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["гром", "сопровождать", "мёрзнуть", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["молния", "защищать", "мёрзнуть", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["молния", "сопровождать", "защищать", "мёрзнуть"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "вести", "утёс", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «führen»?", "choices": ["слепой", "обманывать", "утёс", "вести"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утешать", "спасать", "утёс", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["слепой", "спасать", "хитрость", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["спасать", "утёс", "слепой", "вести"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["спасать", "хитрость", "обманывать", "утёс"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["обманывать", "слепой", "утешать", "вести"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "утешать", "обманывать", "слепой"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "бой", "дуэль", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["месть", "дуэль", "разоблачать", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["меч", "справедливость", "побеждать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["дуэль", "справедливость", "разоблачать", "побеждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["бой", "меч", "брат", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["месть", "дуэль", "побеждать", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["побеждать", "меч", "брат", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["месть", "меч", "брат", "справедливость"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["наследовать", "будущее", "править", "выживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["будущее", "править", "выживать", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["будущее", "ответственность", "порядок", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["порядок", "мудрость", "править", "ответственность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["выживать", "мудрость", "править", "ответственность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["новый", "выживать", "наследовать", "порядок"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["новый", "ответственность", "править", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["будущее", "наследовать", "выживать", "новый"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,24 +662,8 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
@@ -694,63 +678,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">законный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
@@ -758,15 +726,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
@@ -774,17 +742,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">законный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,13 +797,29 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
@@ -813,29 +829,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
@@ -849,11 +849,11 @@
                         <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                             
@@ -861,65 +861,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,79 +932,31 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
@@ -1012,15 +964,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бормотать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
@@ -1028,31 +1012,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безумный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -1067,31 +1067,15 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
                             
@@ -1099,31 +1083,63 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
@@ -1131,31 +1147,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
@@ -1163,33 +1179,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,33 +1202,33 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «führen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «führen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1238,38 +1238,6 @@
                         <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
@@ -1282,40 +1250,24 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
@@ -1324,7 +1276,55 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утёс</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1337,15 +1337,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
@@ -1353,31 +1353,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                             
@@ -1385,17 +1369,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1405,11 +1405,11 @@
                         <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                             
@@ -1417,17 +1417,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1437,11 +1437,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                             
@@ -1449,17 +1449,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1472,33 +1472,33 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1510,9 +1510,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
@@ -1520,17 +1520,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1540,27 +1540,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
                             
@@ -1568,15 +1552,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
@@ -1584,17 +1584,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «neu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">новый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1996,82 +1996,82 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "наследник",
-                    "королевство",
-                    "знать",
-                    "доверять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Erbe»?",
-                "choices": [
                     "королевство",
                     "наследник",
                     "доверять",
                     "знать"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Königreich»?",
-                "choices": [
-                    "честь",
-                    "ничего не подозревающий",
-                    "королевство",
-                    "граф"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vertrauen»?",
-                "choices": [
-                    "граф",
-                    "честь",
-                    "доверять",
-                    "законный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Ehre»?",
-                "choices": [
-                    "доверять",
-                    "знать",
-                    "ничего не подозревающий",
-                    "честь"
-                ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «legitim»?",
+                "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "законный",
-                    "честь",
-                    "королевство",
-                    "доверять"
+                    "наследник",
+                    "доверять",
+                    "знать",
+                    "королевство"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Graf»?",
+                "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "законный",
-                    "знать",
                     "доверять",
-                    "граф"
+                    "законный",
+                    "наследник",
+                    "королевство"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «vertrauen»?",
+                "choices": [
+                    "знать",
+                    "королевство",
+                    "честь",
+                    "доверять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Ehre»?",
+                "choices": [
+                    "честь",
+                    "королевство",
+                    "ничего не подозревающий",
+                    "граф"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «legitim»?",
+                "choices": [
+                    "честь",
+                    "законный",
+                    "знать",
+                    "граф"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Graf»?",
+                "choices": [
+                    "граф",
+                    "доверять",
+                    "королевство",
+                    "наследник"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
                     "знать",
-                    "ничего не подозревающий",
                     "граф",
-                    "законный"
+                    "ничего не подозревающий",
+                    "честь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2538,27 +2538,27 @@
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
                     "опасность",
-                    "преследовать",
                     "предательство",
-                    "бежать"
+                    "бежать",
+                    "преследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "бежать",
-                    "предательство",
+                    "преследовать",
                     "опасность",
-                    "преследовать"
+                    "предательство",
+                    "бежать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "бежать",
-                    "предательство",
+                    "изгнать",
+                    "прятаться",
                     "опасность",
                     "интрига"
                 ],
@@ -2567,9 +2567,9 @@
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "бежать",
-                    "обман",
+                    "предательство",
                     "изгнать",
+                    "прятаться",
                     "преследовать"
                 ],
                 "correctIndex": 3
@@ -2577,42 +2577,42 @@
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "прятаться",
-                    "изгнать",
-                    "опасность",
-                    "обман"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Intrige»?",
-                "choices": [
-                    "интрига",
-                    "опасность",
                     "предательство",
-                    "изгнать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Betrug»?",
-                "choices": [
-                    "бежать",
-                    "предательство",
-                    "опасность",
-                    "обман"
+                    "преследовать",
+                    "обман",
+                    "прятаться"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «verbannen»?",
+                "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
+                    "предательство",
                     "обман",
-                    "преследовать",
-                    "изгнать",
-                    "бежать"
+                    "интрига",
+                    "опасность"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Betrug»?",
+                "choices": [
+                    "обман",
+                    "предательство",
+                    "преследовать",
+                    "прятаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verbannen»?",
+                "choices": [
+                    "опасность",
+                    "бежать",
+                    "интрига",
+                    "изгнать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3103,82 +3103,82 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "маскировка",
-                    "голый",
                     "нищий",
-                    "безумие"
+                    "безумие",
+                    "маскировка",
+                    "голый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "маскировка",
+                    "нищий",
                     "голый",
-                    "безумие",
-                    "нищий"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verkleidung»?",
-                "choices": [
                     "маскировка",
-                    "голый",
-                    "безумие",
-                    "безумный"
+                    "безумие"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «nackt»?",
+                "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
                     "безумный",
-                    "безумие",
-                    "голый",
-                    "нищета"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «murmeln»?",
-                "choices": [
+                    "дрожать",
                     "нищий",
-                    "голый",
-                    "бормотать",
-                    "безумие"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «zittern»?",
-                "choices": [
-                    "голый",
-                    "нищета",
-                    "бормотать",
-                    "дрожать"
+                    "маскировка"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «nackt»?",
+                "choices": [
+                    "нищета",
+                    "бормотать",
+                    "маскировка",
+                    "голый"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «murmeln»?",
+                "choices": [
+                    "маскировка",
+                    "бормотать",
+                    "голый",
+                    "дрожать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «zittern»?",
+                "choices": [
+                    "дрожать",
+                    "маскировка",
+                    "нищий",
+                    "голый"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "безумие",
                     "голый",
                     "нищета",
-                    "бормотать"
+                    "безумный",
+                    "нищий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
                     "бормотать",
+                    "безумие",
                     "безумный",
-                    "нищета",
                     "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3681,81 +3681,81 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "мёрзнуть",
-                    "хижина",
                     "страдать",
-                    "буря"
+                    "буря",
+                    "хижина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "страдать",
-                    "буря",
                     "мёрзнуть",
-                    "хижина"
+                    "хижина",
+                    "буря",
+                    "страдать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "страдать",
                     "сопровождать",
                     "буря",
-                    "защищать"
+                    "мёрзнуть",
+                    "страдать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
+                    "молния",
                     "хижина",
-                    "гром",
                     "сопровождать",
-                    "мёрзнуть"
+                    "страдать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
+                    "страдать",
+                    "гром",
                     "защищать",
-                    "сопровождать",
-                    "мёрзнуть",
-                    "хижина"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "страдать",
-                    "молния",
+                    "гром",
                     "сопровождать",
-                    "гром"
+                    "мёрзнуть",
+                    "страдать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "гром",
-                    "хижина",
-                    "сопровождать",
-                    "буря"
+                    "молния",
+                    "защищать",
+                    "мёрзнуть",
+                    "гром"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "гром",
-                    "буря",
                     "молния",
-                    "страдать"
+                    "сопровождать",
+                    "защищать",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4246,82 +4246,82 @@
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "утёс",
-                    "обманывать",
+                    "слепой",
                     "вести",
-                    "слепой"
+                    "утёс",
+                    "обманывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
+                    "слепой",
                     "обманывать",
-                    "вести",
                     "утёс",
-                    "слепой"
+                    "вести"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
-                    "слепой",
+                    "утешать",
                     "спасать",
                     "утёс",
-                    "хитрость"
+                    "слепой"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "утёс",
-                    "обманывать",
-                    "утешать",
-                    "спасать"
+                    "слепой",
+                    "спасать",
+                    "хитрость",
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "утешать",
                     "спасать",
                     "утёс",
-                    "слепой"
+                    "слепой",
+                    "вести"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
+                    "спасать",
                     "хитрость",
                     "обманывать",
-                    "утёс",
-                    "вести"
+                    "утёс"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
+                    "обманывать",
+                    "слепой",
                     "утешать",
-                    "отчаяние",
-                    "хитрость",
                     "вести"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "спасать",
-                    "утёс",
-                    "слепой",
-                    "отчаяние"
+                    "отчаяние",
+                    "утешать",
+                    "обманывать",
+                    "слепой"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4792,49 +4792,49 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
+                    "разоблачать",
                     "бой",
                     "дуэль",
-                    "разоблачать",
                     "месть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "бой",
-                    "разоблачать",
                     "месть",
-                    "дуэль"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
                     "дуэль",
-                    "месть",
-                    "брат",
+                    "разоблачать",
                     "бой"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «enthüllen»?",
+                "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "брат",
+                    "меч",
+                    "справедливость",
                     "побеждать",
-                    "месть",
-                    "разоблачать"
+                    "месть"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "дуэль",
+                    "справедливость",
+                    "разоблачать",
+                    "побеждать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
+                    "бой",
+                    "меч",
                     "брат",
-                    "справедливость",
-                    "дуэль",
                     "побеждать"
                 ],
                 "correctIndex": 3
@@ -4842,19 +4842,19 @@
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "справедливость",
-                    "меч",
+                    "месть",
+                    "дуэль",
                     "побеждать",
-                    "разоблачать"
+                    "справедливость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
-                    "разоблачать",
+                    "побеждать",
                     "меч",
-                    "дуэль",
+                    "брат",
                     "бой"
                 ],
                 "correctIndex": 1
@@ -4862,12 +4862,12 @@
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "дуэль",
-                    "брат",
                     "месть",
-                    "бой"
+                    "меч",
+                    "брат",
+                    "справедливость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5352,28 +5352,28 @@
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
                     "наследовать",
-                    "выживать",
                     "будущее",
-                    "править"
+                    "править",
+                    "выживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
                     "будущее",
+                    "править",
                     "выживать",
-                    "править"
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zukunft»?",
                 "choices": [
                     "будущее",
-                    "новый",
-                    "править",
+                    "ответственность",
+                    "порядок",
                     "наследовать"
                 ],
                 "correctIndex": 0
@@ -5381,52 +5381,52 @@
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "ответственность",
+                    "порядок",
+                    "мудрость",
                     "править",
-                    "выживать",
-                    "будущее"
+                    "ответственность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "будущее",
-                    "мудрость",
                     "выживать",
-                    "новый"
+                    "мудрость",
+                    "править",
+                    "ответственность"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
-                    "править",
-                    "порядок",
+                    "новый",
+                    "выживать",
                     "наследовать",
-                    "ответственность"
+                    "порядок"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
+                    "новый",
                     "ответственность",
-                    "будущее",
-                    "выживать",
+                    "править",
                     "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «neu»?",
                 "choices": [
-                    "править",
-                    "порядок",
-                    "новый",
-                    "выживать"
+                    "будущее",
+                    "наследовать",
+                    "выживать",
+                    "новый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5531,6 +5531,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5815,36 +6016,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6357,6 +6544,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6380,97 +6571,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7388,6 +7545,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["амбиция", "бастард", "обделённый", "зависть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "обделённый", "амбиция", "зависть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["зависть", "возвышаться", "амбиция", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["возвышаться", "внебрачный", "природа", "обделённый"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["внебрачный", "месть", "амбиция", "зависть"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["возвышаться", "бастард", "месть", "внебрачный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["внебрачный", "амбиция", "зависть", "обделённый"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "внебрачный", "природа", "возвышаться"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "обвинять", "интриговать", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "подделывать", "план", "интриговать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["письмо", "лгать", "интриговать", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["письмо", "обвинять", "манипулировать", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "план", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["подделывать", "письмо", "обвинять", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["манипулировать", "обвинять", "лгать", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["обман", "лгать", "интриговать", "письмо"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "успех", "наследовать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["успех", "изгонять", "наследовать", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "победа", "вытеснять", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "наследовать", "победа", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["награда", "торжествовать", "выигрывать", "победа"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "наследовать", "победа", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["изгонять", "выигрывать", "вытеснять", "победа"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["успех", "победа", "торжествовать", "вытеснять"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["завоёвывать", "власть", "союз", "объединяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["завоёвывать", "союз", "объединяться", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоевание", "союз", "соблазнять", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["завоёвывать", "союз", "соблазнять", "господствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "объединяться", "завоёвывать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["завоевание", "власть", "альянс", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["господствовать", "завоёвывать", "объединяться", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["союз", "альянс", "господствовать", "соблазнять"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "предавать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "доносить", "жестокость", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "пытка", "выдавать", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["ослеплять", "доносить", "выдавать", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["предавать", "доносить", "выдавать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["жертвовать", "доносить", "пытка", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жертвовать", "беспощадный", "доносить", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жертвовать", "беспощадный", "доносить", "предавать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["любовная связь", "играть", "соперничество", "завлекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соперничество", "играть", "любовная связь", "завлекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["похоть", "использовать", "играть", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["завлекать", "похоть", "интрига", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["жонглировать", "использовать", "похоть", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["любовная связь", "интрига", "соперничество", "использовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["похоть", "любовная связь", "жонглировать", "использовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "использовать", "любовная связь", "похоть"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["дуэль", "падать", "сожалеть", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["поражение", "сожалеть", "падать", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["поражение", "падение", "дуэль", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["конец", "проигрывать", "сожалеть", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["поражение", "проигрывать", "конец", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["падение", "сожалеть", "поражение", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["падать", "конец", "поражение", "признаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["проигрывать", "признаваться", "конец", "поражение"], "correct_index": 2}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["бастард", "обделённый", "зависть", "амбиция"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "обделённый", "бастард", "амбиция"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["бастард", "амбиция", "природа", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["природа", "обделённый", "зависть", "возвышаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["амбиция", "природа", "обделённый", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["зависть", "бастард", "амбиция", "возвышаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["возвышаться", "внебрачный", "бастард", "обделённый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["природа", "месть", "внебрачный", "обделённый"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "обвинять", "интриговать", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["интриговать", "обвинять", "план", "подделывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обвинять", "подделывать", "интриговать", "манипулировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "письмо", "манипулировать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["план", "манипулировать", "обман", "подделывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["обман", "подделывать", "план", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["манипулировать", "лгать", "подделывать", "письмо"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["письмо", "обман", "подделывать", "план"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "наследовать", "успех", "торжествовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "успех", "торжествовать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["изгонять", "награда", "победа", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["изгонять", "победа", "выигрывать", "успех"], "correct_index": 3}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["выигрывать", "торжествовать", "успех", "награда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["изгонять", "победа", "награда", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["вытеснять", "выигрывать", "успех", "награда"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["вытеснять", "успех", "изгонять", "победа"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["союз", "завоёвывать", "объединяться", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "завоёвывать", "объединяться", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоевание", "союз", "завоёвывать", "господствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "союз", "завоевание", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "завоёвывать", "власть", "союз"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["соблазнять", "власть", "завоевание", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["объединяться", "соблазнять", "господствовать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["власть", "альянс", "соблазнять", "объединяться"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "жестокость", "ослеплять", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["жестокость", "доносить", "предавать", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["доносить", "жестокость", "жертвовать", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["предавать", "жертвовать", "ослеплять", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["беспощадный", "выдавать", "пытка", "жертвовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "беспощадный", "жестокость", "доносить"], "correct_index": 0}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жертвовать", "пытка", "ослеплять", "выдавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "жертвовать", "беспощадный", "предавать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["завлекать", "играть", "любовная связь", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "завлекать", "соперничество", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["использовать", "любовная связь", "жонглировать", "играть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["соперничество", "использовать", "любовная связь", "завлекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["завлекать", "использовать", "похоть", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "завлекать", "похоть", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["использовать", "интрига", "любовная связь", "жонглировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["играть", "соперничество", "жонглировать", "интрига"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "дуэль", "поражение", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "падение", "проигрывать", "признаваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["сожалеть", "проигрывать", "падать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["проигрывать", "сожалеть", "падать", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["поражение", "падать", "дуэль", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["конец", "признаваться", "падение", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["сожалеть", "конец", "проигрывать", "падение"], "correct_index": 1}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,129 +662,129 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">зависть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -813,79 +813,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
                             
@@ -893,15 +845,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                             
@@ -909,17 +893,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,31 +932,15 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
                             
@@ -964,31 +948,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -996,31 +964,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                             
@@ -1028,33 +996,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вытеснять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,29 +1067,13 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
                             
@@ -1099,7 +1083,23 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                         <div class="quiz-choices">
                             
@@ -1107,9 +1107,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1119,13 +1119,13 @@
                         <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1137,25 +1137,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                             
@@ -1163,17 +1163,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1183,13 +1183,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,97 +1202,97 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1304,25 +1304,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
@@ -1337,47 +1337,31 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
                             
@@ -1385,17 +1369,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1405,61 +1405,61 @@
                         <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">использовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1472,13 +1472,29 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
@@ -1488,33 +1504,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1524,11 +1524,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1536,65 +1536,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1995,82 +1995,82 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "амбиция",
                     "бастард",
                     "обделённый",
-                    "зависть"
+                    "зависть",
+                    "амбиция"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
-                    "бастард",
+                    "зависть",
                     "обделённый",
-                    "амбиция",
-                    "зависть"
+                    "бастард",
+                    "амбиция"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "зависть",
-                    "возвышаться",
+                    "бастард",
                     "амбиция",
-                    "внебрачный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «benachteiligt»?",
-                "choices": [
-                    "возвышаться",
-                    "внебрачный",
                     "природа",
-                    "обделённый"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "внебрачный",
-                    "месть",
-                    "амбиция",
-                    "зависть"
+                    "месть"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «benachteiligt»?",
+                "choices": [
+                    "природа",
+                    "обделённый",
+                    "зависть",
+                    "возвышаться"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "амбиция",
+                    "природа",
+                    "обделённый",
+                    "месть"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "возвышаться",
+                    "зависть",
                     "бастард",
-                    "месть",
-                    "внебрачный"
+                    "амбиция",
+                    "возвышаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
+                    "возвышаться",
                     "внебрачный",
-                    "амбиция",
-                    "зависть",
+                    "бастард",
                     "обделённый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
-                    "амбиция",
-                    "внебрачный",
                     "природа",
-                    "возвышаться"
+                    "месть",
+                    "внебрачный",
+                    "обделённый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2569,72 +2569,72 @@
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
+                    "интриговать",
                     "обвинять",
-                    "подделывать",
                     "план",
-                    "интриговать"
+                    "подделывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
-                    "письмо",
-                    "лгать",
+                    "обвинять",
+                    "подделывать",
                     "интриговать",
-                    "обвинять"
+                    "манипулировать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "письмо",
-                    "обвинять",
-                    "манипулировать",
-                    "план"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «manipulieren»?",
-                "choices": [
-                    "манипулировать",
                     "план",
-                    "подделывать",
+                    "письмо",
+                    "манипулировать",
                     "обвинять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Brief»?",
+                "question": "Что означает немецкое слово «manipulieren»?",
                 "choices": [
-                    "подделывать",
-                    "письмо",
-                    "обвинять",
-                    "манипулировать"
+                    "план",
+                    "манипулировать",
+                    "обман",
+                    "подделывать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Brief»?",
+                "choices": [
+                    "обман",
+                    "подделывать",
+                    "план",
+                    "письмо"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
                     "манипулировать",
-                    "обвинять",
                     "лгать",
+                    "подделывать",
                     "письмо"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
+                    "письмо",
                     "обман",
-                    "лгать",
-                    "интриговать",
-                    "письмо"
+                    "подделывать",
+                    "план"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3106,82 +3106,82 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "торжествовать",
-                    "успех",
+                    "изгонять",
                     "наследовать",
-                    "изгонять"
+                    "успех",
+                    "торжествовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
-                    "успех",
-                    "изгонять",
                     "наследовать",
-                    "торжествовать"
+                    "успех",
+                    "торжествовать",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
+                    "изгонять",
+                    "награда",
                     "победа",
-                    "вытеснять",
-                    "успех"
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
-                    "успех",
-                    "наследовать",
+                    "изгонять",
                     "победа",
-                    "изгонять"
+                    "выигрывать",
+                    "успех"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "награда",
-                    "торжествовать",
                     "выигрывать",
-                    "победа"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Belohnung»?",
-                "choices": [
-                    "награда",
-                    "наследовать",
-                    "победа",
-                    "успех"
+                    "торжествовать",
+                    "успех",
+                    "награда"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verdrängen»?",
+                "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
                     "изгонять",
-                    "выигрывать",
-                    "вытеснять",
-                    "победа"
+                    "победа",
+                    "награда",
+                    "наследовать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «verdrängen»?",
+                "choices": [
+                    "вытеснять",
+                    "выигрывать",
+                    "успех",
+                    "награда"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
+                    "вытеснять",
                     "успех",
-                    "победа",
-                    "торжествовать",
-                    "вытеснять"
+                    "изгонять",
+                    "победа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3668,18 +3668,18 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "завоёвывать",
-                    "власть",
                     "союз",
-                    "объединяться"
+                    "завоёвывать",
+                    "объединяться",
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "завоёвывать",
                     "союз",
+                    "завоёвывать",
                     "объединяться",
                     "власть"
                 ],
@@ -3690,18 +3690,18 @@
                 "choices": [
                     "завоевание",
                     "союз",
-                    "соблазнять",
-                    "завоёвывать"
+                    "завоёвывать",
+                    "господствовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "завоёвывать",
-                    "союз",
                     "соблазнять",
-                    "господствовать"
+                    "союз",
+                    "завоевание",
+                    "завоёвывать"
                 ],
                 "correctIndex": 1
             },
@@ -3709,39 +3709,39 @@
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
                     "соблазнять",
-                    "объединяться",
                     "завоёвывать",
-                    "власть"
+                    "власть",
+                    "союз"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
-                    "завоевание",
+                    "соблазнять",
                     "власть",
-                    "альянс",
+                    "завоевание",
                     "завоёвывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
-                    "господствовать",
-                    "завоёвывать",
                     "объединяться",
-                    "соблазнять"
+                    "соблазнять",
+                    "господствовать",
+                    "власть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
-                    "союз",
+                    "власть",
                     "альянс",
-                    "господствовать",
-                    "соблазнять"
+                    "соблазнять",
+                    "объединяться"
                 ],
                 "correctIndex": 1
             }
@@ -4266,82 +4266,82 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "доносить",
-                    "ослеплять",
                     "предавать",
-                    "жестокость"
+                    "жестокость",
+                    "ослеплять",
+                    "доносить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "ослеплять",
-                    "доносить",
                     "жестокость",
-                    "предавать"
+                    "доносить",
+                    "предавать",
+                    "ослеплять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "жестокость",
-                    "пытка",
-                    "выдавать",
-                    "предавать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «denunzieren»?",
-                "choices": [
-                    "ослеплять",
                     "доносить",
-                    "выдавать",
-                    "пытка"
+                    "жестокость",
+                    "жертвовать",
+                    "беспощадный"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «ausliefern»?",
+                "question": "Что означает немецкое слово «denunzieren»?",
                 "choices": [
                     "предавать",
-                    "доносить",
-                    "выдавать",
-                    "жестокость"
+                    "жертвовать",
+                    "ослеплять",
+                    "доносить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "беспощадный",
+                    "выдавать",
+                    "пытка",
+                    "жертвовать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "жертвовать",
-                    "доносить",
                     "пытка",
-                    "жестокость"
+                    "беспощадный",
+                    "жестокость",
+                    "доносить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
                     "жертвовать",
-                    "беспощадный",
-                    "доносить",
-                    "предавать"
+                    "пытка",
+                    "ослеплять",
+                    "выдавать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
+                    "ослеплять",
                     "жертвовать",
                     "беспощадный",
-                    "доносить",
                     "предавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4830,82 +4830,82 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "любовная связь",
+                    "завлекать",
                     "играть",
-                    "соперничество",
-                    "завлекать"
+                    "любовная связь",
+                    "соперничество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
+                    "играть",
+                    "завлекать",
                     "соперничество",
-                    "играть",
-                    "любовная связь",
-                    "завлекать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «spielen»?",
-                "choices": [
-                    "похоть",
-                    "использовать",
-                    "играть",
                     "любовная связь"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «spielen»?",
+                "choices": [
+                    "использовать",
+                    "любовная связь",
+                    "жонглировать",
+                    "играть"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
-                    "завлекать",
-                    "похоть",
-                    "интрига",
-                    "соперничество"
+                    "соперничество",
+                    "использовать",
+                    "любовная связь",
+                    "завлекать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "жонглировать",
+                    "завлекать",
                     "использовать",
                     "похоть",
-                    "соперничество"
+                    "интрига"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "любовная связь",
-                    "интрига",
-                    "соперничество",
-                    "использовать"
+                    "использовать",
+                    "завлекать",
+                    "похоть",
+                    "играть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
-                    "похоть",
+                    "использовать",
+                    "интрига",
                     "любовная связь",
-                    "жонглировать",
-                    "использовать"
+                    "жонглировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
-                    "интрига",
-                    "использовать",
-                    "любовная связь",
-                    "похоть"
+                    "играть",
+                    "соперничество",
+                    "жонглировать",
+                    "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5380,39 +5380,39 @@
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
+                    "сожалеть",
                     "дуэль",
+                    "поражение",
+                    "падать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «fallen»?",
+                "choices": [
                     "падать",
+                    "дуэль",
                     "сожалеть",
                     "поражение"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «fallen»?",
-                "choices": [
-                    "поражение",
-                    "сожалеть",
-                    "падать",
-                    "дуэль"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "поражение",
+                    "сожалеть",
                     "падение",
-                    "дуэль",
-                    "сожалеть"
+                    "проигрывать",
+                    "признаваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "конец",
-                    "проигрывать",
                     "сожалеть",
+                    "проигрывать",
+                    "падать",
                     "поражение"
                 ],
                 "correctIndex": 3
@@ -5420,42 +5420,42 @@
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "поражение",
                     "проигрывать",
-                    "конец",
-                    "падать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Untergang»?",
-                "choices": [
-                    "падение",
                     "сожалеть",
-                    "поражение",
-                    "падать"
+                    "падать",
+                    "поражение"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «gestehen»?",
+                "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
-                    "падать",
-                    "конец",
                     "поражение",
-                    "признаваться"
+                    "падать",
+                    "дуэль",
+                    "падение"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «gestehen»?",
+                "choices": [
+                    "конец",
+                    "признаваться",
+                    "падение",
+                    "проигрывать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "проигрывать",
-                    "признаваться",
+                    "сожалеть",
                     "конец",
-                    "поражение"
+                    "проигрывать",
+                    "падение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5560,6 +5560,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5844,36 +6045,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6386,6 +6573,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6409,97 +6600,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7417,6 +7574,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "печаль", "шутить", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "мудрость", "шут", "печаль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["забава", "шутить", "печаль", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шутить", "остроумие", "мудрость", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["мудрость", "забава", "шут", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «klug»?", "choices": ["забава", "остроумие", "умный", "печаль"], "correct_index": 2}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["забава", "шут", "скучать", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["умный", "остроумие", "шутить", "забава"], "correct_index": 1}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["предупреждение", "горький", "шутка", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["предупреждение", "горький", "правда", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["дразнить", "горький", "раскрывать", "предупреждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["шутка", "насмехаться", "правда", "горький"], "correct_index": 3}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["правда", "насмехаться", "горький", "шутка"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["насмехаться", "правда", "дразнить", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["дразнить", "раскрывать", "правда", "предупреждение"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "загадка", "предчувствие", "пророчество"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["загадка", "пророчество", "предсказывать", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["знамение", "пророчество", "предчувствие", "загадочный"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["загадка", "предсказывать", "толковать", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["знамение", "толковать", "предчувствовать", "пророчество"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "загадка", "толковать", "предсказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["знамение", "пророчество", "предсказывать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["пророчество", "загадочный", "знамение", "предсказывать"], "correct_index": 1}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["мёрзнуть", "безумие", "дружба", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "мёрзнуть", "дружба", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["безумие", "сопровождать", "дрожать", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["сопровождать", "мёрзнуть", "дружба", "дрожать"], "correct_index": 1}, {"question": "Что означает немецкое слово «singen»?", "choices": ["безумие", "дрожать", "сопровождать", "петь"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["мёрзнуть", "сопровождать", "дрожать", "верный"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "безумие", "петь", "дружба"], "correct_index": 0}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "песня", "утешение", "ирония"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["утешение", "песня", "ирония", "напевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["напевать", "песня", "мелодия", "ирония"], "correct_index": 3}, {"question": "Что означает немецкое слово «summen»?", "choices": ["утешение", "свистеть", "напевать", "ирония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["рифма", "ирония", "напевать", "мелодия"], "correct_index": 3}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "песня", "ирония", "рифма"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["напевать", "утешение", "рифма", "песня"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["утешение", "песня", "звучать", "рифма"], "correct_index": 2}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["философия", "размышлять", "судьба", "бренность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["размышлять", "судьба", "бренность", "философия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["бренность", "познавать", "философия", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["смысл", "судьба", "размышлять", "познавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["бренность", "познавать", "философия", "судьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["познавать", "размышлять", "смысл", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["познавать", "преходящий", "бренность", "смысл"], "correct_index": 1}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["пустота", "тайна", "растворяться", "исчезать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "пустота", "растворяться", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "загадочный", "бесследно", "пустота"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["исчезать", "бесследно", "растворяться", "туман"], "correct_index": 2}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["уходить", "бесследно", "растворяться", "тайна"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["бесследно", "туман", "исчезать", "пустота"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["уходить", "исчезать", "туман", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["пустота", "туман", "бесследно", "уходить"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["печаль", "мудрость", "шутить", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["печаль", "шутить", "шут", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["шутить", "остроумие", "печаль", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["мудрость", "шутить", "умный", "скучать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["остроумие", "мудрость", "забава", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «klug»?", "choices": ["умный", "мудрость", "шутить", "шут"], "correct_index": 0}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шутить", "мудрость", "забава", "скучать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["печаль", "забава", "остроумие", "скучать"], "correct_index": 2}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "предупреждение", "правда", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["шутка", "предупреждение", "правда", "горький"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "насмехаться", "предупреждение", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "правда", "предупреждение", "шутка"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["шутка", "насмехаться", "дразнить", "горький"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["дразнить", "правда", "предупреждение", "шутка"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["раскрывать", "дразнить", "правда", "предупреждение"], "correct_index": 0}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "предсказывать", "загадка", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "загадка", "предчувствие", "предсказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["толковать", "предсказывать", "предчувствие", "загадочный"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["толковать", "пророчество", "загадка", "предсказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["предчувствовать", "загадка", "толковать", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "знамение", "предсказывать", "толковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["знамение", "предчувствовать", "предсказывать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "пророчество", "загадка", "предчувствие"], "correct_index": 0}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["сопровождать", "безумие", "мёрзнуть", "дружба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["дружба", "безумие", "мёрзнуть", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["мёрзнуть", "дружба", "сопровождать", "дрожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["верный", "дрожать", "петь", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «singen»?", "choices": ["дружба", "безумие", "петь", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["мёрзнуть", "сопровождать", "дрожать", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["сопровождать", "дрожать", "дружба", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "ирония", "утешение", "песня"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "утешение", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["напевать", "рифма", "мелодия", "ирония"], "correct_index": 3}, {"question": "Что означает немецкое слово «summen»?", "choices": ["напевать", "песня", "утешение", "звучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["свистеть", "мелодия", "рифма", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["напевать", "рифма", "свистеть", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["рифма", "утешение", "мелодия", "песня"], "correct_index": 0}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["песня", "звучать", "свистеть", "утешение"], "correct_index": 1}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["судьба", "философия", "бренность", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["размышлять", "судьба", "философия", "бренность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["философия", "познавать", "бренность", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["смысл", "философия", "бренность", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["познавать", "смысл", "преходящий", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["бренность", "преходящий", "познавать", "смысл"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["смысл", "размышлять", "судьба", "преходящий"], "correct_index": 3}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "тайна", "пустота", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["пустота", "тайна", "растворяться", "исчезать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "тайна", "уходить", "пустота"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["растворяться", "пустота", "туман", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["загадочный", "растворяться", "уходить", "бесследно"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["загадочный", "исчезать", "туман", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["тайна", "туман", "загадочный", "пустота"], "correct_index": 2}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "исчезать", "бесследно", "тайна"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,33 +662,33 @@
             <div class="quiz-phase-container active" data-phase="jester">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -698,9 +698,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
                             
@@ -710,63 +710,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
                             
@@ -774,17 +742,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,29 +797,13 @@
             <div class="quiz-phase-container" data-phase="bitter_truths">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
@@ -829,29 +813,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
@@ -861,45 +829,77 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
@@ -916,33 +916,33 @@
             <div class="quiz-phase-container" data-phase="prophecies">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -952,9 +952,9 @@
                         <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                             
@@ -964,33 +964,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1002,11 +1002,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">толковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1018,7 +1018,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
                             
@@ -1028,17 +1028,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1055,43 +1055,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
@@ -1099,15 +1067,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                             
@@ -1115,17 +1099,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1141,23 +1141,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1170,33 +1170,33 @@
             <div class="quiz-phase-container" data-phase="songs">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1208,7 +1208,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                             
@@ -1218,61 +1218,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «summen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
                             
@@ -1282,17 +1250,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,17 +1305,17 @@
             <div class="quiz-phase-container" data-phase="wisdom">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1329,23 +1329,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
@@ -1353,65 +1369,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преходящий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,29 +1424,29 @@
             <div class="quiz-phase-container" data-phase="vanishing">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                             
@@ -1462,9 +1462,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
                             
@@ -1472,61 +1472,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
                             
@@ -1536,17 +1488,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1969,28 +1969,28 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "шут",
                     "печаль",
+                    "мудрость",
                     "шутить",
-                    "мудрость"
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
+                    "печаль",
                     "шутить",
-                    "мудрость",
                     "шут",
-                    "печаль"
+                    "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "забава",
                     "шутить",
+                    "остроумие",
                     "печаль",
                     "мудрость"
                 ],
@@ -1999,52 +1999,52 @@
             {
                 "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
+                    "мудрость",
                     "шутить",
-                    "остроумие",
-                    "мудрость",
-                    "забава"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Spaß»?",
-                "choices": [
-                    "мудрость",
-                    "забава",
-                    "шут",
-                    "остроумие"
+                    "умный",
+                    "скучать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «klug»?",
+                "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "забава",
                     "остроумие",
-                    "умный",
-                    "печаль"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vermissen»?",
-                "choices": [
+                    "мудрость",
                     "забава",
-                    "шут",
-                    "скучать",
                     "шутить"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «der Witz»?",
+                "question": "Что означает немецкое слово «klug»?",
                 "choices": [
                     "умный",
-                    "остроумие",
+                    "мудрость",
                     "шутить",
-                    "забава"
+                    "шут"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «vermissen»?",
+                "choices": [
+                    "шутить",
+                    "мудрость",
+                    "забава",
+                    "скучать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Witz»?",
+                "choices": [
+                    "печаль",
+                    "забава",
+                    "остроумие",
+                    "скучать"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2480,72 +2480,72 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "предупреждение",
                     "горький",
-                    "шутка",
-                    "правда"
+                    "предупреждение",
+                    "правда",
+                    "шутка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
+                    "шутка",
                     "предупреждение",
-                    "горький",
                     "правда",
-                    "шутка"
+                    "горький"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
-                    "дразнить",
                     "горький",
-                    "раскрывать",
-                    "предупреждение"
+                    "насмехаться",
+                    "предупреждение",
+                    "шутка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
-                    "шутка",
-                    "насмехаться",
+                    "горький",
                     "правда",
-                    "горький"
+                    "предупреждение",
+                    "шутка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
-                    "правда",
+                    "шутка",
                     "насмехаться",
-                    "горький",
-                    "шутка"
+                    "дразнить",
+                    "горький"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «necken»?",
                 "choices": [
-                    "насмехаться",
-                    "правда",
                     "дразнить",
+                    "правда",
+                    "предупреждение",
                     "шутка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "дразнить",
                     "раскрывать",
+                    "дразнить",
                     "правда",
                     "предупреждение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3017,28 +3017,28 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "предсказывать",
-                    "загадка",
-                    "предчувствие",
-                    "пророчество"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Rätsel»?",
-                "choices": [
-                    "загадка",
                     "пророчество",
                     "предсказывать",
+                    "загадка",
                     "предчувствие"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «das Rätsel»?",
+                "choices": [
+                    "пророчество",
+                    "загадка",
+                    "предчувствие",
+                    "предсказывать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "знамение",
-                    "пророчество",
+                    "толковать",
+                    "предсказывать",
                     "предчувствие",
                     "загадочный"
                 ],
@@ -3047,30 +3047,30 @@
             {
                 "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
-                    "загадка",
-                    "предсказывать",
                     "толковать",
-                    "загадочный"
+                    "пророчество",
+                    "загадка",
+                    "предсказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
-                    "знамение",
-                    "толковать",
                     "предчувствовать",
-                    "пророчество"
+                    "загадка",
+                    "толковать",
+                    "предчувствие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
                     "предчувствовать",
-                    "загадка",
-                    "толковать",
-                    "предсказывать"
+                    "знамение",
+                    "предсказывать",
+                    "толковать"
                 ],
                 "correctIndex": 0
             },
@@ -3078,7 +3078,7 @@
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
                     "знамение",
-                    "пророчество",
+                    "предчувствовать",
                     "предсказывать",
                     "загадочный"
                 ],
@@ -3087,12 +3087,12 @@
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "пророчество",
                     "загадочный",
-                    "знамение",
-                    "предсказывать"
+                    "пророчество",
+                    "загадка",
+                    "предчувствие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3542,52 +3542,52 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "мёрзнуть",
+                    "сопровождать",
                     "безумие",
-                    "дружба",
-                    "сопровождать"
+                    "мёрзнуть",
+                    "дружба"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
-                    "сопровождать",
-                    "мёрзнуть",
                     "дружба",
-                    "безумие"
+                    "безумие",
+                    "мёрзнуть",
+                    "сопровождать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "безумие",
+                    "мёрзнуть",
+                    "дружба",
                     "сопровождать",
-                    "дрожать",
-                    "дружба"
+                    "дрожать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "сопровождать",
-                    "мёрзнуть",
-                    "дружба",
-                    "дрожать"
+                    "верный",
+                    "дрожать",
+                    "петь",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «singen»?",
                 "choices": [
+                    "дружба",
                     "безумие",
-                    "дрожать",
-                    "сопровождать",
-                    "петь"
+                    "петь",
+                    "сопровождать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
@@ -3595,19 +3595,19 @@
                     "мёрзнуть",
                     "сопровождать",
                     "дрожать",
-                    "верный"
+                    "дружба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "верный",
-                    "безумие",
-                    "петь",
-                    "дружба"
+                    "сопровождать",
+                    "дрожать",
+                    "дружба",
+                    "верный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4072,27 +4072,27 @@
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
                     "напевать",
-                    "песня",
+                    "ирония",
                     "утешение",
-                    "ирония"
+                    "песня"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
-                    "утешение",
-                    "песня",
                     "ирония",
-                    "напевать"
+                    "утешение",
+                    "напевать",
+                    "песня"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
                     "напевать",
-                    "песня",
+                    "рифма",
                     "мелодия",
                     "ирония"
                 ],
@@ -4101,52 +4101,52 @@
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
-                    "утешение",
-                    "свистеть",
                     "напевать",
-                    "ирония"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Melodie»?",
-                "choices": [
-                    "рифма",
-                    "ирония",
-                    "напевать",
-                    "мелодия"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «pfeifen»?",
-                "choices": [
-                    "свистеть",
                     "песня",
-                    "ирония",
-                    "рифма"
+                    "утешение",
+                    "звучать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Reim»?",
+                "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
-                    "напевать",
-                    "утешение",
+                    "свистеть",
+                    "мелодия",
                     "рифма",
                     "песня"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «pfeifen»?",
+                "choices": [
+                    "напевать",
+                    "рифма",
+                    "свистеть",
+                    "утешение"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Reim»?",
+                "choices": [
+                    "рифма",
+                    "утешение",
+                    "мелодия",
+                    "песня"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
-                    "утешение",
                     "песня",
                     "звучать",
-                    "рифма"
+                    "свистеть",
+                    "утешение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4576,72 +4576,72 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
-                    "философия",
-                    "размышлять",
                     "судьба",
-                    "бренность"
+                    "философия",
+                    "бренность",
+                    "размышлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
                     "размышлять",
                     "судьба",
-                    "бренность",
-                    "философия"
+                    "философия",
+                    "бренность"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
-                    "бренность",
-                    "познавать",
                     "философия",
-                    "размышлять"
+                    "познавать",
+                    "бренность",
+                    "судьба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
                     "смысл",
-                    "судьба",
-                    "размышлять",
-                    "познавать"
+                    "философия",
+                    "бренность",
+                    "размышлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "бренность",
                     "познавать",
-                    "философия",
-                    "судьба"
+                    "смысл",
+                    "преходящий",
+                    "размышлять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Sinn»?",
                 "choices": [
+                    "бренность",
+                    "преходящий",
                     "познавать",
-                    "размышлять",
-                    "смысл",
-                    "судьба"
+                    "смысл"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
-                    "познавать",
-                    "преходящий",
-                    "бренность",
-                    "смысл"
+                    "смысл",
+                    "размышлять",
+                    "судьба",
+                    "преходящий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5108,29 +5108,29 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "пустота",
+                    "исчезать",
                     "тайна",
-                    "растворяться",
-                    "исчезать"
+                    "пустота",
+                    "растворяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
-                    "тайна",
                     "пустота",
+                    "тайна",
                     "растворяться",
                     "исчезать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
                     "исчезать",
-                    "загадочный",
-                    "бесследно",
+                    "тайна",
+                    "уходить",
                     "пустота"
                 ],
                 "correctIndex": 3
@@ -5138,52 +5138,52 @@
             {
                 "question": "Что означает немецкое слово «sich auflösen»?",
                 "choices": [
-                    "исчезать",
-                    "бесследно",
                     "растворяться",
-                    "туман"
+                    "пустота",
+                    "туман",
+                    "загадочный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «spurlos»?",
                 "choices": [
-                    "уходить",
-                    "бесследно",
+                    "загадочный",
                     "растворяться",
-                    "тайна"
+                    "уходить",
+                    "бесследно"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Nebel»?",
                 "choices": [
-                    "бесследно",
-                    "туман",
+                    "загадочный",
                     "исчезать",
-                    "пустота"
+                    "туман",
+                    "растворяться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "уходить",
-                    "исчезать",
+                    "тайна",
                     "туман",
-                    "загадочный"
+                    "загадочный",
+                    "пустота"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
-                    "пустота",
-                    "туман",
+                    "уходить",
+                    "исчезать",
                     "бесследно",
-                    "уходить"
+                    "тайна"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5289,6 +5289,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5573,36 +5774,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6115,6 +6302,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6138,97 +6329,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7146,6 +7303,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "граф", "знать", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "служить", "доверять", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "знать", "уважать", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["честь", "служить", "долг", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["граф", "честь", "служить", "уважать"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["честь", "служить", "доверять", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "граф", "долг", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «achten»?", "choices": ["уважать", "праведный", "долг", "служить"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "верить", "обманывать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обманывать", "письмо", "верить", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["верить", "обманывать", "подозревать", "легковерный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["верить", "ловушка", "обман", "легковерный"], "correct_index": 2}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["простодушный", "подозревать", "ловушка", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["легковерный", "подозревать", "обманывать", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["обманывать", "легковерный", "обман", "ловушка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "простодушный", "письмо", "верить"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "сожалеть", "заблуждение", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "изгонять", "заблуждение", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["заблуждение", "несправедливость", "изгонять", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["сожалеть", "проклинать", "заблуждение", "гнать"], "correct_index": 2}, {"question": "Что означает немецкое слово «blind»?", "choices": ["проклинать", "гнать", "изгонять", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "слепой", "проклинать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "сожалеть", "заблуждение", "изгонять"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["помогать", "сострадание", "опасность", "рисковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "опасность", "сострадание", "рисковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["помогать", "измена", "рисковать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["тайно", "сострадание", "опасность", "рисковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["тайно", "защищать", "опасность", "измена"], "correct_index": 0}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["рисковать", "защищать", "тайно", "сострадание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["рисковать", "измена", "тайно", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["опасность", "защищать", "осмеливаться", "сострадание"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["боль", "темнота", "пытка", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "боль", "темнота", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["ослеплять", "боль", "пытка", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "кричать", "боль", "слепнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["слепнуть", "пытка", "кричать", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["пытка", "ослеплять", "месть", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["кричать", "темнота", "месть", "ослеплять"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "пропасть", "обман", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "пропасть", "прыгать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["пропасть", "безнадёжность", "обман", "падать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["избавлять", "прыгать", "обман", "пропасть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "безнадёжность", "прыгать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["пропасть", "безнадёжность", "обман", "прыгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "избавлять", "отчаяние", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["отчаяние", "обман", "избавлять", "прыгать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "умирать", "прощать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "осознание", "узнавать", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "раскаяние", "прощать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["прощать", "узнавать", "осознание", "примирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["сердце", "раскаяние", "осознание", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["сердце", "осознание", "обнимать", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["примирение", "раскаяние", "прощать", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["раскаяние", "обнимать", "умирать", "сердце"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["служить", "доверять", "знать", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["служить", "доверять", "знать", "граф"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["праведный", "долг", "доверять", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["праведный", "уважать", "честь", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["праведный", "граф", "уважать", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["доверять", "уважать", "праведный", "долг"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "знать", "праведный", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «achten»?", "choices": ["честь", "граф", "доверять", "уважать"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["верить", "обманывать", "обман", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["верить", "письмо", "обманывать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обман", "верить", "подозревать", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обманывать", "обман", "простодушный", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["простодушный", "ловушка", "верить", "легковерный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["письмо", "обман", "ловушка", "подозревать"], "correct_index": 3}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["верить", "легковерный", "обман", "простодушный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "верить", "подозревать", "обман"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "изгонять", "сожалеть", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "изгонять", "сожалеть", "заблуждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["заблуждение", "слепой", "сожалеть", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["заблуждение", "изгонять", "проклинать", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "несправедливость", "проклинать", "заблуждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "заблуждение", "слепой", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["проклинать", "заблуждение", "изгонять", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["опасность", "помогать", "сострадание", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "сострадание", "помогать", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["рисковать", "помогать", "сострадание", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["осмеливаться", "тайно", "рисковать", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["помогать", "сострадание", "осмеливаться", "тайно"], "correct_index": 3}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["тайно", "сострадание", "защищать", "измена"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["тайно", "измена", "сострадание", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["осмеливаться", "тайно", "сострадание", "опасность"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["темнота", "пытка", "ослеплять", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["боль", "пытка", "темнота", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["пытка", "боль", "темнота", "слепнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["ослеплять", "темнота", "боль", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["пытка", "кричать", "слепнуть", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["темнота", "месть", "ослеплять", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "пытка", "ослеплять", "боль"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "прыгать", "пропасть", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «springen»?", "choices": ["пропасть", "отчаяние", "прыгать", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["избавлять", "пропасть", "обман", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["обман", "падать", "избавлять", "пропасть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["отчаяние", "сдаваться", "обман", "безнадёжность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["безнадёжность", "обман", "сдаваться", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["сдаваться", "безнадёжность", "падать", "прыгать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["избавлять", "сдаваться", "безнадёжность", "падать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "узнавать", "осознание", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "умирать", "узнавать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "обнимать", "узнавать", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["раскаяние", "умирать", "сердце", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["обнимать", "узнавать", "прощать", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощать", "обнимать", "примирение", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["узнавать", "раскаяние", "сердце", "примирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["раскаяние", "умирать", "узнавать", "сердце"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -666,43 +666,43 @@
                         <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
@@ -714,11 +714,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                             
@@ -726,47 +726,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                             
@@ -774,17 +774,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «achten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,13 +797,29 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
@@ -813,49 +829,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -867,27 +867,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -897,13 +897,13 @@
                         <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -915,11 +915,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,17 +932,17 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -956,23 +956,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
@@ -980,33 +996,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1018,27 +1018,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,29 +1051,13 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
@@ -1083,13 +1067,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                             
@@ -1099,49 +1115,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1151,29 +1151,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">тайно</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1186,29 +1186,29 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
@@ -1222,27 +1222,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
@@ -1250,17 +1234,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1270,11 +1270,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
                             
@@ -1282,17 +1282,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1311,11 +1311,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1325,57 +1325,9 @@
                         <div class="quiz-question">Что означает немецкое слово «springen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
                             
@@ -1385,49 +1337,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безнадёжность</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1440,17 +1440,17 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1462,11 +1462,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1478,57 +1478,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                             
@@ -1536,17 +1488,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1558,9 +1558,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
@@ -1969,39 +1969,39 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
+                    "служить",
                     "доверять",
-                    "граф",
                     "знать",
-                    "служить"
+                    "граф"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "граф",
                     "служить",
                     "доверять",
-                    "знать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vertrauen»?",
-                "choices": [
-                    "доверять",
                     "знать",
-                    "уважать",
-                    "служить"
+                    "граф"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «vertrauen»?",
+                "choices": [
+                    "праведный",
+                    "долг",
+                    "доверять",
+                    "служить"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
+                    "праведный",
+                    "уважать",
                     "честь",
-                    "служить",
-                    "долг",
                     "граф"
                 ],
                 "correctIndex": 3
@@ -2009,42 +2009,42 @@
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
+                    "праведный",
                     "граф",
-                    "честь",
-                    "служить",
-                    "уважать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «rechtschaffen»?",
-                "choices": [
-                    "честь",
-                    "служить",
-                    "доверять",
-                    "праведный"
+                    "уважать",
+                    "честь"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Pflicht»?",
+                "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "честь",
-                    "граф",
-                    "долг",
-                    "доверять"
+                    "доверять",
+                    "уважать",
+                    "праведный",
+                    "долг"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «achten»?",
+                "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "уважать",
-                    "праведный",
                     "долг",
-                    "служить"
+                    "знать",
+                    "праведный",
+                    "доверять"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «achten»?",
+                "choices": [
+                    "честь",
+                    "граф",
+                    "доверять",
+                    "уважать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2520,70 +2520,70 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "письмо",
                     "верить",
+                    "обманывать",
+                    "обман",
+                    "письмо"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «glauben»?",
+                "choices": [
+                    "верить",
+                    "письмо",
                     "обманывать",
                     "обман"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «glauben»?",
-                "choices": [
-                    "обманывать",
-                    "письмо",
-                    "верить",
-                    "обман"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
+                    "обман",
                     "верить",
-                    "обманывать",
                     "подозревать",
-                    "легковерный"
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "верить",
-                    "ловушка",
+                    "обманывать",
                     "обман",
-                    "легковерный"
+                    "простодушный",
+                    "верить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
                     "простодушный",
-                    "подозревать",
                     "ловушка",
-                    "письмо"
+                    "верить",
+                    "легковерный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "легковерный",
-                    "подозревать",
-                    "обманывать",
-                    "обман"
+                    "письмо",
+                    "обман",
+                    "ловушка",
+                    "подозревать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
-                    "обманывать",
+                    "верить",
                     "легковерный",
                     "обман",
-                    "ловушка"
+                    "простодушный"
                 ],
                 "correctIndex": 1
             },
@@ -2591,9 +2591,9 @@
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
                     "ловушка",
-                    "простодушный",
-                    "письмо",
-                    "верить"
+                    "верить",
+                    "подозревать",
+                    "обман"
                 ],
                 "correctIndex": 0
             }
@@ -3049,19 +3049,19 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "проклинать",
+                    "изгонять",
                     "сожалеть",
-                    "заблуждение",
-                    "изгонять"
+                    "заблуждение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
                     "проклинать",
                     "изгонять",
-                    "заблуждение",
-                    "сожалеть"
+                    "сожалеть",
+                    "заблуждение"
                 ],
                 "correctIndex": 0
             },
@@ -3069,51 +3069,51 @@
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "заблуждение",
-                    "несправедливость",
-                    "изгонять",
-                    "сожалеть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Irrtum»?",
-                "choices": [
+                    "слепой",
                     "сожалеть",
-                    "проклинать",
-                    "заблуждение",
-                    "гнать"
+                    "несправедливость"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Irrtum»?",
+                "choices": [
+                    "заблуждение",
+                    "изгонять",
+                    "проклинать",
+                    "сожалеть"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
+                    "слепой",
+                    "несправедливость",
                     "проклинать",
-                    "гнать",
-                    "изгонять",
-                    "слепой"
+                    "заблуждение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
                     "гнать",
+                    "заблуждение",
                     "слепой",
-                    "проклинать",
-                    "изгонять"
+                    "сожалеть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "несправедливость",
-                    "сожалеть",
+                    "проклинать",
                     "заблуждение",
-                    "изгонять"
+                    "изгонять",
+                    "несправедливость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3569,82 +3569,82 @@
             {
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
+                    "опасность",
                     "помогать",
                     "сострадание",
-                    "опасность",
                     "рисковать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Mitleid»?",
-                "choices": [
-                    "помогать",
-                    "опасность",
-                    "сострадание",
-                    "рисковать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «riskieren»?",
-                "choices": [
-                    "помогать",
-                    "измена",
-                    "рисковать",
-                    "опасность"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Gefahr»?",
-                "choices": [
-                    "тайно",
-                    "сострадание",
-                    "опасность",
-                    "рисковать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «heimlich»?",
-                "choices": [
-                    "тайно",
-                    "защищать",
-                    "опасность",
-                    "измена"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «schützen»?",
-                "choices": [
-                    "рисковать",
-                    "защищать",
-                    "тайно",
-                    "сострадание"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «der Verrat»?",
+                "question": "Что означает немецкое слово «das Mitleid»?",
+                "choices": [
+                    "опасность",
+                    "сострадание",
+                    "помогать",
+                    "рисковать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
                     "рисковать",
-                    "измена",
+                    "помогать",
+                    "сострадание",
+                    "осмеливаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "осмеливаться",
                     "тайно",
-                    "защищать"
+                    "рисковать",
+                    "опасность"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «heimlich»?",
+                "choices": [
+                    "помогать",
+                    "сострадание",
+                    "осмеливаться",
+                    "тайно"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «schützen»?",
+                "choices": [
+                    "тайно",
+                    "сострадание",
+                    "защищать",
+                    "измена"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Verrat»?",
+                "choices": [
+                    "тайно",
+                    "измена",
+                    "сострадание",
+                    "опасность"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "опасность",
-                    "защищать",
                     "осмеливаться",
-                    "сострадание"
+                    "тайно",
+                    "сострадание",
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4087,59 +4087,59 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "боль",
                     "темнота",
                     "пытка",
-                    "ослеплять"
+                    "ослеплять",
+                    "боль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытка",
                     "боль",
+                    "пытка",
                     "темнота",
                     "ослеплять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "ослеплять",
-                    "боль",
                     "пытка",
-                    "месть"
+                    "боль",
+                    "темнота",
+                    "слепнуть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
+                    "ослеплять",
                     "темнота",
-                    "кричать",
                     "боль",
-                    "слепнуть"
+                    "кричать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "слепнуть",
                     "пытка",
                     "кричать",
-                    "ослеплять"
+                    "слепнуть",
+                    "месть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
-                    "пытка",
-                    "ослеплять",
+                    "темнота",
                     "месть",
+                    "ослеплять",
                     "слепнуть"
                 ],
                 "correctIndex": 3
@@ -4147,12 +4147,12 @@
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "кричать",
-                    "темнота",
                     "месть",
-                    "ослеплять"
+                    "пытка",
+                    "ослеплять",
+                    "боль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4629,38 +4629,38 @@
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
                     "отчаяние",
+                    "прыгать",
                     "пропасть",
-                    "обман",
-                    "прыгать"
+                    "обман"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «springen»?",
                 "choices": [
-                    "обман",
                     "пропасть",
+                    "отчаяние",
                     "прыгать",
-                    "отчаяние"
+                    "обман"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
+                    "избавлять",
                     "пропасть",
-                    "безнадёжность",
                     "обман",
-                    "падать"
+                    "отчаяние"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "избавлять",
-                    "прыгать",
                     "обман",
+                    "падать",
+                    "избавлять",
                     "пропасть"
                 ],
                 "correctIndex": 3
@@ -4668,42 +4668,42 @@
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
+                    "отчаяние",
                     "сдаваться",
-                    "безнадёжность",
-                    "прыгать",
-                    "обман"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
-                "choices": [
-                    "пропасть",
-                    "безнадёжность",
                     "обман",
-                    "прыгать"
+                    "безнадёжность"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «stürzen»?",
+                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "падать",
-                    "избавлять",
-                    "отчаяние",
-                    "прыгать"
+                    "безнадёжность",
+                    "обман",
+                    "сдаваться",
+                    "отчаяние"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «erlösen»?",
+                "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "отчаяние",
-                    "обман",
-                    "избавлять",
+                    "сдаваться",
+                    "безнадёжность",
+                    "падать",
                     "прыгать"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «erlösen»?",
+                "choices": [
+                    "избавлять",
+                    "сдаваться",
+                    "безнадёжность",
+                    "падать"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5181,20 +5181,20 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
-                    "умирать",
                     "прощать",
-                    "осознание"
+                    "узнавать",
+                    "осознание",
+                    "умирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
                     "прощать",
-                    "осознание",
+                    "умирать",
                     "узнавать",
-                    "умирать"
+                    "осознание"
                 ],
                 "correctIndex": 0
             },
@@ -5202,58 +5202,58 @@
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "умирать",
-                    "раскаяние",
-                    "прощать",
-                    "осознание"
+                    "обнимать",
+                    "узнавать",
+                    "раскаяние"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "прощать",
-                    "узнавать",
-                    "осознание",
-                    "примирение"
+                    "раскаяние",
+                    "умирать",
+                    "сердце",
+                    "осознание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "сердце",
-                    "раскаяние",
-                    "осознание",
-                    "прощать"
+                    "обнимать",
+                    "узнавать",
+                    "прощать",
+                    "раскаяние"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "сердце",
-                    "осознание",
+                    "прощать",
                     "обнимать",
+                    "примирение",
                     "раскаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
-                    "примирение",
+                    "узнавать",
                     "раскаяние",
-                    "прощать",
-                    "узнавать"
+                    "сердце",
+                    "примирение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
                     "раскаяние",
-                    "обнимать",
                     "умирать",
+                    "узнавать",
                     "сердце"
                 ],
                 "correctIndex": 3
@@ -5361,6 +5361,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5645,36 +5846,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6187,6 +6374,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6210,97 +6401,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7218,6 +7375,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "клясться", "лицемерить", "ложь"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["ложь", "клясться", "лицемерить", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["обманывать", "состояние", "ложь", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["льстить", "ложь", "лицемерить", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["лицемерить", "жадность", "клясться", "льстить"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["состояние", "льстить", "наследство", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["состояние", "обманывать", "жадность", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["обманывать", "состояние", "ложь", "льстить"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["приказывать", "трон", "править", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "трон", "власть", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["подчинять", "господство", "трон", "приказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "господство", "завоёвывать", "управлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["управлять", "господство", "подчинять", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["приказывать", "власть", "подчинять", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["приказывать", "управлять", "господство", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["господство", "подчинять", "править", "власть"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["месть", "унижать", "жестокий", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["жестокий", "месть", "изгонять", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["жестокий", "отказывать", "месть", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["ограничивать", "унижать", "презирать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["мучить", "презирать", "месть", "ограничивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["ограничивать", "отказывать", "мучить", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["презирать", "отказывать", "мучить", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["отказывать", "ограничивать", "презирать", "унижать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["запирать", "буря", "безжалостный", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "отвергать", "безжалостный", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["запирать", "беспощадный", "безжалостный", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["холод", "запирать", "беспощадный", "ожесточаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["безжалостный", "беспощадный", "буря", "холод"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "беспощадный", "холод", "запирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["ожесточаться", "безжалостный", "холод", "запирать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["ненавидеть", "ссориться", "предавать", "раздор"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "раздор", "ненавидеть", "ссориться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["презрение", "раздор", "изменять", "разрушать"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "разрушать", "страсть", "ссориться"], "correct_index": 0}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["страсть", "изменять", "ссориться", "раздор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["разрушать", "ненавидеть", "презрение", "раздор"], "correct_index": 2}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["раздор", "разрушать", "предавать", "страсть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["раздор", "разрушать", "страсть", "ненавидеть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["желать", "бороться", "ревность", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["желать", "бороться", "ревность", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["ревность", "бороться", "яд", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["яд", "желать", "убивать", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["убивать", "ревность", "яд", "устранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["яд", "устранять", "ревность", "соперничать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["желать", "бороться", "интрига", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["устранять", "убивать", "ревность", "бороться"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["вина", "умирать", "отчаяние", "отравлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "отравлять", "вина", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["ад", "погибель", "умирать", "отравлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["отчаяние", "ад", "погибель", "вина"], "correct_index": 3}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["уничтожать", "ад", "умирать", "погибель"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["погибель", "ад", "сожалеть", "уничтожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "отчаяние", "вина", "уничтожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["уничтожать", "отравлять", "вина", "ад"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["наследство", "ложь", "клясться", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["наследство", "лицемерить", "ложь", "клясться"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["лицемерить", "состояние", "наследство", "клясться"], "correct_index": 2}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["жадность", "наследство", "клясться", "лицемерить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "лицемерить", "льстить", "состояние"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["клясться", "обманывать", "ложь", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["лицемерить", "наследство", "обманывать", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["льстить", "обманывать", "состояние", "наследство"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "править", "приказывать", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "приказывать", "трон", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["подчинять", "править", "приказывать", "господство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["править", "господство", "трон", "управлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "управлять", "править", "господство"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["господство", "управлять", "власть", "приказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "завоёвывать", "управлять", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["власть", "управлять", "подчинять", "завоёвывать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["месть", "жестокий", "унижать", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "месть", "жестокий", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["мучить", "отказывать", "презирать", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["месть", "ограничивать", "мучить", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["презирать", "отказывать", "жестокий", "ограничивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["отказывать", "изгонять", "жестокий", "ограничивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["отказывать", "жестокий", "мучить", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["унижать", "мучить", "ограничивать", "изгонять"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["запирать", "буря", "отвергать", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["отвергать", "буря", "безжалостный", "запирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "запирать", "отвергать", "ожесточаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["отвергать", "ожесточаться", "холод", "запирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["ожесточаться", "холод", "безжалостный", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["запирать", "холод", "беспощадный", "ожесточаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["буря", "ожесточаться", "безжалостный", "запирать"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ссориться", "ненавидеть", "предавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["ссориться", "предавать", "раздор", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["предавать", "разрушать", "ссориться", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["предавать", "ненавидеть", "презрение", "ссориться"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["разрушать", "презрение", "изменять", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["презрение", "предавать", "ссориться", "раздор"], "correct_index": 0}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["ненавидеть", "разрушать", "изменять", "страсть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["изменять", "ненавидеть", "страсть", "ссориться"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["соперничать", "желать", "бороться", "ревность"], "correct_index": 3}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "бороться", "желать", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["интрига", "соперничать", "бороться", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["интрига", "яд", "желать", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["соперничать", "убивать", "устранять", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["ревность", "яд", "бороться", "устранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["яд", "соперничать", "интрига", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["интрига", "ревность", "убивать", "желать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["умирать", "вина", "отравлять", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["вина", "отравлять", "отчаяние", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["уничтожать", "сожалеть", "отравлять", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["погибель", "вина", "отчаяние", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["умирать", "вина", "уничтожать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["отравлять", "вина", "погибель", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["погибель", "сожалеть", "умирать", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "отравлять", "вина", "уничтожать"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,97 +662,97 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,11 +762,11 @@
                         <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
                             
@@ -774,17 +774,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -801,11 +801,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
@@ -819,7 +819,71 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
@@ -829,97 +893,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,13 +932,29 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
@@ -948,33 +964,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -984,11 +984,11 @@
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -996,15 +996,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
                             
@@ -1012,17 +1012,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,29 +1032,29 @@
                         <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,7 +1067,7 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                         <div class="quiz-choices">
                             
@@ -1075,21 +1075,21 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
@@ -1099,29 +1099,61 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">запирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
@@ -1131,47 +1163,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                             
@@ -1190,73 +1190,41 @@
                         <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
@@ -1266,15 +1234,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">презрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
                             
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                             
@@ -1302,13 +1302,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1321,17 +1321,17 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1341,11 +1341,11 @@
                         <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
                             
@@ -1353,15 +1353,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">устранять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                             
@@ -1369,49 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1421,29 +1421,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1456,31 +1456,31 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
@@ -1488,97 +1488,97 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">погибель</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">погибель</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2018,68 +2018,68 @@
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
                     "наследство",
+                    "ложь",
                     "клясться",
-                    "лицемерить",
-                    "ложь"
+                    "лицемерить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
-                    "ложь",
-                    "клясться",
+                    "наследство",
                     "лицемерить",
-                    "наследство"
+                    "ложь",
+                    "клясться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
-                    "обманывать",
-                    "состояние",
-                    "ложь",
-                    "наследство"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «heucheln»?",
-                "choices": [
-                    "льстить",
-                    "ложь",
                     "лицемерить",
-                    "обманывать"
+                    "состояние",
+                    "наследство",
+                    "клясться"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Gier»?",
+                "question": "Что означает немецкое слово «heucheln»?",
                 "choices": [
-                    "лицемерить",
                     "жадность",
-                    "клясться",
-                    "льстить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "состояние",
-                    "льстить",
                     "наследство",
-                    "обманывать"
+                    "клясться",
+                    "лицемерить"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "жадность",
+                    "лицемерить",
+                    "льстить",
+                    "состояние"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "клясться",
+                    "обманывать",
+                    "ложь",
+                    "лицемерить"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "состояние",
+                    "лицемерить",
+                    "наследство",
                     "обманывать",
-                    "жадность",
                     "льстить"
                 ],
                 "correctIndex": 3
@@ -2087,12 +2087,12 @@
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
+                    "льстить",
                     "обманывать",
                     "состояние",
-                    "ложь",
-                    "льстить"
+                    "наследство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2623,9 +2623,9 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "приказывать",
                     "трон",
                     "править",
+                    "приказывать",
                     "власть"
                 ],
                 "correctIndex": 3
@@ -2634,9 +2634,9 @@
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
                     "править",
+                    "приказывать",
                     "трон",
-                    "власть",
-                    "приказывать"
+                    "власть"
                 ],
                 "correctIndex": 0
             },
@@ -2644,61 +2644,61 @@
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
                     "подчинять",
-                    "господство",
-                    "трон",
-                    "приказывать"
+                    "править",
+                    "приказывать",
+                    "господство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "трон",
+                    "править",
                     "господство",
-                    "завоёвывать",
+                    "трон",
                     "управлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
+                    "завоёвывать",
                     "управлять",
-                    "господство",
-                    "подчинять",
-                    "завоёвывать"
+                    "править",
+                    "господство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "приказывать",
+                    "господство",
+                    "управлять",
                     "власть",
-                    "подчинять",
-                    "господство"
+                    "приказывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "приказывать",
+                    "власть",
+                    "завоёвывать",
                     "управлять",
-                    "господство",
-                    "власть"
+                    "трон"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "господство",
+                    "власть",
+                    "управлять",
                     "подчинять",
-                    "править",
-                    "власть"
+                    "завоёвывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3244,38 +3244,38 @@
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
                     "месть",
+                    "жестокий",
                     "унижать",
-                    "жестокий",
                     "изгонять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «grausam»?",
-                "choices": [
-                    "жестокий",
-                    "месть",
-                    "изгонять",
-                    "унижать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "жестокий",
-                    "отказывать",
-                    "месть",
-                    "унижать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «grausam»?",
+                "choices": [
+                    "унижать",
+                    "месть",
+                    "жестокий",
+                    "изгонять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "мучить",
+                    "отказывать",
+                    "презирать",
+                    "месть"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
+                    "месть",
                     "ограничивать",
-                    "унижать",
-                    "презирать",
+                    "мучить",
                     "изгонять"
                 ],
                 "correctIndex": 3
@@ -3283,42 +3283,42 @@
             {
                 "question": "Что означает немецкое слово «verachten»?",
                 "choices": [
-                    "мучить",
                     "презирать",
-                    "месть",
+                    "отказывать",
+                    "жестокий",
                     "ограничивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verweigern»?",
                 "choices": [
-                    "ограничивать",
                     "отказывать",
-                    "мучить",
-                    "месть"
+                    "изгонять",
+                    "жестокий",
+                    "ограничивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "презирать",
                     "отказывать",
+                    "жестокий",
                     "мучить",
-                    "изгонять"
+                    "унижать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
-                    "отказывать",
+                    "унижать",
+                    "мучить",
                     "ограничивать",
-                    "презирать",
-                    "унижать"
+                    "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3819,70 +3819,70 @@
                 "choices": [
                     "запирать",
                     "буря",
-                    "безжалостный",
-                    "отвергать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Sturm»?",
-                "choices": [
-                    "буря",
                     "отвергать",
-                    "безжалостный",
-                    "запирать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «gnadenlos»?",
-                "choices": [
-                    "запирать",
-                    "беспощадный",
-                    "безжалостный",
-                    "буря"
+                    "безжалостный"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verschließen»?",
+                "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "холод",
-                    "запирать",
-                    "беспощадный",
-                    "ожесточаться"
+                    "отвергать",
+                    "буря",
+                    "безжалостный",
+                    "запирать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Kälte»?",
+                "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
                     "безжалостный",
-                    "беспощадный",
-                    "буря",
-                    "холод"
+                    "запирать",
+                    "отвергать",
+                    "ожесточаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verschließen»?",
+                "choices": [
+                    "отвергать",
+                    "ожесточаться",
+                    "холод",
+                    "запирать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "отвергать",
-                    "беспощадный",
+                    "ожесточаться",
                     "холод",
-                    "запирать"
+                    "безжалостный",
+                    "беспощадный"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "запирать",
+                    "холод",
+                    "беспощадный",
+                    "ожесточаться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
+                    "буря",
                     "ожесточаться",
                     "безжалостный",
-                    "холод",
                     "запирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4393,69 +4393,69 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
-                    "ненавидеть",
+                    "раздор",
                     "ссориться",
-                    "предавать",
-                    "раздор"
+                    "ненавидеть",
+                    "предавать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
+                    "ссориться",
                     "предавать",
                     "раздор",
-                    "ненавидеть",
-                    "ссориться"
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
-                    "презрение",
-                    "раздор",
-                    "изменять",
-                    "разрушать"
+                    "предавать",
+                    "разрушать",
+                    "ссориться",
+                    "раздор"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
+                    "предавать",
                     "ненавидеть",
-                    "разрушать",
-                    "страсть",
+                    "презрение",
                     "ссориться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «betrügen»?",
-                "choices": [
-                    "страсть",
-                    "изменять",
-                    "ссориться",
-                    "раздор"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Verachtung»?",
+                "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
                     "разрушать",
-                    "ненавидеть",
                     "презрение",
-                    "раздор"
+                    "изменять",
+                    "предавать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Verachtung»?",
+                "choices": [
+                    "презрение",
+                    "предавать",
+                    "ссориться",
+                    "раздор"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
-                    "раздор",
+                    "ненавидеть",
                     "разрушать",
-                    "предавать",
+                    "изменять",
                     "страсть"
                 ],
                 "correctIndex": 1
@@ -4463,10 +4463,10 @@
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "раздор",
-                    "разрушать",
+                    "изменять",
+                    "ненавидеть",
                     "страсть",
-                    "ненавидеть"
+                    "ссориться"
                 ],
                 "correctIndex": 2
             }
@@ -4996,19 +4996,19 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
+                    "соперничать",
                     "желать",
                     "бороться",
-                    "ревность",
-                    "соперничать"
+                    "ревность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
-                    "желать",
-                    "бороться",
                     "ревность",
+                    "бороться",
+                    "желать",
                     "соперничать"
                 ],
                 "correctIndex": 3
@@ -5016,62 +5016,62 @@
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "ревность",
+                    "интрига",
+                    "соперничать",
                     "бороться",
-                    "яд",
-                    "интрига"
+                    "ревность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
+                    "интрига",
                     "яд",
                     "желать",
+                    "ревность"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «beseitigen»?",
+                "choices": [
+                    "соперничать",
                     "убивать",
+                    "устранять",
+                    "интрига"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «das Gift»?",
+                "choices": [
+                    "ревность",
+                    "яд",
+                    "бороться",
                     "устранять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «beseitigen»?",
-                "choices": [
-                    "убивать",
-                    "ревность",
-                    "яд",
-                    "устранять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Gift»?",
-                "choices": [
-                    "яд",
-                    "устранять",
-                    "ревность",
-                    "соперничать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "желать",
-                    "бороться",
+                    "яд",
+                    "соперничать",
                     "интрига",
-                    "соперничать"
+                    "ревность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "устранять",
-                    "убивать",
+                    "интрига",
                     "ревность",
-                    "бороться"
+                    "убивать",
+                    "желать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5598,82 +5598,82 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "вина",
                     "умирать",
-                    "отчаяние",
-                    "отравлять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "отчаяние",
+                    "вина",
                     "отравлять",
-                    "вина",
-                    "умирать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "ад",
-                    "погибель",
-                    "умирать",
-                    "отравлять"
+                    "отчаяние"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Schuld»?",
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
+                    "вина",
+                    "отравлять",
                     "отчаяние",
-                    "ад",
-                    "погибель",
-                    "вина"
+                    "умирать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "уничтожать",
+                    "сожалеть",
+                    "отравлять",
+                    "умирать"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Schuld»?",
+                "choices": [
+                    "погибель",
+                    "вина",
+                    "отчаяние",
+                    "сожалеть"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
-                    "уничтожать",
-                    "ад",
                     "умирать",
-                    "погибель"
+                    "вина",
+                    "уничтожать",
+                    "отчаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Verderben»?",
                 "choices": [
+                    "отравлять",
+                    "вина",
                     "погибель",
-                    "ад",
-                    "сожалеть",
-                    "уничтожать"
+                    "отчаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
+                    "погибель",
                     "сожалеть",
-                    "отчаяние",
-                    "вина",
-                    "уничтожать"
+                    "умирать",
+                    "отчаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "уничтожать",
+                    "ад",
                     "отравлять",
                     "вина",
-                    "ад"
+                    "уничтожать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5794,6 +5794,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6078,36 +6279,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6620,6 +6807,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6643,97 +6834,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7651,6 +7808,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "верность", "мужество", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["возражать", "верность", "мужество", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "защищать", "верность", "возражать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["защищать", "мужество", "предупреждать", "искренний"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["верность", "возражать", "мужество", "искренний"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["защищать", "мужество", "слуга", "предупреждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["справедливый", "предупреждать", "слуга", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["справедливый", "предупреждать", "верность", "возражать"], "correct_index": 0}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["гнев", "несправедливость", "изгнание", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "изгнание", "гнев", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["прощание", "гнев", "возвращаться", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["возвращаться", "изгнание", "несправедливость", "изгнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["возвращаться", "наказание", "гнев", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "наказание", "прощание", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["возвращаться", "наказание", "прощание", "гнев"], "correct_index": 0}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["переодевание", "неузнанный", "притворяться", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["переодевание", "притворяться", "неузнанный", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["верный", "изменять", "переодевание", "неузнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "переодевание", "хитрость", "изменять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["притворяться", "наниматься", "изменять", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["хитрость", "верный", "изменять", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["неузнанный", "притворяться", "наниматься", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "притворяться", "хитрость", "борода"], "correct_index": 0}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["опасность", "служба", "защита", "охранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["сражаться", "опасность", "стража", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["охранять", "сражаться", "опасность", "советовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "опасность", "стража", "служба"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "защита", "охранять", "сражаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["стража", "советовать", "сражаться", "опасность"], "correct_index": 0}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["сковывать", "наказание", "стойкость", "унижение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["стойкость", "наказание", "сковывать", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["наказание", "позор", "стойкость", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["терпеть", "унижение", "сковывать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["наказание", "терпеть", "унижение", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["позор", "терпеть", "колодка", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["терпеть", "выдерживать", "наказание", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["стойкость", "позор", "сковывать", "выдерживать"], "correct_index": 1}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "буря", "поддержка", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["утешать", "поддержка", "сопровождать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["утешать", "выдерживать", "сопровождать", "убежище"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["убежище", "буря", "поддержка", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["утешать", "сопровождать", "холод", "убежище"], "correct_index": 3}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["убежище", "поддержка", "выдерживать", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["убежище", "буря", "утешать", "холод"], "correct_index": 3}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["прощание", "плакать", "вечный", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["плакать", "смерть", "прощание", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["истощение", "вечный", "смерть", "скорбь"], "correct_index": 1}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["смерть", "плакать", "скорбь", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["смерть", "вечный", "истощение", "плакать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["скорбь", "сдаваться", "следовать", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скорбь", "следовать", "сдаваться", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["скорбь", "следовать", "вечный", "плакать"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["мужество", "возражать", "верность", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "возражать", "защищать", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["мужество", "возражать", "слуга", "предупреждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["слуга", "возражать", "защищать", "верность"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["справедливый", "искренний", "мужество", "предупреждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["верность", "предупреждать", "возражать", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["возражать", "предупреждать", "мужество", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["справедливый", "мужество", "искренний", "слуга"], "correct_index": 0}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["гнев", "изгнание", "изгнанный", "несправедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["гнев", "изгнание", "изгнанный", "несправедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнанный", "гнев", "прощание", "несправедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["прощание", "несправедливость", "изгнанный", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["гнев", "наказание", "возвращаться", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгнанный", "несправедливость", "прощание", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["изгнание", "возвращаться", "наказание", "прощание"], "correct_index": 1}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["притворяться", "переодевание", "хитрость", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["притворяться", "хитрость", "переодевание", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "наниматься", "борода", "притворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["верный", "неузнанный", "хитрость", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["хитрость", "притворяться", "переодевание", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["верный", "борода", "притворяться", "изменять"], "correct_index": 1}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["переодевание", "притворяться", "наниматься", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["хитрость", "неузнанный", "верный", "борода"], "correct_index": 2}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["охранять", "опасность", "защита", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "защита", "служба", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "защита", "сражаться", "стража"], "correct_index": 0}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["охранять", "стража", "советовать", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["защита", "стража", "охранять", "сражаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «raten»?", "choices": ["советовать", "служба", "опасность", "охранять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["охранять", "служба", "стража", "опасность"], "correct_index": 2}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["унижение", "наказание", "стойкость", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["унижение", "сковывать", "наказание", "стойкость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["позор", "наказание", "колодка", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["наказание", "терпеть", "сковывать", "выдерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["позор", "терпеть", "унижение", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["позор", "колодка", "сковывать", "выдерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["терпеть", "выдерживать", "унижение", "позор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["выдерживать", "позор", "терпеть", "стойкость"], "correct_index": 1}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["сопровождать", "утешать", "поддержка", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["поддержка", "сопровождать", "буря", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["выдерживать", "убежище", "сопровождать", "утешать"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["выдерживать", "утешать", "буря", "поддержка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["убежище", "буря", "поддержка", "холод"], "correct_index": 0}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["утешать", "буря", "выдерживать", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["поддержка", "убежище", "холод", "сопровождать"], "correct_index": 2}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "вечный", "прощание", "плакать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["плакать", "вечный", "прощание", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["следовать", "истощение", "сдаваться", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["сдаваться", "вечный", "смерть", "плакать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["плакать", "смерть", "истощение", "скорбь"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["плакать", "истощение", "смерть", "сдаваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["следовать", "плакать", "прощание", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["следовать", "вечный", "плакать", "истощение"], "correct_index": 0}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,93 +662,45 @@
             <div class="quiz-phase-container active" data-phase="loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
@@ -758,17 +710,65 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -780,11 +780,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,17 +797,17 @@
             <div class="quiz-phase-container" data-phase="banishment">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -817,11 +817,11 @@
                         <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
@@ -833,29 +833,29 @@
                         <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -865,11 +865,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
@@ -877,33 +877,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -916,45 +916,29 @@
             <div class="quiz-phase-container" data-phase="disguise">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
@@ -964,15 +948,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                             
@@ -980,33 +996,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1016,27 +1016,27 @@
                         <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
                             
@@ -1055,45 +1055,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,27 +1105,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1137,25 +1137,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                             
@@ -1174,45 +1174,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">стойкость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1222,13 +1222,13 @@
                         <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1238,29 +1238,29 @@
                         <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1274,9 +1274,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1286,13 +1286,13 @@
                         <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,33 +1305,33 @@
             <div class="quiz-phase-container" data-phase="storm_companion">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1341,20 +1341,36 @@
                         <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
@@ -1363,23 +1379,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1389,9 +1389,9 @@
                         <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                             
@@ -1401,17 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,17 +1424,17 @@
             <div class="quiz-phase-container" data-phase="final_loyalty">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1446,9 +1446,25 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
@@ -1456,33 +1472,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1492,61 +1492,61 @@
                         <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">истощение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1943,70 +1943,70 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
+                    "мужество",
                     "возражать",
                     "верность",
-                    "мужество",
                     "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
+                    "мужество",
                     "возражать",
-                    "верность",
-                    "мужество",
-                    "защищать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «widersprechen»?",
-                "choices": [
-                    "искренний",
                     "защищать",
-                    "верность",
-                    "возражать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verteidigen»?",
-                "choices": [
-                    "защищать",
-                    "мужество",
-                    "предупреждать",
-                    "искренний"
+                    "верность"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «aufrichtig»?",
+                "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
-                    "верность",
+                    "мужество",
                     "возражать",
-                    "мужество",
-                    "искренний"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Diener»?",
-                "choices": [
-                    "защищать",
-                    "мужество",
                     "слуга",
                     "предупреждать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «verteidigen»?",
+                "choices": [
+                    "слуга",
+                    "возражать",
+                    "защищать",
+                    "верность"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «warnen»?",
+                "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
                     "справедливый",
+                    "искренний",
+                    "мужество",
+                    "предупреждать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Diener»?",
+                "choices": [
+                    "верность",
                     "предупреждать",
-                    "слуга",
-                    "верность"
+                    "возражать",
+                    "слуга"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «warnen»?",
+                "choices": [
+                    "возражать",
+                    "предупреждать",
+                    "мужество",
+                    "защищать"
                 ],
                 "correctIndex": 1
             },
@@ -2014,9 +2014,9 @@
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
                     "справедливый",
-                    "предупреждать",
-                    "верность",
-                    "возражать"
+                    "мужество",
+                    "искренний",
+                    "слуга"
                 ],
                 "correctIndex": 0
             }
@@ -2477,18 +2477,18 @@
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
                     "гнев",
-                    "несправедливость",
                     "изгнание",
-                    "изгнанный"
+                    "изгнанный",
+                    "несправедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "изгнанный",
-                    "изгнание",
                     "гнев",
+                    "изгнание",
+                    "изгнанный",
                     "несправедливость"
                 ],
                 "correctIndex": 3
@@ -2496,29 +2496,29 @@
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "прощание",
+                    "изгнанный",
                     "гнев",
-                    "возвращаться",
-                    "наказание"
+                    "прощание",
+                    "несправедливость"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
-                    "возвращаться",
-                    "изгнание",
+                    "прощание",
                     "несправедливость",
-                    "изгнанный"
+                    "изгнанный",
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "возвращаться",
-                    "наказание",
                     "гнев",
+                    "наказание",
+                    "возвращаться",
                     "прощание"
                 ],
                 "correctIndex": 3
@@ -2526,22 +2526,22 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "возвращаться",
-                    "наказание",
+                    "изгнанный",
+                    "несправедливость",
                     "прощание",
-                    "изгнанный"
+                    "наказание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
+                    "изгнание",
                     "возвращаться",
                     "наказание",
-                    "прощание",
-                    "гнев"
+                    "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3037,82 +3037,82 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "переодевание",
-                    "неузнанный",
                     "притворяться",
-                    "хитрость"
+                    "переодевание",
+                    "хитрость",
+                    "неузнанный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "переодевание",
                     "притворяться",
-                    "неузнанный",
-                    "хитрость"
+                    "хитрость",
+                    "переодевание",
+                    "неузнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
-                    "верный",
-                    "изменять",
-                    "переодевание",
-                    "неузнанный"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «vorgeben»?",
-                "choices": [
-                    "притворяться",
-                    "переодевание",
-                    "хитрость",
-                    "изменять"
+                    "неузнанный",
+                    "наниматься",
+                    "борода",
+                    "притворяться"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verstellen»?",
+                "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
-                    "притворяться",
-                    "наниматься",
-                    "изменять",
-                    "неузнанный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Bart»?",
-                "choices": [
-                    "хитрость",
                     "верный",
-                    "изменять",
-                    "борода"
+                    "неузнанный",
+                    "хитрость",
+                    "притворяться"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verstellen»?",
+                "choices": [
+                    "хитрость",
+                    "притворяться",
+                    "переодевание",
+                    "изменять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Bart»?",
+                "choices": [
+                    "верный",
+                    "борода",
+                    "притворяться",
+                    "изменять"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
-                    "неузнанный",
+                    "переодевание",
                     "притворяться",
                     "наниматься",
-                    "хитрость"
+                    "неузнанный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "верный",
-                    "притворяться",
                     "хитрость",
+                    "неузнанный",
+                    "верный",
                     "борода"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3538,8 +3538,8 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
-                    "опасность",
                     "охранять",
+                    "опасность",
                     "защита",
                     "служба"
                 ],
@@ -3548,62 +3548,62 @@
             {
                 "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
-                    "опасность",
-                    "служба",
+                    "охранять",
                     "защита",
-                    "охранять"
+                    "служба",
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "сражаться",
                     "опасность",
-                    "стража",
-                    "служба"
+                    "защита",
+                    "сражаться",
+                    "стража"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
                     "охранять",
-                    "сражаться",
-                    "опасность",
-                    "советовать"
+                    "стража",
+                    "советовать",
+                    "опасность"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "сражаться",
-                    "опасность",
+                    "защита",
                     "стража",
-                    "служба"
+                    "охранять",
+                    "сражаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
                     "советовать",
-                    "защита",
-                    "охранять",
-                    "сражаться"
+                    "служба",
+                    "опасность",
+                    "охранять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
+                    "охранять",
+                    "служба",
                     "стража",
-                    "советовать",
-                    "сражаться",
                     "опасность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4072,50 +4072,50 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "сковывать",
+                    "унижение",
                     "наказание",
                     "стойкость",
-                    "унижение"
+                    "сковывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
-                    "стойкость",
-                    "наказание",
+                    "унижение",
                     "сковывать",
-                    "унижение"
+                    "наказание",
+                    "стойкость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
-                    "наказание",
                     "позор",
-                    "стойкость",
-                    "сковывать"
+                    "наказание",
+                    "колодка",
+                    "стойкость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
+                    "наказание",
                     "терпеть",
-                    "унижение",
                     "сковывать",
-                    "наказание"
+                    "выдерживать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
-                    "наказание",
+                    "позор",
                     "терпеть",
                     "унижение",
-                    "стойкость"
+                    "сковывать"
                 ],
                 "correctIndex": 1
             },
@@ -4123,29 +4123,29 @@
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
                     "позор",
-                    "терпеть",
                     "колодка",
-                    "сковывать"
+                    "сковывать",
+                    "выдерживать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
                     "терпеть",
                     "выдерживать",
-                    "наказание",
-                    "стойкость"
+                    "унижение",
+                    "позор"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
-                    "стойкость",
+                    "выдерживать",
                     "позор",
-                    "сковывать",
-                    "выдерживать"
+                    "терпеть",
+                    "стойкость"
                 ],
                 "correctIndex": 1
             }
@@ -4594,57 +4594,57 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "сопровождать",
-                    "буря",
+                    "утешать",
                     "поддержка",
-                    "утешать"
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
-                    "утешать",
                     "поддержка",
                     "сопровождать",
-                    "буря"
+                    "буря",
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "утешать",
                     "выдерживать",
+                    "убежище",
                     "сопровождать",
-                    "убежище"
+                    "утешать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "убежище",
+                    "выдерживать",
+                    "утешать",
                     "буря",
-                    "поддержка",
-                    "утешать"
+                    "поддержка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "утешать",
-                    "сопровождать",
-                    "холод",
-                    "убежище"
+                    "убежище",
+                    "буря",
+                    "поддержка",
+                    "холод"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "убежище",
-                    "поддержка",
+                    "утешать",
+                    "буря",
                     "выдерживать",
                     "сопровождать"
                 ],
@@ -4653,12 +4653,12 @@
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
+                    "поддержка",
                     "убежище",
-                    "буря",
-                    "утешать",
-                    "холод"
+                    "холод",
+                    "сопровождать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5157,82 +5157,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "прощание",
-                    "плакать",
+                    "смерть",
                     "вечный",
-                    "смерть"
+                    "прощание",
+                    "плакать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
                     "плакать",
-                    "смерть",
+                    "вечный",
                     "прощание",
-                    "вечный"
+                    "смерть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
+                    "следовать",
                     "истощение",
-                    "вечный",
-                    "смерть",
-                    "скорбь"
+                    "сдаваться",
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
+                    "сдаваться",
+                    "вечный",
                     "смерть",
-                    "плакать",
-                    "скорбь",
-                    "прощание"
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
+                    "плакать",
                     "смерть",
-                    "вечный",
                     "истощение",
-                    "плакать"
+                    "скорбь"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "скорбь",
-                    "сдаваться",
-                    "следовать",
-                    "плакать"
+                    "плакать",
+                    "истощение",
+                    "смерть",
+                    "сдаваться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "скорбь",
                     "следовать",
-                    "сдаваться",
-                    "смерть"
+                    "плакать",
+                    "прощание",
+                    "скорбь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
-                    "скорбь",
                     "следовать",
                     "вечный",
-                    "плакать"
+                    "плакать",
+                    "истощение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5337,6 +5337,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5621,36 +5822,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6163,6 +6350,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6186,97 +6377,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7194,6 +7351,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "королевство", "править", "трон"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "трон", "править", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["великолепный", "править", "власть", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["корона", "королевство", "править", "великолепный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["провозглашать", "корона", "трон", "великолепный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["королевство", "власть", "корона", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "власть", "провозглашать", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["церемония", "корона", "великолепный", "королевство"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["проклинать", "гнев", "неблагодарность", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "унижать", "гнев", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["сожалеть", "неблагодарность", "проклинать", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "унижать", "сожалеть", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["проклятие", "изгонять", "проклинать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["сожалеть", "обида", "гнев", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["обида", "сожалеть", "изгонять", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "неблагодарность", "сожалеть", "изгонять"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "покидать", "отчаяние", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "покидать", "жестокость", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "слеза", "отвергать", "одиночество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["просить", "слеза", "покидать", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["отвергать", "нужда", "жестокость", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["просить", "слеза", "одиночество", "нужда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["нужда", "слеза", "просить", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["просить", "покидать", "нужда", "отвергать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "буря", "безумие", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["гром", "безумие", "бушевать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["бушевать", "буря", "кричать", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["голый", "хаос", "безумие", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["бушевать", "буря", "молния", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["гром", "бушевать", "кричать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["молния", "бушевать", "голый", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["голый", "кричать", "хаос", "безумие"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "мёрзнуть", "бедный", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "бедный", "мёрзнуть", "нищета"], "correct_index": 0}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "шут", "нищета", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["бедный", "хижина", "мёрзнуть", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["страдать", "нищий", "хижина", "познание"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "хижина", "нищета", "шут"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["познание", "хижина", "нищета", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["познание", "бедный", "нищий", "страдать"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["понимать", "раскаяние", "узнавать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["понимать", "раскаяние", "узнавать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["раскаяние", "виновный", "понимать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "узнавать", "понимать", "виновный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["понимать", "узнавать", "прозрение", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["виновный", "понимать", "правда", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["понимать", "мудрость", "правда", "прозрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["прозрение", "раскаяние", "понимать", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "конец", "смерть", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["прощать", "умирать", "конец", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "умирать", "прощать", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "прощание", "прощать", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "сердце", "конец", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "скорбь", "вечный", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["скорбь", "умирать", "прощать", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["смерть", "прощать", "прощание", "вечный"], "correct_index": 3}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["королевство", "править", "власть", "трон"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "королевство", "трон", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "церемония", "корона", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["королевство", "править", "трон", "великолепный"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["власть", "королевство", "провозглашать", "корона"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["корона", "королевство", "править", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "королевство", "трон", "корона"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["королевство", "власть", "провозглашать", "великолепный"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "гнев", "неблагодарность", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["проклинать", "гнев", "неблагодарность", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["унижать", "неблагодарность", "гнев", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["гнев", "проклинать", "проклятие", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["обида", "проклинать", "неблагодарность", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["неблагодарность", "обида", "унижать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "унижать", "обида", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["гнев", "проклятие", "изгонять", "неблагодарность"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["жестокость", "отчаяние", "отвергать", "покидать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["жестокость", "отчаяние", "отвергать", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["слеза", "жестокость", "одиночество", "нужда"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "покидать", "слеза", "просить"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["одиночество", "жестокость", "просить", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["жестокость", "отчаяние", "нужда", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["слеза", "одиночество", "жестокость", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "жестокость", "одиночество", "просить"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["гром", "бушевать", "буря", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["безумие", "бушевать", "кричать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["безумие", "гром", "хаос", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["голый", "молния", "бушевать", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["гром", "голый", "кричать", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["голый", "хаос", "бушевать", "молния"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "буря", "гром", "голый"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["бедный", "нищета", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "бедный", "нищий", "нищета"], "correct_index": 2}, {"question": "Что означает немецкое слово «arm»?", "choices": ["познание", "страдать", "нищий", "бедный"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "страдать", "шут", "познание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["нищета", "хижина", "познание", "бедный"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["нищий", "страдать", "бедный", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["хижина", "нищета", "страдать", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["хижина", "бедный", "нищета", "познание"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["правда", "раскаяние", "узнавать", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["раскаяние", "узнавать", "понимать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["прощать", "правда", "раскаяние", "прозрение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "мудрость", "раскаяние", "прозрение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["понимать", "прощать", "прозрение", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "прозрение", "прощать", "понимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["раскаяние", "прозрение", "правда", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["мудрость", "виновный", "понимать", "узнавать"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "смерть", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "умирать", "конец", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "прощать", "умирать", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "вечный", "сердце", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "скорбь", "конец", "сердце"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощание", "скорбь", "умирать", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "скорбь", "конец", "сердце"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["смерть", "умирать", "прощание", "вечный"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -666,11 +666,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
                             
@@ -678,61 +678,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
@@ -742,17 +726,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -764,27 +764,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,8 +797,24 @@
             <div class="quiz-phase-container" data-phase="goneril">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
@@ -813,47 +829,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
@@ -861,17 +861,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -881,45 +881,45 @@
                         <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">обида</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -932,93 +932,45 @@
             <div class="quiz-phase-container" data-phase="regan">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                             
@@ -1028,33 +980,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1067,17 +1067,17 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1087,43 +1087,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «toben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
                             
@@ -1131,15 +1099,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «toben»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                             
@@ -1153,43 +1153,43 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1202,15 +1202,15 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                             
@@ -1218,15 +1218,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
                             
@@ -1234,47 +1234,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «arm»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
                             
@@ -1282,15 +1266,31 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
@@ -1302,11 +1302,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                             
@@ -1314,17 +1314,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1341,52 +1341,20 @@
                         <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
@@ -1395,7 +1363,39 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1407,7 +1407,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
                             
@@ -1417,13 +1417,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                             
@@ -1433,33 +1449,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1472,15 +1472,31 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                             
@@ -1488,33 +1504,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1524,11 +1524,11 @@
                         <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                             
@@ -1536,17 +1536,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1556,29 +1556,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1590,7 +1590,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                             
@@ -2053,9 +2053,9 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "власть",
                     "королевство",
                     "править",
+                    "власть",
                     "трон"
                 ],
                 "correctIndex": 3
@@ -2064,71 +2064,71 @@
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
                     "власть",
+                    "королевство",
                     "трон",
-                    "править",
-                    "королевство"
+                    "править"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "великолепный",
                     "править",
-                    "власть",
-                    "провозглашать"
+                    "церемония",
+                    "корона",
+                    "власть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "корона",
                     "королевство",
                     "править",
+                    "трон",
                     "великолепный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
+                    "власть",
+                    "королевство",
                     "провозглашать",
-                    "корона",
-                    "трон",
-                    "великолепный"
+                    "корона"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
-                    "королевство",
-                    "власть",
                     "корона",
-                    "провозглашать"
+                    "королевство",
+                    "править",
+                    "церемония"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
                     "церемония",
-                    "власть",
-                    "провозглашать",
-                    "трон"
+                    "королевство",
+                    "трон",
+                    "корона"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
-                    "церемония",
-                    "корона",
-                    "великолепный",
-                    "королевство"
+                    "королевство",
+                    "власть",
+                    "провозглашать",
+                    "великолепный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2671,82 +2671,82 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "проклинать",
+                    "унижать",
                     "гнев",
                     "неблагодарность",
-                    "унижать"
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "неблагодарность",
-                    "унижать",
+                    "проклинать",
                     "гнев",
-                    "проклинать"
+                    "неблагодарность",
+                    "унижать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
-                    "сожалеть",
+                    "унижать",
                     "неблагодарность",
-                    "проклинать",
-                    "унижать"
+                    "гнев",
+                    "сожалеть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
+                    "гнев",
                     "проклинать",
-                    "унижать",
-                    "сожалеть",
-                    "изгонять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
                     "проклятие",
-                    "изгонять",
-                    "проклинать",
-                    "неблагодарность"
+                    "изгонять"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «vertreiben»?",
+                "choices": [
+                    "обида",
+                    "проклинать",
+                    "неблагодарность",
+                    "изгонять"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "сожалеть",
+                    "неблагодарность",
                     "обида",
-                    "гнев",
-                    "неблагодарность"
+                    "унижать",
+                    "изгонять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "обида",
                     "сожалеть",
-                    "изгонять",
-                    "унижать"
+                    "унижать",
+                    "обида",
+                    "проклинать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
+                    "гнев",
                     "проклятие",
-                    "неблагодарность",
-                    "сожалеть",
-                    "изгонять"
+                    "изгонять",
+                    "неблагодарность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3301,81 +3301,81 @@
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
                     "жестокость",
-                    "покидать",
                     "отчаяние",
-                    "отвергать"
+                    "отвергать",
+                    "покидать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "отчаяние",
-                    "покидать",
                     "жестокость",
-                    "отвергать"
+                    "отчаяние",
+                    "отвергать",
+                    "покидать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
+                    "слеза",
                     "жестокость",
-                    "слеза",
-                    "отвергать",
-                    "одиночество"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "просить",
-                    "слеза",
-                    "покидать",
-                    "отчаяние"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «betteln»?",
-                "choices": [
-                    "отвергать",
-                    "нужда",
-                    "жестокость",
-                    "просить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Einsamkeit»?",
-                "choices": [
-                    "просить",
-                    "слеза",
                     "одиночество",
                     "нужда"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Träne»?",
-                "choices": [
-                    "нужда",
-                    "слеза",
-                    "просить",
-                    "жестокость"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Not»?",
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "просить",
+                    "отчаяние",
                     "покидать",
-                    "нужда",
-                    "отвергать"
+                    "слеза",
+                    "просить"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «betteln»?",
+                "choices": [
+                    "одиночество",
+                    "жестокость",
+                    "просить",
+                    "отчаяние"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Einsamkeit»?",
+                "choices": [
+                    "жестокость",
+                    "отчаяние",
+                    "нужда",
+                    "одиночество"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Träne»?",
+                "choices": [
+                    "слеза",
+                    "одиночество",
+                    "жестокость",
+                    "отвергать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Not»?",
+                "choices": [
+                    "нужда",
+                    "жестокость",
+                    "одиночество",
+                    "просить"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3916,82 +3916,82 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
+                    "гром",
                     "бушевать",
                     "буря",
-                    "безумие",
-                    "гром"
+                    "безумие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "гром",
+                    "буря",
                     "безумие",
                     "бушевать",
-                    "буря"
+                    "гром"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
+                    "безумие",
                     "бушевать",
-                    "буря",
                     "кричать",
-                    "голый"
+                    "буря"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "голый",
-                    "хаос",
                     "безумие",
-                    "гром"
+                    "гром",
+                    "хаос",
+                    "голый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "бушевать",
-                    "буря",
+                    "голый",
                     "молния",
+                    "бушевать",
                     "кричать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
                     "гром",
-                    "бушевать",
+                    "голый",
                     "кричать",
-                    "безумие"
+                    "бушевать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "молния",
-                    "бушевать",
                     "голый",
-                    "безумие"
+                    "хаос",
+                    "бушевать",
+                    "молния"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
-                    "голый",
-                    "кричать",
                     "хаос",
-                    "безумие"
+                    "буря",
+                    "гром",
+                    "голый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4549,69 +4549,69 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
+                    "бедный",
                     "нищета",
                     "мёрзнуть",
-                    "бедный",
                     "нищий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "нищий",
-                    "бедный",
                     "мёрзнуть",
+                    "бедный",
+                    "нищий",
                     "нищета"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «arm»?",
                 "choices": [
-                    "бедный",
-                    "шут",
-                    "нищета",
-                    "нищий"
+                    "познание",
+                    "страдать",
+                    "нищий",
+                    "бедный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "бедный",
-                    "хижина",
                     "мёрзнуть",
-                    "страдать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Hütte»?",
-                "choices": [
                     "страдать",
-                    "нищий",
-                    "хижина",
+                    "шут",
                     "познание"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "страдать",
-                    "хижина",
-                    "нищета",
-                    "шут"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Hütte»?",
+                "choices": [
+                    "нищета",
+                    "хижина",
+                    "познание",
+                    "бедный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "нищий",
+                    "страдать",
+                    "бедный",
+                    "шут"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "познание",
                     "хижина",
                     "нищета",
+                    "страдать",
                     "шут"
                 ],
                 "correctIndex": 3
@@ -4619,12 +4619,12 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "познание",
+                    "хижина",
                     "бедный",
-                    "нищий",
-                    "страдать"
+                    "нищета",
+                    "познание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5172,48 +5172,48 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "понимать",
+                    "правда",
                     "раскаяние",
                     "узнавать",
-                    "правда"
+                    "понимать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
-                    "понимать",
                     "раскаяние",
                     "узнавать",
+                    "понимать",
                     "правда"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "прощать",
+                    "правда",
                     "раскаяние",
-                    "виновный",
-                    "понимать",
-                    "правда"
+                    "прозрение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "раскаяние",
                     "узнавать",
-                    "понимать",
-                    "виновный"
+                    "мудрость",
+                    "раскаяние",
+                    "прозрение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "понимать",
-                    "узнавать",
+                    "прощать",
                     "прозрение",
                     "мудрость"
                 ],
@@ -5222,32 +5222,32 @@
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "виновный",
-                    "понимать",
-                    "правда",
-                    "прощать"
+                    "узнавать",
+                    "прозрение",
+                    "прощать",
+                    "понимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Einsicht»?",
                 "choices": [
-                    "понимать",
-                    "мудрость",
+                    "раскаяние",
+                    "прозрение",
                     "правда",
-                    "прозрение"
+                    "прощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
-                    "прозрение",
-                    "раскаяние",
+                    "мудрость",
+                    "виновный",
                     "понимать",
-                    "виновный"
+                    "узнавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5813,39 +5813,39 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "умирать",
-                    "конец",
+                    "прощать",
                     "смерть",
-                    "прощать"
+                    "конец",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "прощать",
+                    "смерть",
                     "умирать",
                     "конец",
-                    "смерть"
+                    "прощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "смерть",
-                    "умирать",
+                    "конец",
                     "прощать",
-                    "сердце"
+                    "умирать",
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "умирать",
-                    "прощание",
-                    "прощать",
+                    "скорбь",
+                    "вечный",
+                    "сердце",
                     "конец"
                 ],
                 "correctIndex": 3
@@ -5854,37 +5854,37 @@
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
                     "прощать",
-                    "сердце",
+                    "скорбь",
                     "конец",
-                    "вечный"
+                    "сердце"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "конец",
+                    "прощание",
                     "скорбь",
-                    "вечный",
-                    "умирать"
+                    "умирать",
+                    "сердце"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
+                    "прощание",
                     "скорбь",
-                    "умирать",
-                    "прощать",
-                    "прощание"
+                    "конец",
+                    "сердце"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "смерть",
-                    "прощать",
+                    "умирать",
                     "прощание",
                     "вечный"
                 ],
@@ -6009,6 +6009,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6293,36 +6494,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6835,6 +7022,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6858,97 +7049,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7866,6 +8023,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["служить", "преданность", "слуга", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["преданность", "послушание", "слуга", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["преданность", "покорный", "слуга", "исполнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["управляющий", "преданность", "раболепный", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["преданность", "управляющий", "слуга", "исполнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["покорный", "управляющий", "слуга", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["раболепный", "служить", "преданность", "послушание"], "correct_index": 0}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["раболепный", "преданность", "исполнять", "управляющий"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["поручение", "спешка", "гонец", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["спешка", "поручение", "гонец", "передавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["гонец", "поручение", "торопиться", "спешка"], "correct_index": 3}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["послание", "торопиться", "спешить", "передавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["гонец", "спешить", "спешка", "торопиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["передавать", "спешить", "спешка", "послание"], "correct_index": 3}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["послание", "передавать", "поручение", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорбление", "трусость", "оскорблять", "неуважение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорбление", "оскорблять", "неуважение", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["пренебрегать", "трусость", "дерзкий", "трусливый"], "correct_index": 1}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["оскорбление", "пренебрегать", "дерзкий", "оскорблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["неуважение", "трусость", "оскорблять", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["оскорбление", "дерзкий", "оскорблять", "высмеивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["оскорбление", "оскорблять", "пренебрегать", "дерзкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «feige»?", "choices": ["высмеивать", "трусливый", "оскорблять", "дерзкий"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпион", "скрытность", "шпионить", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпион", "скрытность", "предательство", "шпионить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["предательство", "вынюхивать", "подслушивать", "скрытность"], "correct_index": 3}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "подслушивать", "скрытность", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["вынюхивать", "скрытность", "шпионить", "подслушивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["скрытность", "шпион", "выдавать", "подслушивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["шпион", "вынюхивать", "предательство", "подслушивать"], "correct_index": 1}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["коварство", "интрига", "ковать", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "коварство", "интрига", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["интрига", "коварство", "план", "коварный"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварство", "ковать", "интрига", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["хитрый", "интрига", "обманывать", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["обманывать", "хитрый", "коварный", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["коварство", "хитрый", "обманывать", "ловушка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["ловушка", "коварство", "интрига", "обманывать"], "correct_index": 0}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["гнаться", "охота", "преследование", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследовать", "охота", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["гнаться", "охота", "преследовать", "выслеживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["охота", "гнаться", "травить", "выслеживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["выслеживать", "охота", "травить", "преследование"], "correct_index": 0}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["травить", "преследовать", "добыча", "преследование"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["добыча", "преследовать", "выслеживать", "гнаться"], "correct_index": 0}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "поражение", "трусость", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["смерть", "падать", "трусость", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["жалкий", "падать", "поражение", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["хныкать", "падать", "умолять", "жалкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["поражение", "трусость", "падать", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["умолять", "падать", "поражение", "хныкать"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["падать", "поражение", "трусость", "умолять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["жалкий", "хныкать", "трусость", "проигрывать"], "correct_index": 0}]}'>
+        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "послушание", "служить", "преданность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "служить", "слуга", "преданность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["покорный", "управляющий", "слуга", "преданность"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["исполнять", "служить", "слуга", "послушание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["исполнять", "управляющий", "раболепный", "слуга"], "correct_index": 1}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["исполнять", "покорный", "служить", "управляющий"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["исполнять", "раболепный", "управляющий", "покорный"], "correct_index": 1}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["раболепный", "послушание", "исполнять", "слуга"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["спешка", "поручение", "передавать", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "поручение", "спешка", "передавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешка", "торопиться", "гонец", "спешить"], "correct_index": 0}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "спешить", "поручение", "послание"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["торопиться", "гонец", "спешить", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "торопиться", "спешить", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["спешить", "поручение", "послание", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорбление", "трусость", "неуважение", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["трусость", "оскорбление", "оскорблять", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["дерзкий", "оскорбление", "трусость", "оскорблять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["оскорблять", "трусость", "оскорбление", "дерзкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["трусость", "дерзкий", "оскорблять", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["высмеивать", "оскорблять", "неуважение", "дерзкий"], "correct_index": 3}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["дерзкий", "неуважение", "пренебрегать", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «feige»?", "choices": ["пренебрегать", "трусливый", "высмеивать", "дерзкий"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "шпион", "скрытность", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпион", "скрытность", "шпионить", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпионить", "выдавать", "вынюхивать", "скрытность"], "correct_index": 3}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["шпионить", "вынюхивать", "предательство", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["скрытность", "выдавать", "подслушивать", "шпионить"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["шпионить", "выдавать", "предательство", "скрытность"], "correct_index": 1}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "шпион", "подслушивать", "предательство"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["план", "интрига", "ковать", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "интрига", "план", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["ковать", "коварство", "коварный", "ловушка"], "correct_index": 1}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["хитрый", "обманывать", "ловушка", "ковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["интрига", "обманывать", "план", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["хитрый", "ловушка", "план", "коварный"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["коварный", "хитрый", "ловушка", "ковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["обманывать", "ковать", "ловушка", "план"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["гнаться", "преследовать", "охота", "преследование"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследование", "гнаться", "преследовать", "охота"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["выслеживать", "преследовать", "гнаться", "охота"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["выслеживать", "преследовать", "гнаться", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["выслеживать", "охота", "преследование", "травить"], "correct_index": 0}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "травить", "охота", "преследование"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["преследовать", "гнаться", "выслеживать", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["трусость", "падать", "смерть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "поражение", "смерть", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["смерть", "умолять", "падать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "поражение", "жалкий", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["поражение", "умолять", "проигрывать", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["жалкий", "поражение", "хныкать", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["падать", "умолять", "поражение", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["проигрывать", "умолять", "жалкий", "трусость"], "correct_index": 2}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,65 +662,65 @@
             <div class="quiz-phase-container active" data-phase="steward">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -730,45 +730,45 @@
                         <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">покорный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -780,11 +780,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -797,17 +797,17 @@
             <div class="quiz-phase-container" data-phase="messenger">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -817,11 +817,11 @@
                         <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
                             
@@ -829,29 +829,45 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">спешить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
@@ -861,33 +877,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -897,11 +897,11 @@
                         <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поручение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
                             
@@ -924,6 +924,22 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
+                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                            
                             <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
@@ -932,49 +948,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -984,23 +984,7 @@
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
                             
@@ -1012,17 +996,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">неуважение</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1032,11 +1032,11 @@
                         <div class="quiz-question">Что означает немецкое слово «feige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">высмеивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">дерзкий</button>
                             
@@ -1051,8 +1051,24 @@
             <div class="quiz-phase-container" data-phase="spy">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
@@ -1067,31 +1083,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
                             
@@ -1105,59 +1105,59 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
                             <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1174,29 +1174,29 @@
                         <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1206,9 +1206,57 @@
                         <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">план</button>
                             
@@ -1218,81 +1266,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
                     <div class="quiz-card" data-question-index="6" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1305,24 +1305,8 @@
             <div class="quiz-phase-container" data-phase="pursuer">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
@@ -1337,33 +1321,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1377,23 +1377,23 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
                             
@@ -1401,17 +1401,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,31 +1424,15 @@
             <div class="quiz-phase-container" data-phase="coward_death">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
@@ -1456,97 +1440,113 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жалкий</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1951,80 +1951,80 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "служить",
-                    "преданность",
                     "слуга",
-                    "послушание"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Gehorsam»?",
-                "choices": [
-                    "преданность",
                     "послушание",
-                    "слуга",
-                    "служить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Ergebenheit»?",
-                "choices": [
-                    "преданность",
-                    "покорный",
-                    "слуга",
-                    "исполнять"
+                    "служить",
+                    "преданность"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «dienen»?",
+                "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
+                    "послушание",
+                    "служить",
+                    "слуга",
+                    "преданность"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Ergebenheit»?",
+                "choices": [
+                    "покорный",
                     "управляющий",
-                    "преданность",
-                    "раболепный",
-                    "служить"
+                    "слуга",
+                    "преданность"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «dienen»?",
+                "choices": [
+                    "исполнять",
+                    "служить",
+                    "слуга",
+                    "послушание"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "преданность",
+                    "исполнять",
                     "управляющий",
-                    "слуга",
-                    "исполнять"
+                    "раболепный",
+                    "слуга"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
+                    "исполнять",
                     "покорный",
-                    "управляющий",
-                    "слуга",
-                    "служить"
+                    "служить",
+                    "управляющий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
+                    "исполнять",
                     "раболепный",
-                    "служить",
-                    "преданность",
-                    "послушание"
+                    "управляющий",
+                    "покорный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
                     "раболепный",
-                    "преданность",
+                    "послушание",
                     "исполнять",
-                    "управляющий"
+                    "слуга"
                 ],
                 "correctIndex": 2
             }
@@ -2452,19 +2452,19 @@
             {
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
-                    "поручение",
                     "спешка",
-                    "гонец",
-                    "передавать"
+                    "поручение",
+                    "передавать",
+                    "гонец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
-                    "спешка",
-                    "поручение",
                     "гонец",
+                    "поручение",
+                    "спешка",
                     "передавать"
                 ],
                 "correctIndex": 1
@@ -2472,49 +2472,49 @@
             {
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "гонец",
-                    "поручение",
+                    "спешка",
                     "торопиться",
-                    "спешка"
+                    "гонец",
+                    "спешить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
-                    "послание",
-                    "торопиться",
+                    "передавать",
                     "спешить",
-                    "передавать"
+                    "поручение",
+                    "послание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
+                    "торопиться",
                     "гонец",
                     "спешить",
-                    "спешка",
-                    "торопиться"
+                    "передавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
-                    "передавать",
+                    "послание",
+                    "торопиться",
                     "спешить",
-                    "спешка",
-                    "послание"
+                    "гонец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "послание",
-                    "передавать",
+                    "спешить",
                     "поручение",
+                    "послание",
                     "торопиться"
                 ],
                 "correctIndex": 3
@@ -2994,46 +2994,46 @@
                 "choices": [
                     "оскорбление",
                     "трусость",
-                    "оскорблять",
-                    "неуважение"
+                    "неуважение",
+                    "оскорблять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
+                    "трусость",
                     "оскорбление",
                     "оскорблять",
-                    "неуважение",
-                    "трусость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Feigheit»?",
-                "choices": [
-                    "пренебрегать",
-                    "трусость",
-                    "дерзкий",
-                    "трусливый"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «beleidigen»?",
-                "choices": [
-                    "оскорбление",
-                    "пренебрегать",
-                    "дерзкий",
-                    "оскорблять"
+                    "неуважение"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Feigheit»?",
+                "choices": [
+                    "дерзкий",
+                    "оскорбление",
+                    "трусость",
+                    "оскорблять"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «beleidigen»?",
+                "choices": [
+                    "оскорблять",
+                    "трусость",
+                    "оскорбление",
+                    "дерзкий"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "неуважение",
                     "трусость",
+                    "дерзкий",
                     "оскорблять",
                     "высмеивать"
                 ],
@@ -3042,29 +3042,29 @@
             {
                 "question": "Что означает немецкое слово «frech»?",
                 "choices": [
-                    "оскорбление",
-                    "дерзкий",
+                    "высмеивать",
                     "оскорблять",
-                    "высмеивать"
+                    "неуважение",
+                    "дерзкий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "оскорбление",
-                    "оскорблять",
+                    "дерзкий",
+                    "неуважение",
                     "пренебрегать",
-                    "дерзкий"
+                    "трусость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "высмеивать",
+                    "пренебрегать",
                     "трусливый",
-                    "оскорблять",
+                    "высмеивать",
                     "дерзкий"
                 ],
                 "correctIndex": 1
@@ -3498,29 +3498,29 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
+                    "шпионить",
                     "шпион",
                     "скрытность",
-                    "шпионить",
                     "предательство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
                     "шпион",
                     "скрытность",
-                    "предательство",
-                    "шпионить"
+                    "шпионить",
+                    "предательство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "предательство",
+                    "шпионить",
+                    "выдавать",
                     "вынюхивать",
-                    "подслушивать",
                     "скрытность"
                 ],
                 "correctIndex": 3
@@ -3529,41 +3529,41 @@
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
                     "шпионить",
-                    "подслушивать",
-                    "скрытность",
-                    "предательство"
+                    "вынюхивать",
+                    "предательство",
+                    "скрытность"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
-                    "вынюхивать",
                     "скрытность",
-                    "шпионить",
-                    "подслушивать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verraten»?",
-                "choices": [
-                    "скрытность",
-                    "шпион",
                     "выдавать",
-                    "подслушивать"
+                    "подслушивать",
+                    "шпионить"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «schnüffeln»?",
+                "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "шпион",
-                    "вынюхивать",
+                    "шпионить",
+                    "выдавать",
                     "предательство",
-                    "подслушивать"
+                    "скрытность"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «schnüffeln»?",
+                "choices": [
+                    "вынюхивать",
+                    "шпион",
+                    "подслушивать",
+                    "предательство"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4050,10 +4050,10 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "коварство",
+                    "план",
                     "интрига",
                     "ковать",
-                    "план"
+                    "коварство"
                 ],
                 "correctIndex": 1
             },
@@ -4061,71 +4061,71 @@
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
                     "ковать",
-                    "коварство",
                     "интрига",
-                    "план"
+                    "план",
+                    "коварство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "интрига",
+                    "ковать",
                     "коварство",
-                    "план",
-                    "коварный"
+                    "коварный",
+                    "ловушка"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "коварство",
-                    "ковать",
-                    "интрига",
-                    "план"
+                    "хитрый",
+                    "обманывать",
+                    "ловушка",
+                    "ковать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
-                    "хитрый",
                     "интрига",
                     "обманывать",
-                    "план"
+                    "план",
+                    "коварство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "обманывать",
                     "хитрый",
-                    "коварный",
-                    "коварство"
+                    "ловушка",
+                    "план",
+                    "коварный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
-                    "коварство",
+                    "коварный",
                     "хитрый",
-                    "обманывать",
-                    "ловушка"
+                    "ловушка",
+                    "ковать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
+                    "обманывать",
+                    "ковать",
                     "ловушка",
-                    "коварство",
-                    "интрига",
-                    "обманывать"
+                    "план"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4562,71 +4562,71 @@
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
                     "гнаться",
-                    "охота",
-                    "преследование",
-                    "преследовать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Jagd»?",
-                "choices": [
-                    "гнаться",
                     "преследовать",
                     "охота",
                     "преследование"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Jagd»?",
+                "choices": [
+                    "преследование",
+                    "гнаться",
+                    "преследовать",
+                    "охота"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
-                    "гнаться",
-                    "охота",
+                    "выслеживать",
                     "преследовать",
-                    "выслеживать"
+                    "гнаться",
+                    "охота"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "охота",
+                    "выслеживать",
+                    "преследовать",
                     "гнаться",
-                    "травить",
-                    "выслеживать"
+                    "охота"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
                     "выслеживать",
                     "охота",
-                    "травить",
-                    "преследование"
+                    "преследование",
+                    "травить"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
+                    "гнаться",
                     "травить",
-                    "преследовать",
-                    "добыча",
+                    "охота",
                     "преследование"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "добыча",
                     "преследовать",
+                    "гнаться",
                     "выслеживать",
-                    "гнаться"
+                    "добыча"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5112,82 +5112,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "падать",
-                    "поражение",
                     "трусость",
-                    "смерть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Feigheit»?",
-                "choices": [
+                    "падать",
                     "смерть",
-                    "падать",
-                    "трусость",
                     "поражение"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Feigheit»?",
+                "choices": [
+                    "трусость",
+                    "поражение",
+                    "смерть",
+                    "падать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "жалкий",
+                    "смерть",
+                    "умолять",
                     "падать",
-                    "поражение",
-                    "проигрывать"
+                    "поражение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "хныкать",
                     "падать",
-                    "умолять",
-                    "жалкий"
+                    "поражение",
+                    "жалкий",
+                    "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
                     "поражение",
-                    "трусость",
-                    "падать",
-                    "проигрывать"
+                    "умолять",
+                    "проигрывать",
+                    "трусость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «wimmern»?",
                 "choices": [
-                    "умолять",
-                    "падать",
+                    "жалкий",
                     "поражение",
-                    "хныкать"
+                    "хныкать",
+                    "проигрывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
                     "падать",
+                    "умолять",
                     "поражение",
-                    "трусость",
-                    "умолять"
+                    "проигрывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erbärmlich»?",
                 "choices": [
+                    "проигрывать",
+                    "умолять",
                     "жалкий",
-                    "хныкать",
-                    "трусость",
-                    "проигрывать"
+                    "трусость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5292,6 +5292,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5576,36 +5777,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6118,6 +6305,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6141,97 +6332,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7149,6 +7306,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -643,7 +643,7 @@
         </div>
 
         
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["фальшь", "превосходить", "состязаться", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "фальшь", "превосходить", "состязаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["фальшь", "состязаться", "хитрость", "выманивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["выманивать", "состязаться", "фальшь", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["состязаться", "разыгрывать", "хитрость", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["алчность", "хитрость", "разыгрывать", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["фальшь", "состязаться", "разыгрывать", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["состязаться", "алчность", "превосходить", "фальшь"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["заговорить", "планировать", "союз", "делить"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["делить", "планировать", "союз", "заговорить"], "correct_index": 0}, {"question": "Что означает немецкое слово «planen»?", "choices": ["планировать", "договариваться", "союз", "делить"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["стратегия", "заговорить", "планировать", "сговор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["заговорить", "делить", "сговор", "договариваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "планировать", "сговор", "стратегия"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["стратегия", "договариваться", "делить", "союз"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "унижать", "насмехаться", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["пытать", "унижать", "злоба", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жестокость", "унижать", "насмехаться", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["насмехаться", "злоба", "пытать", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестоко обращаться", "унижать", "отвергать", "пытать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жёсткость", "отвергать", "пытать", "злоба"], "correct_index": 0}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["пытать", "отвергать", "жестоко обращаться", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "насмехаться", "отвергать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "выкалывать", "наслаждаться", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["садизм", "наслаждаться", "ослеплять", "выкалывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["брутальность", "выкалывать", "наслаждаться", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["выкалывать", "ослеплять", "растаптывать", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "садизм", "выкалывать", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["выкалывать", "садизм", "беспощадный", "растаптывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "беспощадный", "пытка", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["брутальность", "растаптывать", "садизм", "ослеплять"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вдова", "вожделение", "соблазнять", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вдова", "вожделение", "соблазнять", "вожделеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["похоть", "вожделение", "соблазнять", "добиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["добиваться", "вдова", "соблазнять", "вожделение"], "correct_index": 3}, {"question": "Что означает немецкое слово «locken»?", "choices": ["похоть", "вожделеть", "вдова", "заманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["заманивать", "вдова", "соблазнять", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «werben»?", "choices": ["соблазнять", "заманивать", "вожделение", "добиваться"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "ненавидеть", "угрожать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "ненавидеть", "соревноваться", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["не доверять", "ненавидеть", "угрожать", "подозревать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["бороться", "соперничество", "подозревать", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["бороться", "угрожать", "не доверять", "соревноваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["бороться", "соперничество", "ненавидеть", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["бороться", "подозревать", "ненавидеть", "угрожать"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["отравленный", "мучение", "издыхать", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "издыхать", "страдать", "отравленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["расплачиваться", "издыхать", "мучение", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мучение", "издыхать", "отравленный", "рок"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклинать", "издыхать", "проклятый", "отравленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["рок", "проклятый", "издыхать", "расплачиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["проклинать", "мучение", "расплачиваться", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклинать", "проклятый", "расплачиваться", "издыхать"], "correct_index": 1}]}'>
+        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["притворяться", "фальшь", "состязаться", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["превосходить", "фальшь", "притворяться", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "превосходить", "притворяться", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["фальшь", "хитрость", "состязаться", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["фальшь", "выманивать", "хитрость", "разыгрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["разыгрывать", "притворяться", "превосходить", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "разыгрывать", "притворяться", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["разыгрывать", "превосходить", "выманивать", "алчность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["делить", "планировать", "союз", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["планировать", "делить", "заговорить", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «planen»?", "choices": ["заговорить", "делить", "планировать", "сговор"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["планировать", "союз", "заговорить", "договариваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["союз", "делить", "стратегия", "сговор"], "correct_index": 3}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["союз", "сговор", "договариваться", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["сговор", "заговорить", "делить", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "унижать", "злоба", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "злоба", "пытать", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["насмехаться", "отвергать", "жестоко обращаться", "жёсткость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жестоко обращаться", "жестокость", "отвергать", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["отвергать", "жёсткость", "жестоко обращаться", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестоко обращаться", "жёсткость", "пытать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["отвергать", "жёсткость", "жестокость", "злоба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "жестоко обращаться", "насмехаться", "пытать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["наслаждаться", "садизм", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["наслаждаться", "ослеплять", "выкалывать", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["беспощадный", "садизм", "наслаждаться", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["выкалывать", "беспощадный", "брутальность", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "наслаждаться", "выкалывать", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["растаптывать", "брутальность", "беспощадный", "наслаждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["пытка", "наслаждаться", "брутальность", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["растаптывать", "наслаждаться", "выкалывать", "садизм"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["соблазнять", "вожделеть", "вдова", "вожделение"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделеть", "соблазнять", "вдова", "вожделение"], "correct_index": 0}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["вожделеть", "заманивать", "соблазнять", "вдова"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["заманивать", "соблазнять", "вожделение", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «locken»?", "choices": ["похоть", "добиваться", "вожделеть", "заманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["заманивать", "соблазнять", "вожделеть", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «werben»?", "choices": ["вожделеть", "заманивать", "вдова", "добиваться"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["угрожать", "соревноваться", "ненавидеть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "угрожать", "соревноваться", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "ненавидеть", "угрожать", "подозревать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["угрожать", "не доверять", "соперничество", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["бороться", "соревноваться", "ненавидеть", "не доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["не доверять", "бороться", "соперничество", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["соревноваться", "ненавидеть", "подозревать", "не доверять"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "страдать", "издыхать", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "отравленный", "издыхать", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["страдать", "проклинать", "издыхать", "проклятый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["издыхать", "страдать", "мучение", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["страдать", "мучение", "проклинать", "рок"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["проклинать", "мучение", "рок", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["расплачиваться", "мучение", "издыхать", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклинать", "издыхать", "рок", "проклятый"], "correct_index": 3}]}'>
             <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                 <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                 <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -662,63 +662,15 @@
             <div class="quiz-phase-container active" data-phase="throne">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
                             
@@ -726,33 +678,81 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -762,11 +762,11 @@
                         <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
                             
@@ -774,17 +774,17 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -801,22 +801,6 @@
                         <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
-                        <div class="quiz-choices">
-                            
                             <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
@@ -829,29 +813,29 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
+                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                        <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                             
@@ -861,15 +845,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
                             
@@ -877,33 +861,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -920,11 +920,11 @@
                         <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
@@ -932,15 +932,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                             
@@ -948,61 +948,61 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                             
@@ -1012,15 +1012,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                             
@@ -1034,11 +1034,11 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1051,29 +1051,13 @@
             <div class="quiz-phase-container" data-phase="storm">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                             
@@ -1083,17 +1067,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
                     <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1105,27 +1105,27 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1135,45 +1135,45 @@
                         <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальность</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1186,33 +1186,33 @@
             <div class="quiz-phase-container" data-phase="hut">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1222,29 +1222,29 @@
                         <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1256,9 +1256,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
                             
@@ -1272,9 +1272,9 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
                             
@@ -1286,11 +1286,11 @@
                         <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
                             
@@ -1305,15 +1305,15 @@
             <div class="quiz-phase-container" data-phase="dover">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                         <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                             
@@ -1321,13 +1321,13 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
                         <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
                             
@@ -1341,7 +1341,7 @@
                         <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
@@ -1353,15 +1353,15 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                             
@@ -1375,23 +1375,7 @@
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                             
@@ -1401,17 +1385,33 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1424,13 +1424,29 @@
             <div class="quiz-phase-container" data-phase="prison">
                 
                     
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
@@ -1440,47 +1456,47 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                         <div class="quiz-choices">
                             
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
                             
@@ -1488,65 +1504,49 @@
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
                         <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
                             <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
                     </div>
                     
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
+                        <div class="quiz-choices">
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                            
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                            
+                        </div>
+                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                    </div>
+                    
+                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
                         <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                         <div class="quiz-choices">
                             
                             <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
+                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
+                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
                             
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                            <button class="quiz-choice" type="button" data-choice-index="3">проклятый</button>
                             
                         </div>
                         <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1967,69 +1967,69 @@
             {
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
+                    "притворяться",
                     "фальшь",
-                    "превосходить",
                     "состязаться",
-                    "притворяться"
+                    "превосходить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
-                    "притворяться",
-                    "фальшь",
                     "превосходить",
+                    "фальшь",
+                    "притворяться",
                     "состязаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
-                    "фальшь",
                     "состязаться",
-                    "хитрость",
-                    "выманивать"
+                    "превосходить",
+                    "притворяться",
+                    "хитрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
-                    "выманивать",
-                    "состязаться",
                     "фальшь",
-                    "превосходить"
+                    "хитрость",
+                    "состязаться",
+                    "выманивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "состязаться",
-                    "разыгрывать",
+                    "фальшь",
+                    "выманивать",
                     "хитрость",
-                    "фальшь"
+                    "разыгрывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "алчность",
-                    "хитрость",
                     "разыгрывать",
-                    "фальшь"
+                    "притворяться",
+                    "превосходить",
+                    "хитрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
-                    "фальшь",
-                    "состязаться",
+                    "хитрость",
                     "разыгрывать",
+                    "притворяться",
                     "выманивать"
                 ],
                 "correctIndex": 3
@@ -2037,12 +2037,12 @@
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
-                    "состязаться",
-                    "алчность",
+                    "разыгрывать",
                     "превосходить",
-                    "фальшь"
+                    "выманивать",
+                    "алчность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2470,72 +2470,72 @@
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "заговорить",
+                    "делить",
                     "планировать",
                     "союз",
-                    "делить"
+                    "заговорить"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
+                    "планировать",
                     "делить",
-                    "планировать",
-                    "союз",
-                    "заговорить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «planen»?",
-                "choices": [
-                    "планировать",
-                    "договариваться",
-                    "союз",
-                    "делить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verschwören»?",
-                "choices": [
-                    "стратегия",
                     "заговорить",
-                    "планировать",
-                    "сговор"
+                    "союз"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Absprache»?",
+                "question": "Что означает немецкое слово «planen»?",
                 "choices": [
                     "заговорить",
                     "делить",
-                    "сговор",
+                    "планировать",
+                    "сговор"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verschwören»?",
+                "choices": [
+                    "планировать",
+                    "союз",
+                    "заговорить",
                     "договариваться"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Absprache»?",
+                "choices": [
+                    "союз",
+                    "делить",
+                    "стратегия",
+                    "сговор"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
-                    "договариваться",
-                    "планировать",
+                    "союз",
                     "сговор",
-                    "стратегия"
+                    "договариваться",
+                    "планировать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
-                    "стратегия",
-                    "договариваться",
+                    "сговор",
+                    "заговорить",
                     "делить",
-                    "союз"
+                    "стратегия"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3061,9 +3061,9 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "злоба",
-                    "унижать",
                     "насмехаться",
+                    "унижать",
+                    "злоба",
                     "пытать"
                 ],
                 "correctIndex": 3
@@ -3071,70 +3071,70 @@
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "пытать",
                     "унижать",
                     "злоба",
+                    "пытать",
                     "насмехаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "жестокость",
-                    "унижать",
                     "насмехаться",
-                    "отвергать"
+                    "отвергать",
+                    "жестоко обращаться",
+                    "жёсткость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "насмехаться",
-                    "злоба",
-                    "пытать",
-                    "отвергать"
+                    "жестоко обращаться",
+                    "жестокость",
+                    "отвергать",
+                    "злоба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
-                    "жестоко обращаться",
-                    "унижать",
                     "отвергать",
-                    "пытать"
+                    "жёсткость",
+                    "жестоко обращаться",
+                    "злоба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
+                    "жестоко обращаться",
                     "жёсткость",
-                    "отвергать",
                     "пытать",
                     "злоба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "пытать",
                     "отвергать",
-                    "жестоко обращаться",
+                    "жёсткость",
+                    "жестокость",
                     "злоба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
                     "жестокость",
-                    "унижать",
+                    "жестоко обращаться",
                     "насмехаться",
-                    "отвергать"
+                    "пытать"
                 ],
                 "correctIndex": 0
             }
@@ -3646,30 +3646,30 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "садизм",
-                    "выкалывать",
                     "наслаждаться",
-                    "ослеплять"
+                    "садизм",
+                    "ослеплять",
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "садизм",
                     "наслаждаться",
                     "ослеплять",
-                    "выкалывать"
+                    "выкалывать",
+                    "садизм"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "брутальность",
-                    "выкалывать",
+                    "беспощадный",
+                    "садизм",
                     "наслаждаться",
-                    "беспощадный"
+                    "выкалывать"
                 ],
                 "correctIndex": 2
             },
@@ -3677,51 +3677,51 @@
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
                     "выкалывать",
-                    "ослеплять",
-                    "растаптывать",
-                    "беспощадный"
+                    "беспощадный",
+                    "брутальность",
+                    "пытка"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытка",
                     "садизм",
+                    "наслаждаться",
                     "выкалывать",
-                    "ослеплять"
+                    "пытка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "выкалывать",
-                    "садизм",
+                    "растаптывать",
+                    "брутальность",
                     "беспощадный",
-                    "растаптывать"
+                    "наслаждаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Brutalität»?",
                 "choices": [
-                    "садизм",
-                    "беспощадный",
                     "пытка",
-                    "брутальность"
+                    "наслаждаться",
+                    "брутальность",
+                    "беспощадный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
-                    "брутальность",
                     "растаптывать",
-                    "садизм",
-                    "ослеплять"
+                    "наслаждаться",
+                    "выкалывать",
+                    "садизм"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4162,49 +4162,49 @@
             {
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
-                    "вдова",
-                    "вожделение",
                     "соблазнять",
-                    "вожделеть"
+                    "вожделеть",
+                    "вдова",
+                    "вожделение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "вдова",
-                    "вожделение",
+                    "вожделеть",
                     "соблазнять",
-                    "вожделеть"
+                    "вдова",
+                    "вожделение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "похоть",
-                    "вожделение",
+                    "вожделеть",
+                    "заманивать",
                     "соблазнять",
-                    "добиваться"
+                    "вдова"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
-                    "добиваться",
-                    "вдова",
+                    "заманивать",
                     "соблазнять",
-                    "вожделение"
+                    "вожделение",
+                    "вожделеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
                     "похоть",
+                    "добиваться",
                     "вожделеть",
-                    "вдова",
                     "заманивать"
                 ],
                 "correctIndex": 3
@@ -4213,8 +4213,8 @@
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
                     "заманивать",
-                    "вдова",
                     "соблазнять",
+                    "вожделеть",
                     "похоть"
                 ],
                 "correctIndex": 3
@@ -4222,9 +4222,9 @@
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
-                    "соблазнять",
+                    "вожделеть",
                     "заманивать",
-                    "вожделение",
+                    "вдова",
                     "добиваться"
                 ],
                 "correctIndex": 3
@@ -4655,27 +4655,27 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
+                    "угрожать",
                     "соревноваться",
                     "ненавидеть",
-                    "угрожать",
-                    "соперничество"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «hassen»?",
-                "choices": [
-                    "угрожать",
-                    "ненавидеть",
-                    "соревноваться",
                     "соперничество"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «hassen»?",
+                "choices": [
+                    "ненавидеть",
+                    "угрожать",
+                    "соревноваться",
+                    "соперничество"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "не доверять",
+                    "соперничество",
                     "ненавидеть",
                     "угрожать",
                     "подозревать"
@@ -4685,42 +4685,42 @@
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "бороться",
+                    "угрожать",
+                    "не доверять",
                     "соперничество",
-                    "подозревать",
                     "ненавидеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
                     "бороться",
-                    "угрожать",
-                    "не доверять",
-                    "соревноваться"
+                    "соревноваться",
+                    "ненавидеть",
+                    "не доверять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
+                    "не доверять",
                     "бороться",
                     "соперничество",
-                    "ненавидеть",
-                    "не доверять"
+                    "ненавидеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
-                    "бороться",
-                    "подозревать",
+                    "соревноваться",
                     "ненавидеть",
-                    "угрожать"
+                    "подозревать",
+                    "не доверять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5202,82 +5202,82 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "отравленный",
                     "мучение",
+                    "страдать",
                     "издыхать",
-                    "страдать"
+                    "отравленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
                     "мучение",
+                    "отравленный",
                     "издыхать",
-                    "страдать",
-                    "отравленный"
+                    "страдать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "расплачиваться",
+                    "страдать",
+                    "проклинать",
                     "издыхать",
-                    "мучение",
-                    "страдать"
+                    "проклятый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "мучение",
                     "издыхать",
-                    "отравленный",
-                    "рок"
+                    "страдать",
+                    "мучение",
+                    "проклинать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
+                    "страдать",
+                    "мучение",
                     "проклинать",
-                    "издыхать",
-                    "проклятый",
-                    "отравленный"
+                    "рок"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
+                    "проклинать",
+                    "мучение",
                     "рок",
-                    "проклятый",
-                    "издыхать",
-                    "расплачиваться"
+                    "страдать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
-                    "проклинать",
-                    "мучение",
                     "расплачиваться",
-                    "издыхать"
+                    "мучение",
+                    "издыхать",
+                    "проклинать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
                     "проклинать",
-                    "проклятый",
-                    "расплачиваться",
-                    "издыхать"
+                    "издыхать",
+                    "рок",
+                    "проклятый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5382,6 +5382,207 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+const STUDY_WORDS_LIMIT = null; // null = unlimited, number = custom limit
+
+function readReviewQueue() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    try {
+        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
+        if (!stored) {
+            return [];
+        }
+
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(item => item && typeof item === 'object');
+        }
+    } catch (error) {
+        console.error('[ReviewQueue] Error reading from localStorage:', error);
+    }
+
+    return [];
+}
+
+function writeReviewQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return false;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        return true;
+    } catch (error) {
+        console.error('[ReviewQueue] Error saving to localStorage:', error);
+        return false;
+    }
+}
+
+function extractStudyEntries(queue) {
+    if (!Array.isArray(queue)) {
+        return [];
+    }
+
+    return queue.filter(entry => entry && typeof entry.word === 'string');
+}
+
+function findStudyWordIndex(queue, word, characterId) {
+    if (!Array.isArray(queue)) {
+        return -1;
+    }
+
+    const targetWord = typeof word === 'string' ? word : '';
+    const targetCharacterId = typeof characterId === 'string' ? characterId : '';
+
+    return queue.findIndex(entry => {
+        if (!entry || typeof entry.word !== 'string') {
+            return false;
+        }
+
+        const entryCharacterId = typeof entry.characterId === 'string' ? entry.characterId : '';
+        return entry.word === targetWord && entryCharacterId === targetCharacterId;
+    });
+}
+
+function setStudyButtonState(button, isAdded) {
+    if (!button) {
+        return;
+    }
+
+    const added = Boolean(isAdded);
+    button.disabled = false;
+    button.classList.toggle('added', added);
+    button.classList.remove('limit-reached');
+    button.style.background = '';
+    button.style.opacity = '';
+    button.style.cursor = '';
+    button.removeAttribute('aria-disabled');
+    button.setAttribute('aria-pressed', added ? 'true' : 'false');
+
+    if (added) {
+        button.textContent = '✓ Добавлено';
+    } else {
+        button.textContent = 'Изучить';
+    }
+}
+
+function updateStudyCounter(count) {
+    const header = document.querySelector('.vocabulary-section h2');
+    if (!header) {
+        return;
+    }
+
+    let counter = header.querySelector('.study-counter');
+    if (!counter) {
+        counter = document.createElement('span');
+        counter.className = 'study-counter';
+        header.appendChild(counter);
+    }
+
+    counter.textContent = `Выбрано слов: ${count}`;
+}
+
+function updateWordButtons() {
+    const queue = readReviewQueue();
+    const studyEntries = extractStudyEntries(queue);
+    const studyCount = studyEntries.length;
+
+    document.querySelectorAll('.btn-study').forEach(button => {
+        const wordId = button.dataset.word || '';
+        const characterId = button.dataset.characterId || '';
+        const existsIndex = findStudyWordIndex(queue, wordId, characterId);
+        setStudyButtonState(button, existsIndex !== -1);
+    });
+
+    if (STUDY_WORDS_LIMIT !== null) {
+        const limitReached = studyCount >= STUDY_WORDS_LIMIT;
+        document.querySelectorAll('.btn-study').forEach(button => {
+            if (!button.classList.contains('added')) {
+                if (limitReached) {
+                    button.classList.add('limit-reached');
+                    button.setAttribute('aria-disabled', 'true');
+                } else {
+                    button.classList.remove('limit-reached');
+                    button.removeAttribute('aria-disabled');
+                }
+            }
+        });
+    }
+
+    updateStudyCounter(studyCount);
+}
+
+function toggleStudyWord(button, wordData) {
+    if (!button || !wordData) {
+        return;
+    }
+
+    const queue = readReviewQueue();
+    const currentIndex = findStudyWordIndex(queue, wordData.word, wordData.characterId);
+    const updatedQueue = queue.slice();
+
+    if (currentIndex > -1) {
+        const removedWord = updatedQueue.splice(currentIndex, 1)[0];
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось обновить список для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Removed word from review:', removedWord);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(12);
+        }
+    } else {
+        if (STUDY_WORDS_LIMIT !== null) {
+            const currentCount = extractStudyEntries(queue).length;
+            if (currentCount >= STUDY_WORDS_LIMIT) {
+                button.classList.add('limit-reached');
+                button.textContent = `Максимум ${STUDY_WORDS_LIMIT} слов`;
+                setTimeout(() => updateWordButtons(), 1500);
+                return;
+            }
+        }
+
+        const newEntry = Object.assign({}, wordData);
+        if (!Array.isArray(newEntry.examples)) {
+            newEntry.examples = [];
+        } else {
+            newEntry.examples = newEntry.examples.map(example =>
+                Object.assign({}, example)
+            );
+        }
+
+        newEntry.emoji = newEntry.emoji || '📝';
+        newEntry.sentence = typeof newEntry.sentence === 'string' ? newEntry.sentence : '';
+        newEntry.example = typeof newEntry.example === 'string' ? newEntry.example : newEntry.sentence;
+        newEntry.sentenceTranslation = typeof newEntry.sentenceTranslation === 'string'
+            ? newEntry.sentenceTranslation
+            : '';
+        newEntry.addedAt = new Date().toISOString();
+
+        updatedQueue.push(newEntry);
+
+        if (!writeReviewQueue(updatedQueue)) {
+            alert('Не удалось сохранить слово для изучения');
+            updateWordButtons();
+            return;
+        }
+
+        console.log('[ReviewQueue] Added word to review:', newEntry);
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    }
+
+    button.blur();
+    updateWordButtons();
+    window.dispatchEvent(new Event('storage'));
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5666,36 +5867,22 @@ function updateQuizStatsUI(phaseKey) {
 }
 
 function queuePhaseReview(detail) {
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
+    const queue = readReviewQueue();
 
-    let queue = [];
-    try {
-        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-        if (stored) {
-            const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                queue = parsed;
-            }
+    const filteredQueue = queue.filter(entry => {
+        if (!entry) {
+            return false;
         }
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to read review queue', error);
-    }
 
-    queue = queue.filter(entry => {
-        if (!entry) return false;
         return !(entry.characterId === detail.characterId && entry.phaseId === detail.phaseId);
     });
 
     if (detail.incorrectWords && detail.incorrectWords.length > 0) {
-        queue.push(detail);
+        filteredQueue.push(detail);
     }
 
-    try {
-        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
-    } catch (error) {
-        console.warn('[ReviewQueue] Unable to update review queue', error);
+    if (!writeReviewQueue(filteredQueue)) {
+        console.warn('[ReviewQueue] Unable to update review queue');
     }
 }
 
@@ -6208,6 +6395,10 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
+    const initialQueue = readReviewQueue();
+    const initialStudyEntries = extractStudyEntries(initialQueue);
+    updateStudyCounter(initialStudyEntries.length);
+
     phase.words.forEach((item, index) => {
         setTimeout(() => {
             const card = document.createElement('div');
@@ -6231,97 +6422,63 @@ function displayVocabulary(phaseKey) {
                     data-phase-key="${phaseKey || ''}"
                 >Изучить</button>
             `;
-            
-            // Добавляем обработчик для кнопки
+
+            const normalizedWord = (item.word || '').toLowerCase().trim();
+            const baseWordId = normalizedWord
+                ? normalizedWord.replace(/\s+/g, '_')
+                : `word-${index}`;
+
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                const alreadyAdded = findStudyWordIndex(
+                    initialQueue,
+                    studyBtn.dataset.word || '',
+                    studyBtn.dataset.characterId || ''
+                ) !== -1;
+                setStudyButtonState(studyBtn, alreadyAdded);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
+
                     const fullWordData = {
                         word: this.dataset.word,
                         translation: this.dataset.translation,
                         transcription: this.dataset.transcription,
                         characterId: this.dataset.characterId,
                         phaseKey: this.dataset.phaseKey,
+                        sentence: this.dataset.sentence || '',
+                        example: this.dataset.sentence || '',
+                        sentenceTranslation: this.dataset.sentenceTranslation || '',
+                        wordId: baseWordId,
+                        id: `${this.dataset.characterId || 'word'}-${baseWordId}`,
                         examples: []
                     };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
+
                     if (this.dataset.sentence || this.dataset.sentenceTranslation) {
                         fullWordData.examples.push({
                             german: this.dataset.sentence || '',
                             russian: this.dataset.sentenceTranslation || ''
                         });
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
-                    }
+
+                    fullWordData.emoji = item.visual_hint || '📝';
+
+                    toggleStudyWord(this, fullWordData);
                 });
             }
-            
+
             grid.appendChild(card);
+
+            if (index === phase.words.length - 1) {
+                updateWordButtons();
+            }
         }, index * 50);
     });
+
+    if (!phase.words.length) {
+        updateWordButtons();
+    }
     
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
@@ -7239,6 +7396,12 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeProgressLine();
     initializeConstructorSection();
     attachQuizHandlers();
+
+    window.addEventListener('storage', function(event) {
+        if (!event || !event.key || event.key === REVIEW_QUEUE_KEY) {
+            updateWordButtons();
+        }
+    });
 
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -71,6 +71,25 @@
     background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
 }
 
+.study-counter {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 16px;
+    padding: 6px 16px;
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    color: #fff;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 6px 16px rgba(34, 197, 94, 0.25);
+}
+
+.word-card .btn-study[disabled] {
+    opacity: 1;
+    cursor: pointer;
+}
+
 /* Анимация появления карточек */
 @keyframes fadeInUp {
     from {

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -71,6 +71,25 @@
     background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
 }
 
+.study-counter {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 16px;
+    padding: 6px 16px;
+    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    color: #fff;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 500;
+    box-shadow: 0 6px 16px rgba(34, 197, 94, 0.25);
+}
+
+.word-card .btn-study[disabled] {
+    opacity: 1;
+    cursor: pointer;
+}
+
 /* Анимация появления карточек */
 @keyframes fadeInUp {
     from {


### PR DESCRIPTION
## Summary
- remove the 5 word study limit in the journey runtime and allow toggling words in/out of the list
- add helper utilities to keep the study counter and buttons in sync and surface a counter badge in the header
- regenerate static assets and journey pages so the updated behaviour ships with the built site

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68ced15eb24c8320ad52acf71f8f75ef