### PR TITLE
Remove study limit and sync study counter

### DIFF
--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Олбани</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Олбани</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="passive_duke">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="passive_duke">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="first_doubts">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="awakening">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="confrontation">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="moral_stand">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="justice_seeker">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="new_ruler">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["брак", "слабость", "терпеть", "молчание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "терпеть", "молчание", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["слабость", "уступать", "пассивный", "брак"], "correct_index": 3}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["уступать", "терпеть", "мягкий", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["терпеть", "пассивный", "колебаться", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["терпеть", "слабость", "пассивный", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["слабость", "терпеть", "мягкий", "колебаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «mild»?", "choices": ["молчание", "уступать", "мягкий", "брак"], "correct_index": 2}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["сомнение", "беспокойство", "подвергать сомнению", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["совесть", "сомнение", "беспокойство", "подвергать сомнению"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["сомнение", "подвергать сомнению", "неуверенный", "беспокойство"], "correct_index": 3}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "тревожить", "совесть", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "размышлять", "подвергать сомнению", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["сомнение", "неуверенный", "подвергать сомнению", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["неуверенный", "сомнение", "размышлять", "тревожить"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["ужас", "понимать", "пробуждаться", "осознание"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["понимать", "ужас", "осознание", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["просыпаться", "пугаться", "понимать", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["превращение", "понимать", "ясно видеть", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["ясно видеть", "пугаться", "просыпаться", "превращение"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["ужас", "просыпаться", "пугаться", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["пробуждаться", "ясно видеть", "просыпаться", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["понимать", "превращение", "ясно видеть", "пробуждаться"], "correct_index": 1}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["сопротивление", "спор", "мужество", "противостоять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["сопротивление", "спор", "противостоять", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["обвинять", "сопротивление", "мужество", "восставать"], "correct_index": 1}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["защищаться", "мужество", "сопротивление", "противостоять"], "correct_index": 3}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["мужество", "противостоять", "обвинять", "восставать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["сопротивление", "восставать", "противостоять", "защищаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["мужество", "восставать", "спор", "противостоять"], "correct_index": 1}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["решение", "выбирать", "мораль", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["мораль", "справедливость", "выбирать", "решение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["праведный", "принцип", "решение", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["мораль", "справедливость", "выбирать", "добродетель"], "correct_index": 2}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["принцип", "праведный", "мораль", "благородный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["выбирать", "принцип", "праведный", "добродетель"], "correct_index": 1}, {"question": "Что означает немецкое слово «edel»?", "choices": ["справедливость", "благородный", "принцип", "выбирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["справедливость", "решение", "принцип", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["борьба", "право", "наказывать", "доброта"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["наказывать", "борьба", "право", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["вмешиваться", "наказывать", "доброта", "борьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["вмешиваться", "наказывать", "доброта", "судить"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["наказывать", "вмешиваться", "борьба", "судить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "судить", "право", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["право", "доброта", "вмешиваться", "судить"], "correct_index": 2}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "направлять", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["направлять", "новое начало", "мудрость", "примирять"], "correct_index": 1}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["обновлять", "примирять", "правление", "направлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "обновлять", "мир", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["правление", "обновлять", "новое начало", "мир"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["направлять", "примирять", "строить", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["мир", "направлять", "новое начало", "правление"], "correct_index": 0}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="passive_duke">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">колебаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «mild»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брак</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="first_doubts">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тревожить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="awakening">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ясно видеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пугаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">превращение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="confrontation">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="moral_stand">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="justice_seeker">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">право</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «richten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">право</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="new_ruler">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">примирять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">строить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мир</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="first_doubts">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="passive_duke">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="first_doubts">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="awakening">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="confrontation">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="moral_stand">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="justice_seeker">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="new_ruler">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="awakening">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="confrontation">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="moral_stand">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="justice_seeker">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="new_ruler">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="passive_duke">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="first_doubts">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="awakening">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="confrontation">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="moral_stand">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="justice_seeker">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="new_ruler">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["терпеть", "брак", "слабость", "молчание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["брак", "терпеть", "молчание", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["молчание", "мягкий", "брак", "терпеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["уступать", "терпеть", "брак", "мягкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["пассивный", "уступать", "колебаться", "слабость"], "correct_index": 0}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["терпеть", "колебаться", "мягкий", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["пассивный", "молчание", "колебаться", "мягкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «mild»?", "choices": ["слабость", "брак", "колебаться", "мягкий"], "correct_index": 3}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["совесть", "подвергать сомнению", "беспокойство", "сомнение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["подвергать сомнению", "совесть", "сомнение", "беспокойство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["беспокойство", "совесть", "неуверенный", "размышлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["беспокойство", "подвергать сомнению", "совесть", "сомнение"], "correct_index": 1}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "беспокойство", "размышлять", "неуверенный"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["тревожить", "совесть", "размышлять", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["сомнение", "размышлять", "тревожить", "подвергать сомнению"], "correct_index": 1}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["ужас", "осознание", "понимать", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["ужас", "осознание", "понимать", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["пугаться", "пробуждаться", "ясно видеть", "понимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["пугаться", "ужас", "понимать", "ясно видеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пробуждаться", "понимать", "превращение", "пугаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["пугаться", "понимать", "ясно видеть", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["просыпаться", "ужас", "понимать", "ясно видеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["понимать", "просыпаться", "пробуждаться", "превращение"], "correct_index": 3}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["спор", "сопротивление", "мужество", "противостоять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["спор", "противостоять", "сопротивление", "мужество"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["сопротивление", "мужество", "спор", "восставать"], "correct_index": 0}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["восставать", "защищаться", "противостоять", "мужество"], "correct_index": 2}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["спор", "восставать", "сопротивление", "обвинять"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["противостоять", "мужество", "восставать", "защищаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["противостоять", "мужество", "защищаться", "восставать"], "correct_index": 3}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["решение", "выбирать", "мораль", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "решение", "мораль", "выбирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["добродетель", "праведный", "справедливость", "решение"], "correct_index": 3}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["добродетель", "выбирать", "принцип", "мораль"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["решение", "благородный", "праведный", "добродетель"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["принцип", "мораль", "праведный", "благородный"], "correct_index": 0}, {"question": "Что означает немецкое слово «edel»?", "choices": ["благородный", "добродетель", "решение", "принцип"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["решение", "принцип", "благородный", "добродетель"], "correct_index": 3}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "право", "борьба", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["право", "борьба", "наказывать", "доброта"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["судить", "борьба", "вмешиваться", "доброта"], "correct_index": 3}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["доброта", "наказывать", "борьба", "судить"], "correct_index": 1}, {"question": "Что означает немецкое слово «richten»?", "choices": ["право", "вмешиваться", "судить", "наказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["вмешиваться", "судить", "защищать", "право"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["вмешиваться", "доброта", "право", "борьба"], "correct_index": 0}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "направлять", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "мудрость", "направлять", "правление"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["направлять", "мудрость", "новое начало", "обновлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["обновлять", "строить", "новое начало", "направлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["мудрость", "обновлять", "мир", "примирять"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["новое начало", "направлять", "обновлять", "примирять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["направлять", "мир", "примирять", "строить"], "correct_index": 1}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="passive_duke">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пассивный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «mild»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брак</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="first_doubts">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «hinterfragen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подвергать сомнению</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">совесть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуверенный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тревожить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подвергать сомнению</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="awakening">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erschrecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ясно видеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="confrontation">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">восставать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">восставать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="moral_stand">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мораль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «edel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принцип</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="justice_seeker">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Recht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «richten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">право</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">право</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="new_ruler">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufbauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">строить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1952,9 +1985,9 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "терпеть",
                     "брак",
                     "слабость",
+                    "терпеть",
                     "молчание"
                 ],
                 "correctIndex": 3
@@ -1972,39 +2005,39 @@
             {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
-                    "молчание",
-                    "мягкий",
-                    "брак",
-                    "терпеть"
+                    "слабость",
+                    "уступать",
+                    "пассивный",
+                    "брак"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
                     "уступать",
                     "терпеть",
-                    "брак",
-                    "мягкий"
+                    "мягкий",
+                    "слабость"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
+                    "терпеть",
                     "пассивный",
-                    "уступать",
                     "колебаться",
                     "слабость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
                     "терпеть",
-                    "колебаться",
-                    "мягкий",
+                    "слабость",
+                    "пассивный",
                     "уступать"
                 ],
                 "correctIndex": 3
@@ -2012,22 +2045,22 @@
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "пассивный",
-                    "молчание",
-                    "колебаться",
-                    "мягкий"
+                    "слабость",
+                    "терпеть",
+                    "мягкий",
+                    "колебаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
-                    "слабость",
-                    "брак",
-                    "колебаться",
-                    "мягкий"
+                    "молчание",
+                    "уступать",
+                    "мягкий",
+                    "брак"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2454,49 +2487,49 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "совесть",
-                    "подвергать сомнению",
+                    "сомнение",
                     "беспокойство",
-                    "сомнение"
+                    "подвергать сомнению",
+                    "совесть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "подвергать сомнению",
                     "совесть",
                     "сомнение",
-                    "беспокойство"
+                    "беспокойство",
+                    "подвергать сомнению"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "беспокойство",
-                    "совесть",
+                    "сомнение",
+                    "подвергать сомнению",
                     "неуверенный",
+                    "беспокойство"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «hinterfragen»?",
+                "choices": [
+                    "подвергать сомнению",
+                    "тревожить",
+                    "совесть",
                     "размышлять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «hinterfragen»?",
-                "choices": [
-                    "беспокойство",
-                    "подвергать сомнению",
-                    "совесть",
-                    "сомнение"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
                     "тревожить",
-                    "беспокойство",
                     "размышлять",
+                    "подвергать сомнению",
                     "неуверенный"
                 ],
                 "correctIndex": 0
@@ -2504,22 +2537,22 @@
             {
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "тревожить",
-                    "совесть",
-                    "размышлять",
-                    "неуверенный"
+                    "сомнение",
+                    "неуверенный",
+                    "подвергать сомнению",
+                    "размышлять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
+                    "неуверенный",
                     "сомнение",
                     "размышлять",
-                    "тревожить",
-                    "подвергать сомнению"
+                    "тревожить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2980,81 +3013,81 @@
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
                     "ужас",
-                    "осознание",
                     "понимать",
-                    "пробуждаться"
+                    "пробуждаться",
+                    "осознание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
+                    "понимать",
                     "ужас",
                     "осознание",
-                    "понимать",
                     "пробуждаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «erwachen»?",
-                "choices": [
-                    "пугаться",
-                    "пробуждаться",
-                    "ясно видеть",
-                    "понимать"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «erwachen»?",
+                "choices": [
+                    "просыпаться",
+                    "пугаться",
+                    "понимать",
+                    "пробуждаться"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
-                    "пугаться",
-                    "ужас",
+                    "превращение",
                     "понимать",
-                    "ясно видеть"
+                    "ясно видеть",
+                    "пробуждаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
-                    "пробуждаться",
-                    "понимать",
-                    "превращение",
-                    "пугаться"
+                    "ясно видеть",
+                    "пугаться",
+                    "просыпаться",
+                    "превращение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufwachen»?",
                 "choices": [
+                    "ужас",
+                    "просыпаться",
                     "пугаться",
-                    "понимать",
-                    "ясно видеть",
-                    "просыпаться"
+                    "осознание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «klar sehen»?",
                 "choices": [
+                    "пробуждаться",
+                    "ясно видеть",
                     "просыпаться",
-                    "ужас",
-                    "понимать",
-                    "ясно видеть"
+                    "осознание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
                     "понимать",
-                    "просыпаться",
-                    "пробуждаться",
-                    "превращение"
+                    "превращение",
+                    "ясно видеть",
+                    "пробуждаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3482,19 +3515,19 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "спор",
                     "сопротивление",
+                    "спор",
                     "мужество",
                     "противостоять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
+                    "сопротивление",
                     "спор",
                     "противостоять",
-                    "сопротивление",
                     "мужество"
                 ],
                 "correctIndex": 3
@@ -3502,39 +3535,39 @@
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
+                    "обвинять",
                     "сопротивление",
                     "мужество",
-                    "спор",
                     "восставать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
-                    "восставать",
                     "защищаться",
-                    "противостоять",
-                    "мужество"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «anklagen»?",
-                "choices": [
-                    "спор",
-                    "восставать",
+                    "мужество",
                     "сопротивление",
-                    "обвинять"
+                    "противостоять"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «anklagen»?",
+                "choices": [
+                    "мужество",
+                    "противостоять",
+                    "обвинять",
+                    "восставать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
-                    "противостоять",
-                    "мужество",
+                    "сопротивление",
                     "восставать",
+                    "противостоять",
                     "защищаться"
                 ],
                 "correctIndex": 3
@@ -3542,12 +3575,12 @@
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "противостоять",
                     "мужество",
-                    "защищаться",
-                    "восставать"
+                    "восставать",
+                    "спор",
+                    "противостоять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4021,69 +4054,69 @@
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "справедливость",
-                    "решение",
                     "мораль",
-                    "выбирать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Entscheidung»?",
-                "choices": [
-                    "добродетель",
-                    "праведный",
                     "справедливость",
-                    "решение"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «wählen»?",
-                "choices": [
-                    "добродетель",
                     "выбирать",
-                    "принцип",
-                    "мораль"
+                    "решение"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «rechtschaffen»?",
+                "question": "Что означает немецкое слово «die Entscheidung»?",
                 "choices": [
-                    "решение",
-                    "благородный",
                     "праведный",
+                    "принцип",
+                    "решение",
+                    "выбирать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «wählen»?",
+                "choices": [
+                    "мораль",
+                    "справедливость",
+                    "выбирать",
                     "добродетель"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «das Prinzip»?",
+                "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
                     "принцип",
-                    "мораль",
                     "праведный",
+                    "мораль",
                     "благородный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «das Prinzip»?",
+                "choices": [
+                    "выбирать",
+                    "принцип",
+                    "праведный",
+                    "добродетель"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
+                    "справедливость",
                     "благородный",
-                    "добродетель",
-                    "решение",
-                    "принцип"
+                    "принцип",
+                    "выбирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
+                    "справедливость",
                     "решение",
                     "принцип",
-                    "благородный",
                     "добродетель"
                 ],
                 "correctIndex": 3
@@ -4510,39 +4543,39 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "наказывать",
-                    "право",
                     "борьба",
-                    "доброта"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Recht»?",
-                "choices": [
                     "право",
-                    "борьба",
                     "наказывать",
                     "доброта"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Güte»?",
+                "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
-                    "судить",
+                    "наказывать",
                     "борьба",
-                    "вмешиваться",
+                    "право",
                     "доброта"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Güte»?",
+                "choices": [
+                    "вмешиваться",
+                    "наказывать",
+                    "доброта",
+                    "борьба"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «strafen»?",
                 "choices": [
-                    "доброта",
+                    "вмешиваться",
                     "наказывать",
-                    "борьба",
+                    "доброта",
                     "судить"
                 ],
                 "correctIndex": 1
@@ -4550,32 +4583,32 @@
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
-                    "право",
+                    "наказывать",
                     "вмешиваться",
-                    "судить",
-                    "наказывать"
+                    "борьба",
+                    "судить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "вмешиваться",
-                    "судить",
                     "защищать",
-                    "право"
+                    "судить",
+                    "право",
+                    "наказывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "вмешиваться",
-                    "доброта",
                     "право",
-                    "борьба"
+                    "доброта",
+                    "вмешиваться",
+                    "судить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5074,72 +5107,72 @@
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "новое начало",
-                    "мудрость",
-                    "направлять",
-                    "правление"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Neuanfang»?",
-                "choices": [
-                    "направлять",
-                    "мудрость",
-                    "новое начало",
-                    "обновлять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «lenken»?",
-                "choices": [
                     "мудрость",
                     "направлять",
                     "правление",
                     "новое начало"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «aufbauen»?",
+                "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "обновлять",
-                    "строить",
+                    "направлять",
                     "новое начало",
-                    "направлять"
+                    "мудрость",
+                    "примирять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «erneuern»?",
+                "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
-                    "мудрость",
+                    "обновлять",
+                    "примирять",
+                    "правление",
+                    "направлять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «aufbauen»?",
+                "choices": [
+                    "строить",
                     "обновлять",
                     "мир",
-                    "примирять"
+                    "новое начало"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «erneuern»?",
+                "choices": [
+                    "правление",
+                    "обновлять",
+                    "новое начало",
+                    "мир"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
-                    "новое начало",
                     "направлять",
-                    "обновлять",
-                    "примирять"
+                    "примирять",
+                    "строить",
+                    "новое начало"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "направлять",
                     "мир",
-                    "примирять",
-                    "строить"
+                    "направлять",
+                    "новое начало",
+                    "правление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5244,6 +5277,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5777,6 +6181,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5831,6 +6236,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5860,6 +6266,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -5923,6 +6330,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -5931,6 +6340,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -5949,6 +6359,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -5997,6 +6409,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6015,6 +6449,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6091,100 +6528,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6193,7 +6582,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6306,6 +6699,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6355,6 +6750,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7102,6 +7499,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7118,6 +7560,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Корделии</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Корделии</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1427 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["провозглашать", "церемония", "власть", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "власть", "провозглашать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["власть", "верность", "провозглашать", "повиноваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["провозглашать", "верность", "власть", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["долг", "власть", "повиноваться", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["повиноваться", "власть", "правда", "долг"], "correct_index": 3}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["долг", "церемония", "торжественный", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["провозглашать", "церемония", "верность", "торжественный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["наказание", "изгонять", "гнев", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "изгонять", "наказание", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "покидать", "чужой", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["чужой", "изгонять", "принимать", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["изгонять", "чужой", "покидать", "приданое"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["надежда", "чужой", "приданое", "принимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["гнев", "чужой", "принимать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["покидать", "изгонять", "приданое", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["одиночество", "забота", "известие", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["известие", "страх", "забота", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["защищать", "одиночество", "страдать", "известие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страх", "защищать", "одиночество", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страх", "страдать", "известие", "тоска"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["забота", "защищать", "тоска", "молиться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["страдать", "забота", "тоска", "молиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «beten»?", "choices": ["страх", "молиться", "тоска", "защищать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["битва", "возвращаться", "спасать", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["битва", "спасать", "возвращаться", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["армия", "борьба", "возвращаться", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["армия", "битва", "справедливость", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["армия", "храбрый", "спасать", "возвращаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "битва", "побеждать", "храбрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["храбрый", "возвращаться", "борьба", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["справедливость", "армия", "побеждать", "битва"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "обнимать", "узнавать", "слёзы"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "узнавать", "обнимать", "слёзы"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощение", "исцелять", "обнимать", "нежный"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "прощать", "обнимать", "слёзы"], "correct_index": 0}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["слёзы", "нежный", "исцелять", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["нежный", "раскаяние", "прощать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["нежный", "слёзы", "обнимать", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["исцелять", "прощение", "раскаяние", "слёзы"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "тюрьма", "достоинство", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["утешать", "пленный", "тюрьма", "достоинство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["достоинство", "честь", "отважный", "смирение"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["смирение", "достоинство", "утешать", "пленный"], "correct_index": 2}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "смирение", "честь", "судьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["достоинство", "утешать", "смирение", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["смирение", "тюрьма", "судьба", "честь"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["смирение", "тюрьма", "честь", "пленный"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["душа", "смерть", "умирать", "жертва"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["жертва", "душа", "умирать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["смерть", "умирать", "прощание", "жертва"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["душа", "жертва", "умирать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["спасение", "вечный", "смерть", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["смерть", "конец", "прощание", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "конец", "душа", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["жертва", "смерть", "спасение", "прощание"], "correct_index": 2}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">повиноваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">чужой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «beten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тоска</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нежный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">душа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,971 +1639,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["власть", "церемония", "провозглашать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["провозглашать", "церемония", "власть", "правда"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["верность", "провозглашать", "правда", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["торжественный", "власть", "церемония", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "провозглашать", "правда", "торжественный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["власть", "верность", "долг", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["власть", "правда", "верность", "торжественный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["власть", "правда", "верность", "церемония"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["покидать", "гнев", "изгонять", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "изгонять", "покидать", "наказание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "приданое", "покидать", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "наказание", "чужой", "приданое"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["чужой", "принимать", "гнев", "приданое"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["наказание", "изгонять", "приданое", "принимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["гнев", "наказание", "чужой", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["наказание", "приданое", "покидать", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["одиночество", "известие", "страх", "забота"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "известие", "забота", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["защищать", "тоска", "известие", "молиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["известие", "тоска", "одиночество", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["одиночество", "страх", "молиться", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["тоска", "защищать", "страдать", "одиночество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["защищать", "страх", "забота", "тоска"], "correct_index": 3}, {"question": "Что означает немецкое слово «beten»?", "choices": ["известие", "страдать", "одиночество", "молиться"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["спасать", "возвращаться", "битва", "борьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "борьба", "спасать", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["справедливость", "борьба", "спасать", "храбрый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["битва", "борьба", "армия", "справедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["битва", "храбрый", "борьба", "армия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "битва", "спасать", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["армия", "борьба", "побеждать", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["спасать", "справедливость", "храбрый", "армия"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["слёзы", "узнавать", "обнимать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["обнимать", "слёзы", "прощать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["раскаяние", "прощение", "обнимать", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощение", "обнимать", "узнавать", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["исцелять", "обнимать", "нежный", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["обнимать", "раскаяние", "прощение", "слёзы"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["обнимать", "исцелять", "слёзы", "нежный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "раскаяние", "исцелять", "прощение"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["пленный", "достоинство", "утешать", "тюрьма"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "тюрьма", "пленный", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["смирение", "достоинство", "отважный", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["достоинство", "судьба", "отважный", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["отважный", "честь", "пленный", "тюрьма"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["смирение", "утешать", "тюрьма", "пленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["судьба", "честь", "утешать", "тюрьма"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["смирение", "судьба", "утешать", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "душа", "умирать", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["жертва", "смерть", "умирать", "душа"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["смерть", "прощание", "спасение", "жертва"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["смерть", "душа", "спасение", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "вечный", "спасение", "жертва"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "спасение", "жертва", "конец"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["смерть", "спасение", "прощание", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["смерть", "умирать", "спасение", "прощание"], "correct_index": 2}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">принимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приданое</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Sehnsucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «mutig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Vergebung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отважный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -2054,9 +2087,9 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "власть",
-                    "церемония",
                     "провозглашать",
+                    "церемония",
+                    "власть",
                     "правда"
                 ],
                 "correctIndex": 3
@@ -2064,70 +2097,70 @@
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "провозглашать",
                     "церемония",
                     "власть",
+                    "провозглашать",
                     "правда"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verkünden»?",
-                "choices": [
-                    "верность",
-                    "провозглашать",
-                    "правда",
-                    "долг"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Macht»?",
-                "choices": [
-                    "торжественный",
-                    "власть",
-                    "церемония",
-                    "долг"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «gehorchen»?",
-                "choices": [
-                    "повиноваться",
-                    "провозглашать",
-                    "правда",
-                    "торжественный"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Pflicht»?",
+                "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
                     "власть",
                     "верность",
+                    "провозглашать",
+                    "повиноваться"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Macht»?",
+                "choices": [
+                    "провозглашать",
+                    "верность",
+                    "власть",
+                    "правда"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «gehorchen»?",
+                "choices": [
                     "долг",
+                    "власть",
+                    "повиноваться",
                     "церемония"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «feierlich»?",
+                "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
+                    "повиноваться",
                     "власть",
                     "правда",
-                    "верность",
-                    "торжественный"
+                    "долг"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «feierlich»?",
+                "choices": [
+                    "долг",
+                    "церемония",
+                    "торжественный",
+                    "провозглашать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "власть",
-                    "правда",
+                    "провозглашать",
+                    "церемония",
                     "верность",
-                    "церемония"
+                    "торжественный"
                 ],
                 "correctIndex": 2
             }
@@ -2663,58 +2696,58 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "покидать",
-                    "гнев",
+                    "наказание",
                     "изгонять",
-                    "наказание"
+                    "гнев",
+                    "покидать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "гнев",
-                    "изгонять",
                     "покидать",
-                    "наказание"
+                    "изгонять",
+                    "наказание",
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "чужой",
-                    "приданое",
+                    "гнев",
                     "покидать",
-                    "гнев"
+                    "чужой",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "изгонять",
-                    "наказание",
                     "чужой",
+                    "изгонять",
+                    "принимать",
+                    "наказание"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «fremd»?",
+                "choices": [
+                    "изгонять",
+                    "чужой",
+                    "покидать",
                     "приданое"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «fremd»?",
-                "choices": [
-                    "чужой",
-                    "принимать",
-                    "гнев",
-                    "приданое"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
-                    "наказание",
-                    "изгонять",
+                    "надежда",
+                    "чужой",
                     "приданое",
                     "принимать"
                 ],
@@ -2724,18 +2757,18 @@
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
                     "гнев",
-                    "наказание",
                     "чужой",
-                    "принимать"
+                    "принимать",
+                    "наказание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "наказание",
-                    "приданое",
                     "покидать",
+                    "изгонять",
+                    "приданое",
                     "надежда"
                 ],
                 "correctIndex": 3
@@ -3269,17 +3302,17 @@
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
                     "одиночество",
+                    "забота",
                     "известие",
-                    "страх",
-                    "забота"
+                    "страх"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "страх",
                     "известие",
+                    "страх",
                     "забота",
                     "одиночество"
                 ],
@@ -3289,61 +3322,61 @@
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
                     "защищать",
-                    "тоска",
-                    "известие",
-                    "молиться"
+                    "одиночество",
+                    "страдать",
+                    "известие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
-                    "известие",
-                    "тоска",
+                    "страх",
+                    "защищать",
                     "одиночество",
-                    "страх"
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "одиночество",
                     "страх",
-                    "молиться",
-                    "страдать"
+                    "страдать",
+                    "известие",
+                    "тоска"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "тоска",
+                    "забота",
                     "защищать",
-                    "страдать",
-                    "одиночество"
+                    "тоска",
+                    "молиться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
-                    "защищать",
-                    "страх",
+                    "страдать",
                     "забота",
-                    "тоска"
+                    "тоска",
+                    "молиться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
-                    "известие",
-                    "страдать",
-                    "одиночество",
-                    "молиться"
+                    "страх",
+                    "молиться",
+                    "тоска",
+                    "защищать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3870,9 +3903,9 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "спасать",
-                    "возвращаться",
                     "битва",
+                    "возвращаться",
+                    "спасать",
                     "борьба"
                 ],
                 "correctIndex": 1
@@ -3880,40 +3913,40 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "возвращаться",
-                    "борьба",
+                    "битва",
                     "спасать",
-                    "битва"
+                    "возвращаться",
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "справедливость",
+                    "армия",
                     "борьба",
-                    "спасать",
-                    "храбрый"
+                    "возвращаться",
+                    "спасать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "битва",
-                    "борьба",
                     "армия",
-                    "справедливость"
+                    "битва",
+                    "справедливость",
+                    "побеждать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
-                    "битва",
+                    "армия",
                     "храбрый",
-                    "борьба",
-                    "армия"
+                    "спасать",
+                    "возвращаться"
                 ],
                 "correctIndex": 1
             },
@@ -3922,30 +3955,30 @@
                 "choices": [
                     "справедливость",
                     "битва",
-                    "спасать",
-                    "борьба"
+                    "побеждать",
+                    "храбрый"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "армия",
+                    "храбрый",
+                    "возвращаться",
                     "борьба",
-                    "побеждать",
-                    "спасать"
+                    "побеждать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
-                    "спасать",
                     "справедливость",
-                    "храбрый",
-                    "армия"
+                    "армия",
+                    "побеждать",
+                    "битва"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4487,82 +4520,82 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "слёзы",
-                    "узнавать",
+                    "прощать",
                     "обнимать",
-                    "прощать"
+                    "узнавать",
+                    "слёзы"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
-                    "обнимать",
-                    "слёзы",
                     "прощать",
-                    "узнавать"
+                    "узнавать",
+                    "обнимать",
+                    "слёзы"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "раскаяние",
                     "прощение",
+                    "исцелять",
                     "обнимать",
-                    "узнавать"
+                    "нежный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "прощение",
-                    "обнимать",
                     "узнавать",
-                    "прощать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «heilen»?",
-                "choices": [
-                    "исцелять",
+                    "прощать",
                     "обнимать",
-                    "нежный",
-                    "узнавать"
+                    "слёзы"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «heilen»?",
+                "choices": [
+                    "слёзы",
+                    "нежный",
+                    "исцелять",
+                    "обнимать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "обнимать",
+                    "нежный",
                     "раскаяние",
-                    "прощение",
-                    "слёзы"
+                    "прощать",
+                    "узнавать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
-                    "обнимать",
-                    "исцелять",
+                    "нежный",
                     "слёзы",
-                    "нежный"
+                    "обнимать",
+                    "прощать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
-                    "обнимать",
-                    "раскаяние",
                     "исцелять",
-                    "прощение"
+                    "прощение",
+                    "раскаяние",
+                    "слёзы"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5091,81 +5124,81 @@
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
                     "пленный",
+                    "тюрьма",
                     "достоинство",
-                    "утешать",
-                    "тюрьма"
+                    "утешать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
-                    "достоинство",
-                    "тюрьма",
+                    "утешать",
                     "пленный",
-                    "утешать"
+                    "тюрьма",
+                    "достоинство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
-                    "смирение",
                     "достоинство",
+                    "честь",
                     "отважный",
-                    "утешать"
+                    "смирение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
+                    "смирение",
                     "достоинство",
-                    "судьба",
-                    "отважный",
-                    "утешать"
+                    "утешать",
+                    "пленный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
                     "отважный",
+                    "смирение",
                     "честь",
-                    "пленный",
-                    "тюрьма"
+                    "судьба"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
-                    "смирение",
+                    "достоинство",
                     "утешать",
-                    "тюрьма",
-                    "пленный"
+                    "смирение",
+                    "честь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
+                    "смирение",
+                    "тюрьма",
                     "судьба",
-                    "честь",
-                    "утешать",
-                    "тюрьма"
+                    "честь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
                     "смирение",
-                    "судьба",
-                    "утешать",
-                    "честь"
+                    "тюрьма",
+                    "честь",
+                    "пленный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5727,20 +5760,20 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "смерть",
                     "душа",
+                    "смерть",
                     "умирать",
                     "жертва"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "жертва",
-                    "смерть",
+                    "душа",
                     "умирать",
-                    "душа"
+                    "смерть"
                 ],
                 "correctIndex": 2
             },
@@ -5748,8 +5781,8 @@
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
                     "смерть",
+                    "умирать",
                     "прощание",
-                    "спасение",
                     "жертва"
                 ],
                 "correctIndex": 3
@@ -5757,48 +5790,48 @@
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
-                    "смерть",
                     "душа",
-                    "спасение",
-                    "умирать"
+                    "жертва",
+                    "умирать",
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "конец",
-                    "вечный",
                     "спасение",
-                    "жертва"
+                    "вечный",
+                    "смерть",
+                    "конец"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "вечный",
-                    "спасение",
-                    "жертва",
-                    "конец"
+                    "смерть",
+                    "конец",
+                    "прощание",
+                    "вечный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "смерть",
-                    "спасение",
-                    "прощание",
-                    "жертва"
+                    "умирать",
+                    "конец",
+                    "душа",
+                    "прощание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
+                    "жертва",
                     "смерть",
-                    "умирать",
                     "спасение",
                     "прощание"
                 ],
@@ -5923,6 +5956,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6456,6 +6860,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -6510,6 +6915,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -6539,6 +6945,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6602,6 +7009,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6610,6 +7019,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6628,6 +7038,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6676,6 +7088,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6694,6 +7128,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6770,100 +7207,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6872,7 +7261,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6985,6 +7378,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -7034,6 +7429,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7781,6 +8178,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7797,6 +8239,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Корнуолла</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Корнуолла</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="ambitious_duke">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="ambitious_duke">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="cruel_husband">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="tyrant">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="punishment">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="torturer">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="wounded">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="death">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["жадность", "желать", "честолюбие", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "стремиться", "честолюбие", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["стремиться", "вожделеть", "властолюбие", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["стремиться", "вожделеть", "желать", "властолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["захватывать", "властолюбие", "вожделеть", "стремиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["захватывать", "честолюбие", "вожделеть", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "вожделеть", "захватывать", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["захватывать", "честолюбие", "жадный", "вожделеть"], "correct_index": 0}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["поддерживать", "злоба", "жестокость", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["жестокость", "поддерживать", "одобрять", "злоба"], "correct_index": 3}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["поддерживать", "жестокость", "одобрять", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["одобрять", "поддерживать", "злоба", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["суровость", "подстрекать", "поощрять", "поддерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["злоба", "поддерживать", "жестокость", "поощрять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["поддерживать", "одобрять", "поощрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["угнетение", "подавлять", "страх", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["тирания", "угнетение", "страх", "подавлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["брутальный", "произвол", "тирания", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["страх", "произвол", "подавлять", "порабощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["произвол", "угнетение", "порабощать", "брутальный"], "correct_index": 2}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["произвол", "принуждать", "подавлять", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["брутальный", "тирания", "страх", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["тирания", "произвол", "брутальный", "угнетение"], "correct_index": 2}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["карать", "гнев", "наказывать", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "наказание", "наказывать", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["мучить", "карать", "унижать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["карать", "наказывать", "наказание", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["мучить", "наказание", "унижать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["карать", "унижать", "наказание", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["карать", "мучить", "наказывать", "наказание"], "correct_index": 1}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "пытка", "пытать", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["кровь", "садизм", "пытка", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["кровь", "мука", "садизм", "выкалывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["пытать", "ослеплять", "кровь", "мука"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытать", "пытка", "мука", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "калечить", "кровь", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["садизм", "ослеплять", "выкалывать", "мука"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["садизм", "ослеплять", "выкалывать", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["рана", "удивление", "кровоточить", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "удивление", "кровоточить", "рана"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["удивление", "страдать", "боль", "раненый"], "correct_index": 0}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["кровоточить", "ослаблять", "раненый", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["кровоточить", "страдать", "раненый", "ослаблять"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "рана", "удивление", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["раненый", "страдать", "боль", "ослаблять"], "correct_index": 1}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "возмездие", "смерть", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "возмездие", "смерть", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["возмездие", "издыхать", "конец", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "возмездие", "кара", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "хрипеть", "проклинать", "кара"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["конец", "кара", "умирать", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["возмездие", "хрипеть", "смерть", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возмездие", "конец", "смерть", "кара"], "correct_index": 3}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="ambitious_duke">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «streben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">властолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стремиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="cruel_husband">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="tyrant">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">произвол</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="punishment">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="torturer">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="wounded">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="death">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="cruel_husband">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="ambitious_duke">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="cruel_husband">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="tyrant">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="punishment">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="torturer">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="wounded">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="death">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="tyrant">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="punishment">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="torturer">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="wounded">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="death">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="ambitious_duke">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="cruel_husband">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="tyrant">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="punishment">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="torturer">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="wounded">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="death">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["стремиться", "желать", "честолюбие", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["честолюбие", "жадность", "стремиться", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «streben»?", "choices": ["жадный", "стремиться", "честолюбие", "вожделеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["захватывать", "желать", "жадность", "честолюбие"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["захватывать", "жадность", "властолюбие", "вожделеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["жадный", "честолюбие", "вожделеть", "захватывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "вожделеть", "захватывать", "жадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["захватывать", "вожделеть", "стремиться", "жадный"], "correct_index": 0}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["одобрять", "жестокость", "поддерживать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "жестокость", "злоба", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["суровость", "одобрять", "поддерживать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["одобрять", "злоба", "поддерживать", "поощрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["подстрекать", "одобрять", "поощрять", "поддерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["суровость", "поддерживать", "поощрять", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "суровость", "одобрять", "подстрекать"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["страх", "угнетение", "подавлять", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["подавлять", "угнетение", "тирания", "страх"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["страх", "тирания", "произвол", "подавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["брутальный", "подавлять", "принуждать", "порабощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["угнетение", "тирания", "порабощать", "произвол"], "correct_index": 2}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["угнетение", "принуждать", "брутальный", "произвол"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["произвол", "принуждать", "страх", "угнетение"], "correct_index": 0}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["брутальный", "угнетение", "подавлять", "порабощать"], "correct_index": 0}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["наказание", "гнев", "карать", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "наказание", "наказывать", "карать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["карать", "унижать", "унижать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["гнев", "наказывать", "унижать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["наказывать", "карать", "унижать", "мучить"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "наказание", "наказывать", "мучить"], "correct_index": 0}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "карать", "наказывать", "мучить"], "correct_index": 3}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытать", "пытка", "кровь", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "пытать", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["кровь", "выкалывать", "мука", "калечить"], "correct_index": 0}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["пытка", "калечить", "пытать", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["ослеплять", "пытка", "калечить", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "пытка", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытать", "садизм", "ослеплять", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["калечить", "мука", "пытать", "выкалывать"], "correct_index": 1}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["удивление", "боль", "кровоточить", "рана"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["удивление", "кровоточить", "боль", "рана"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["удивление", "кровоточить", "боль", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["рана", "кровоточить", "страдать", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["страдать", "рана", "удивление", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "ослаблять", "страдать", "удивление"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["ослаблять", "страдать", "удивление", "раненый"], "correct_index": 1}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["умирать", "конец", "возмездие", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["смерть", "возмездие", "конец", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "хрипеть", "кара", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["конец", "издыхать", "смерть", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "кара", "возмездие", "хрипеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["кара", "возмездие", "смерть", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["конец", "возмездие", "хрипеть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["кара", "возмездие", "смерть", "проклинать"], "correct_index": 0}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="ambitious_duke">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «streben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="cruel_husband">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="tyrant">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">произвол</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подавлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">порабощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">произвол</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порабощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="punishment">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «bestrafen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="torturer">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">калечить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мука</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="wounded">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bluten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослаблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="death">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кара</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1952,62 +1985,62 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "стремиться",
+                    "жадность",
                     "желать",
                     "честолюбие",
-                    "жадность"
+                    "стремиться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "честолюбие",
                     "жадность",
                     "стремиться",
+                    "честолюбие",
                     "желать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
-                    "жадный",
                     "стремиться",
-                    "честолюбие",
-                    "вожделеть"
+                    "вожделеть",
+                    "властолюбие",
+                    "желать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
-                    "захватывать",
+                    "стремиться",
+                    "вожделеть",
                     "желать",
-                    "жадность",
-                    "честолюбие"
+                    "властолюбие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
                     "захватывать",
-                    "жадность",
                     "властолюбие",
-                    "вожделеть"
+                    "вожделеть",
+                    "стремиться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
-                    "жадный",
+                    "захватывать",
                     "честолюбие",
                     "вожделеть",
-                    "захватывать"
+                    "жадный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
@@ -2015,7 +2048,7 @@
                     "властолюбие",
                     "вожделеть",
                     "захватывать",
-                    "жадный"
+                    "жадность"
                 ],
                 "correctIndex": 0
             },
@@ -2023,9 +2056,9 @@
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
                     "захватывать",
-                    "вожделеть",
-                    "стремиться",
-                    "жадный"
+                    "честолюбие",
+                    "жадный",
+                    "вожделеть"
                 ],
                 "correctIndex": 0
             }
@@ -2485,72 +2518,72 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "одобрять",
-                    "жестокость",
                     "поддерживать",
-                    "злоба"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "одобрять",
-                    "жестокость",
                     "злоба",
-                    "поддерживать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «billigen»?",
-                "choices": [
-                    "суровость",
-                    "одобрять",
-                    "поддерживать",
-                    "жестокость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «unterstützen»?",
-                "choices": [
-                    "одобрять",
-                    "злоба",
-                    "поддерживать",
-                    "поощрять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «anstacheln»?",
-                "choices": [
-                    "подстрекать",
-                    "одобрять",
-                    "поощрять",
-                    "поддерживать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «ermutigen»?",
-                "choices": [
-                    "суровость",
-                    "поддерживать",
-                    "поощрять",
+                    "жестокость",
                     "одобрять"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Härte»?",
+                "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "злоба",
-                    "суровость",
+                    "жестокость",
+                    "поддерживать",
                     "одобрять",
-                    "подстрекать"
+                    "злоба"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «billigen»?",
+                "choices": [
+                    "поддерживать",
+                    "жестокость",
+                    "одобрять",
+                    "злоба"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «unterstützen»?",
+                "choices": [
+                    "одобрять",
+                    "поддерживать",
+                    "злоба",
+                    "жестокость"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «anstacheln»?",
+                "choices": [
+                    "суровость",
+                    "подстрекать",
+                    "поощрять",
+                    "поддерживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ermutigen»?",
+                "choices": [
+                    "злоба",
+                    "поддерживать",
+                    "жестокость",
+                    "поощрять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Härte»?",
+                "choices": [
+                    "поддерживать",
+                    "одобрять",
+                    "поощрять",
+                    "суровость"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3010,9 +3043,9 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
-                    "страх",
                     "угнетение",
                     "подавлять",
+                    "страх",
                     "тирания"
                 ],
                 "correctIndex": 3
@@ -3020,72 +3053,72 @@
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "подавлять",
-                    "угнетение",
                     "тирания",
-                    "страх"
+                    "угнетение",
+                    "страх",
+                    "подавлять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
-                    "страх",
-                    "тирания",
+                    "брутальный",
                     "произвол",
-                    "подавлять"
+                    "тирания",
+                    "страх"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unterdrücken»?",
                 "choices": [
-                    "брутальный",
+                    "страх",
+                    "произвол",
                     "подавлять",
-                    "принуждать",
                     "порабощать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
+                    "произвол",
                     "угнетение",
-                    "тирания",
                     "порабощать",
-                    "произвол"
+                    "брутальный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
-                    "угнетение",
+                    "произвол",
                     "принуждать",
-                    "брутальный",
-                    "произвол"
+                    "подавлять",
+                    "страх"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "произвол",
-                    "принуждать",
+                    "брутальный",
+                    "тирания",
                     "страх",
-                    "угнетение"
+                    "произвол"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
+                    "тирания",
+                    "произвол",
                     "брутальный",
-                    "угнетение",
-                    "подавлять",
-                    "порабощать"
+                    "угнетение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3533,12 +3566,12 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "наказание",
-                    "гнев",
                     "карать",
-                    "наказывать"
+                    "гнев",
+                    "наказывать",
+                    "наказание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
@@ -3553,52 +3586,52 @@
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
+                    "мучить",
                     "карать",
                     "унижать",
-                    "унижать",
-                    "наказание"
+                    "гнев"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
-                    "гнев",
+                    "карать",
                     "наказывать",
-                    "унижать",
-                    "мучить"
+                    "наказание",
+                    "унижать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "наказывать",
-                    "карать",
+                    "мучить",
+                    "наказание",
                     "унижать",
-                    "мучить"
+                    "гнев"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
+                    "карать",
                     "унижать",
                     "наказание",
-                    "наказывать",
-                    "мучить"
+                    "гнев"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "унижать",
                     "карать",
+                    "мучить",
                     "наказывать",
-                    "мучить"
+                    "наказание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4097,82 +4130,82 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытать",
+                    "садизм",
                     "пытка",
-                    "кровь",
-                    "садизм"
+                    "пытать",
+                    "кровь"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "пытка",
-                    "пытать",
+                    "кровь",
                     "садизм",
-                    "кровь"
+                    "пытка",
+                    "пытать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
                     "кровь",
-                    "выкалывать",
                     "мука",
-                    "калечить"
+                    "садизм",
+                    "выкалывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "пытка",
-                    "калечить",
                     "пытать",
-                    "ослеплять"
+                    "ослеплять",
+                    "кровь",
+                    "мука"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "ослеплять",
-                    "пытка",
-                    "калечить",
-                    "кровь"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «blenden»?",
-                "choices": [
-                    "садизм",
-                    "пытка",
-                    "ослеплять",
-                    "выкалывать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «ausstechen»?",
-                "choices": [
                     "пытать",
-                    "садизм",
-                    "ослеплять",
-                    "выкалывать"
+                    "пытка",
+                    "мука",
+                    "калечить"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «blenden»?",
+                "choices": [
+                    "выкалывать",
+                    "калечить",
+                    "кровь",
+                    "ослеплять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «ausstechen»?",
+                "choices": [
+                    "садизм",
+                    "ослеплять",
+                    "выкалывать",
+                    "мука"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "калечить",
-                    "мука",
-                    "пытать",
-                    "выкалывать"
+                    "садизм",
+                    "ослеплять",
+                    "выкалывать",
+                    "мука"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4598,70 +4631,70 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
+                    "рана",
                     "удивление",
-                    "боль",
                     "кровоточить",
-                    "рана"
+                    "боль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
+                    "боль",
                     "удивление",
                     "кровоточить",
-                    "боль",
                     "рана"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
                     "удивление",
-                    "кровоточить",
+                    "страдать",
                     "боль",
-                    "страдать"
+                    "раненый"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
-                    "рана",
                     "кровоточить",
-                    "страдать",
-                    "боль"
+                    "ослаблять",
+                    "раненый",
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
+                    "кровоточить",
                     "страдать",
-                    "рана",
-                    "удивление",
-                    "раненый"
+                    "раненый",
+                    "ослаблять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
                     "кровоточить",
-                    "ослаблять",
-                    "страдать",
-                    "удивление"
+                    "рана",
+                    "удивление",
+                    "ослаблять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "ослаблять",
+                    "раненый",
                     "страдать",
-                    "удивление",
-                    "раненый"
+                    "боль",
+                    "ослаблять"
                 ],
                 "correctIndex": 1
             }
@@ -5141,58 +5174,58 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "умирать",
-                    "конец",
                     "возмездие",
-                    "смерть"
+                    "смерть",
+                    "конец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
-                    "смерть",
+                    "умирать",
                     "возмездие",
-                    "конец",
-                    "умирать"
+                    "смерть",
+                    "конец"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
+                    "возмездие",
+                    "издыхать",
                     "конец",
-                    "хрипеть",
-                    "кара",
                     "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "конец",
-                    "издыхать",
-                    "смерть",
-                    "умирать"
+                    "умирать",
+                    "возмездие",
+                    "кара",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
                     "издыхать",
-                    "кара",
-                    "возмездие",
-                    "хрипеть"
+                    "хрипеть",
+                    "проклинать",
+                    "кара"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
+                    "конец",
                     "кара",
-                    "возмездие",
-                    "смерть",
+                    "умирать",
                     "проклинать"
                 ],
                 "correctIndex": 3
@@ -5200,22 +5233,22 @@
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
-                    "конец",
                     "возмездие",
                     "хрипеть",
+                    "смерть",
                     "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "кара",
                     "возмездие",
+                    "конец",
                     "смерть",
-                    "проклинать"
+                    "кара"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5321,6 +5354,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5854,6 +6258,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5908,6 +6313,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5937,6 +6343,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6000,6 +6407,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6008,6 +6417,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6026,6 +6436,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6074,6 +6486,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6092,6 +6526,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6168,100 +6605,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6270,7 +6659,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6383,6 +6776,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6432,6 +6827,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7179,6 +7576,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7195,6 +7637,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Превращение Эдгара</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Превращение Эдгара</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1427 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "наследник", "королевство", "знать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["знать", "доверять", "наследник", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["доверять", "наследник", "королевство", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["наследник", "законный", "честь", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["знать", "честь", "наследник", "ничего не подозревающий"], "correct_index": 1}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "ничего не подозревающий", "честь", "наследник"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["королевство", "граф", "законный", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["королевство", "доверять", "ничего не подозревающий", "наследник"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["предательство", "бежать", "преследовать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["опасность", "бежать", "преследовать", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "обман", "интрига", "преследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "изгнать", "предательство", "бежать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["интрига", "прятаться", "изгнать", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "преследовать", "бежать", "изгнать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["предательство", "обман", "изгнать", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["предательство", "изгнать", "опасность", "прятаться"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["маскировка", "нищий", "безумие", "голый"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "маскировка", "нищий", "голый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["безумие", "маскировка", "голый", "нищета"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["голый", "безумный", "нищета", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["бормотать", "безумный", "голый", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["безумный", "нищий", "дрожать", "нищета"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["бормотать", "голый", "дрожать", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "безумный", "бормотать", "нищий"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["страдать", "хижина", "мёрзнуть", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "буря", "страдать", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["буря", "гром", "сопровождать", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["сопровождать", "хижина", "мёрзнуть", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "буря", "мёрзнуть", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "защищать", "страдать", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["страдать", "гром", "мёрзнуть", "молния"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["сопровождать", "молния", "гром", "мёрзнуть"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "слепой", "утёс", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «führen»?", "choices": ["слепой", "вести", "утёс", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "отчаяние", "спасать", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["утёс", "обманывать", "слепой", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «retten»?", "choices": ["вести", "слепой", "утешать", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["утёс", "хитрость", "вести", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["отчаяние", "утешать", "вести", "спасать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["утёс", "утешать", "вести", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "разоблачать", "дуэль", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "бой", "месть", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["бой", "месть", "дуэль", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["месть", "дуэль", "меч", "разоблачать"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["разоблачать", "бой", "брат", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["разоблачать", "справедливость", "бой", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["меч", "брат", "разоблачать", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["брат", "месть", "меч", "бой"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "выживать", "наследовать", "будущее"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["будущее", "выживать", "наследовать", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["наследовать", "ответственность", "будущее", "выживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["ответственность", "порядок", "править", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "новый", "мудрость", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["новый", "порядок", "править", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["ответственность", "наследовать", "править", "новый"], "correct_index": 0}, {"question": "Что означает немецкое слово «neu»?", "choices": ["править", "ответственность", "выживать", "новый"], "correct_index": 3}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «führen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,971 +1639,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["наследник", "знать", "королевство", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["знать", "королевство", "доверять", "наследник"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["королевство", "честь", "граф", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["законный", "королевство", "доверять", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["знать", "ничего не подозревающий", "честь", "законный"], "correct_index": 2}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["ничего не подозревающий", "законный", "наследник", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["доверять", "граф", "законный", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["граф", "доверять", "знать", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "опасность", "бежать", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["преследовать", "опасность", "предательство", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["обман", "опасность", "интрига", "бежать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["изгнать", "предательство", "интрига", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["преследовать", "интрига", "изгнать", "прятаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "изгнать", "предательство", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "предательство", "изгнать", "прятаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["опасность", "прятаться", "преследовать", "изгнать"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "безумие", "нищий", "маскировка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["безумие", "голый", "маскировка", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["бормотать", "дрожать", "маскировка", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["нищий", "голый", "дрожать", "бормотать"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["безумие", "дрожать", "бормотать", "голый"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["голый", "маскировка", "бормотать", "дрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["дрожать", "нищета", "нищий", "бормотать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "безумие", "бормотать", "безумный"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["хижина", "страдать", "мёрзнуть", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["буря", "хижина", "страдать", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["хижина", "мёрзнуть", "молния", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["буря", "молния", "защищать", "хижина"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["хижина", "защищать", "мёрзнуть", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["молния", "хижина", "сопровождать", "гром"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["хижина", "молния", "сопровождать", "гром"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["буря", "молния", "гром", "мёрзнуть"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "утёс", "слепой", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «führen»?", "choices": ["слепой", "утёс", "обманывать", "вести"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["хитрость", "обманывать", "утёс", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "утёс", "спасать", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «retten»?", "choices": ["слепой", "спасать", "утешать", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["отчаяние", "хитрость", "утёс", "слепой"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "хитрость", "утёс", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["обманывать", "отчаяние", "слепой", "спасать"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "бой", "месть", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "дуэль", "бой", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["дуэль", "побеждать", "месть", "меч"], "correct_index": 2}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["разоблачать", "дуэль", "брат", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["бой", "побеждать", "месть", "справедливость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["разоблачать", "бой", "справедливость", "побеждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["дуэль", "меч", "разоблачать", "бой"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["бой", "брат", "месть", "справедливость"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["править", "выживать", "будущее", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["будущее", "выживать", "править", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["будущее", "новый", "наследовать", "выживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["править", "мудрость", "порядок", "наследовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["будущее", "мудрость", "наследовать", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["мудрость", "наследовать", "порядок", "ответственность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["мудрость", "ответственность", "наследовать", "порядок"], "correct_index": 1}, {"question": "Что означает немецкое слово «neu»?", "choices": ["править", "ответственность", "выживать", "новый"], "correct_index": 3}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">законный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прятаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прятаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «blind»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «führen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">меч</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брат</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разоблачать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «überleben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «neu»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1996,67 +2029,67 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
+                    "доверять",
                     "наследник",
-                    "знать",
                     "королевство",
-                    "доверять"
+                    "знать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
                     "знать",
-                    "королевство",
                     "доверять",
-                    "наследник"
+                    "наследник",
+                    "королевство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
+                    "доверять",
+                    "наследник",
                     "королевство",
-                    "честь",
-                    "граф",
-                    "знать"
+                    "граф"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
+                    "наследник",
                     "законный",
-                    "королевство",
-                    "доверять",
-                    "наследник"
+                    "честь",
+                    "доверять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
                     "знать",
-                    "ничего не подозревающий",
                     "честь",
-                    "законный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «legitim»?",
-                "choices": [
-                    "ничего не подозревающий",
-                    "законный",
                     "наследник",
-                    "знать"
+                    "ничего не подозревающий"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «legitim»?",
+                "choices": [
+                    "законный",
+                    "ничего не подозревающий",
+                    "честь",
+                    "наследник"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "доверять",
+                    "королевство",
                     "граф",
                     "законный",
                     "знать"
@@ -2066,12 +2099,12 @@
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
-                    "граф",
+                    "королевство",
                     "доверять",
-                    "знать",
-                    "ничего не подозревающий"
+                    "ничего не подозревающий",
+                    "наследник"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2537,82 +2570,82 @@
             {
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
-                    "преследовать",
-                    "опасность",
-                    "бежать",
-                    "предательство"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Verrat»?",
-                "choices": [
-                    "преследовать",
-                    "опасность",
                     "предательство",
-                    "бежать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Gefahr»?",
-                "choices": [
-                    "обман",
-                    "опасность",
-                    "интрига",
-                    "бежать"
+                    "бежать",
+                    "преследовать",
+                    "опасность"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verfolgen»?",
+                "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "изгнать",
-                    "предательство",
-                    "интрига",
-                    "преследовать"
+                    "опасность",
+                    "бежать",
+                    "преследовать",
+                    "предательство"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «verstecken»?",
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "опасность",
+                    "обман",
+                    "интрига",
+                    "преследовать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "преследовать",
-                    "интрига",
                     "изгнать",
-                    "прятаться"
+                    "предательство",
+                    "бежать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verstecken»?",
+                "choices": [
+                    "интрига",
+                    "прятаться",
+                    "изгнать",
+                    "обман"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
                     "интрига",
-                    "изгнать",
-                    "предательство",
-                    "обман"
+                    "преследовать",
+                    "бежать",
+                    "изгнать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "обман",
                     "предательство",
+                    "обман",
                     "изгнать",
-                    "прятаться"
+                    "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
+                    "предательство",
+                    "изгнать",
                     "опасность",
-                    "прятаться",
-                    "преследовать",
-                    "изгнать"
+                    "прятаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3103,82 +3136,82 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "голый",
-                    "безумие",
-                    "нищий",
-                    "маскировка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Bettler»?",
-                "choices": [
-                    "безумие",
-                    "голый",
                     "маскировка",
-                    "нищий"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Verkleidung»?",
-                "choices": [
-                    "бормотать",
-                    "дрожать",
-                    "маскировка",
-                    "нищий"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «nackt»?",
-                "choices": [
                     "нищий",
-                    "голый",
-                    "дрожать",
-                    "бормотать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «murmeln»?",
-                "choices": [
                     "безумие",
-                    "дрожать",
-                    "бормотать",
                     "голый"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «zittern»?",
+                "question": "Что означает немецкое слово «der Bettler»?",
+                "choices": [
+                    "безумие",
+                    "маскировка",
+                    "нищий",
+                    "голый"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Verkleidung»?",
+                "choices": [
+                    "безумие",
+                    "маскировка",
+                    "голый",
+                    "нищета"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
                     "голый",
-                    "маскировка",
-                    "бормотать",
-                    "дрожать"
+                    "безумный",
+                    "нищета",
+                    "безумие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «murmeln»?",
+                "choices": [
+                    "бормотать",
+                    "безумный",
+                    "голый",
+                    "нищий"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «zittern»?",
+                "choices": [
+                    "безумный",
+                    "нищий",
+                    "дрожать",
+                    "нищета"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
+                    "бормотать",
+                    "голый",
                     "дрожать",
-                    "нищета",
-                    "нищий",
-                    "бормотать"
+                    "нищета"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
                     "дрожать",
-                    "безумие",
+                    "безумный",
                     "бормотать",
-                    "безумный"
+                    "нищий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3680,8 +3713,8 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "хижина",
                     "страдать",
+                    "хижина",
                     "мёрзнуть",
                     "буря"
                 ],
@@ -3690,19 +3723,19 @@
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
+                    "мёрзнуть",
                     "буря",
-                    "хижина",
                     "страдать",
-                    "мёрзнуть"
+                    "хижина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "хижина",
-                    "мёрзнуть",
-                    "молния",
+                    "буря",
+                    "гром",
+                    "сопровождать",
                     "страдать"
                 ],
                 "correctIndex": 3
@@ -3710,47 +3743,47 @@
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "буря",
-                    "молния",
-                    "защищать",
-                    "хижина"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «beschützen»?",
-                "choices": [
+                    "сопровождать",
                     "хижина",
-                    "защищать",
                     "мёрзнуть",
-                    "гром"
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «beschützen»?",
+                "choices": [
+                    "защищать",
+                    "буря",
+                    "мёрзнуть",
+                    "хижина"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "молния",
-                    "хижина",
                     "сопровождать",
+                    "защищать",
+                    "страдать",
                     "гром"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "хижина",
-                    "молния",
-                    "сопровождать",
-                    "гром"
+                    "страдать",
+                    "гром",
+                    "мёрзнуть",
+                    "молния"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "буря",
+                    "сопровождать",
                     "молния",
                     "гром",
                     "мёрзнуть"
@@ -4247,81 +4280,81 @@
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
                     "вести",
-                    "утёс",
                     "слепой",
+                    "утёс",
                     "обманывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
                     "слепой",
+                    "вести",
                     "утёс",
-                    "обманывать",
-                    "вести"
+                    "обманывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
-                    "хитрость",
-                    "обманывать",
                     "утёс",
-                    "отчаяние"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "обманывать",
-                    "утёс",
+                    "отчаяние",
                     "спасать",
-                    "отчаяние"
+                    "хитрость"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «retten»?",
+                "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
+                    "утёс",
+                    "обманывать",
                     "слепой",
-                    "спасать",
-                    "утешать",
                     "хитрость"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «retten»?",
+                "choices": [
+                    "вести",
+                    "слепой",
+                    "утешать",
+                    "спасать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "отчаяние",
-                    "хитрость",
                     "утёс",
-                    "слепой"
+                    "хитрость",
+                    "вести",
+                    "спасать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
+                    "отчаяние",
                     "утешать",
-                    "хитрость",
-                    "утёс",
+                    "вести",
                     "спасать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "обманывать",
-                    "отчаяние",
-                    "слепой",
-                    "спасать"
+                    "утёс",
+                    "утешать",
+                    "вести",
+                    "отчаяние"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4792,82 +4825,82 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "разоблачать",
                     "бой",
-                    "месть",
-                    "дуэль"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Duell»?",
-                "choices": [
                     "разоблачать",
                     "дуэль",
-                    "бой",
-                    "месть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "дуэль",
-                    "побеждать",
-                    "месть",
-                    "меч"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «enthüllen»?",
-                "choices": [
-                    "разоблачать",
-                    "дуэль",
-                    "брат",
                     "месть"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «siegen»?",
+                "question": "Что означает немецкое слово «das Duell»?",
+                "choices": [
+                    "разоблачать",
+                    "бой",
+                    "месть",
+                    "дуэль"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "бой",
-                    "побеждать",
                     "месть",
-                    "справедливость"
+                    "дуэль",
+                    "побеждать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "месть",
+                    "дуэль",
+                    "меч",
+                    "разоблачать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «siegen»?",
+                "choices": [
+                    "разоблачать",
+                    "бой",
+                    "брат",
+                    "побеждать"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "разоблачать",
-                    "бой",
                     "справедливость",
-                    "побеждать"
+                    "бой",
+                    "месть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
-                    "дуэль",
                     "меч",
+                    "брат",
                     "разоблачать",
-                    "бой"
+                    "месть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "бой",
                     "брат",
                     "месть",
-                    "справедливость"
+                    "меч",
+                    "бой"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5353,8 +5386,8 @@
                 "choices": [
                     "править",
                     "выживать",
-                    "будущее",
-                    "наследовать"
+                    "наследовать",
+                    "будущее"
                 ],
                 "correctIndex": 1
             },
@@ -5363,60 +5396,60 @@
                 "choices": [
                     "будущее",
                     "выживать",
-                    "править",
-                    "наследовать"
+                    "наследовать",
+                    "править"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zukunft»?",
                 "choices": [
-                    "будущее",
-                    "новый",
                     "наследовать",
+                    "ответственность",
+                    "будущее",
                     "выживать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "править",
-                    "мудрость",
+                    "ответственность",
                     "порядок",
-                    "наследовать"
+                    "править",
+                    "мудрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "будущее",
+                    "новый",
                     "мудрость",
-                    "наследовать",
-                    "выживать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Ordnung»?",
-                "choices": [
-                    "мудрость",
-                    "наследовать",
-                    "порядок",
-                    "ответственность"
+                    "править"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Verantwortung»?",
+                "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
-                    "мудрость",
-                    "ответственность",
-                    "наследовать",
-                    "порядок"
+                    "новый",
+                    "порядок",
+                    "править",
+                    "наследовать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Verantwortung»?",
+                "choices": [
+                    "ответственность",
+                    "наследовать",
+                    "править",
+                    "новый"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «neu»?",
@@ -5531,6 +5564,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6064,6 +6468,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -6118,6 +6523,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -6147,6 +6553,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6210,6 +6617,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6218,6 +6627,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6236,6 +6646,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6284,6 +6696,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6302,6 +6736,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6378,100 +6815,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6480,7 +6869,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6593,6 +6986,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6642,6 +7037,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7389,6 +7786,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7405,6 +7847,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Эдмунда</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Эдмунда</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1427 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "бастард", "зависть", "амбиция"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["обделённый", "бастард", "зависть", "амбиция"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["обделённый", "месть", "зависть", "амбиция"], "correct_index": 3}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["обделённый", "природа", "бастард", "возвышаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["бастард", "месть", "обделённый", "природа"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["возвышаться", "обделённый", "амбиция", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["обделённый", "амбиция", "возвышаться", "внебрачный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["внебрачный", "амбиция", "зависть", "природа"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["обвинять", "план", "подделывать", "интриговать"], "correct_index": 2}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["интриговать", "план", "обвинять", "подделывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обвинять", "письмо", "манипулировать", "лгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "лгать", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["интриговать", "манипулировать", "лгать", "подделывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["план", "интриговать", "лгать", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["манипулировать", "письмо", "интриговать", "лгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["подделывать", "обвинять", "письмо", "обман"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "торжествовать", "наследовать", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "изгонять", "торжествовать", "успех"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "награда", "выигрывать", "вытеснять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["выигрывать", "награда", "победа", "успех"], "correct_index": 3}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["награда", "выигрывать", "наследовать", "вытеснять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["награда", "выигрывать", "вытеснять", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["торжествовать", "вытеснять", "успех", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["победа", "изгонять", "торжествовать", "вытеснять"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "союз", "объединяться", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "союз", "завоёвывать", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоевание", "соблазнять", "завоёвывать", "альянс"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "завоёвывать", "союз", "альянс"], "correct_index": 2}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["власть", "завоевание", "соблазнять", "объединяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["альянс", "союз", "господствовать", "завоевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["объединяться", "господствовать", "завоёвывать", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["власть", "союз", "альянс", "завоёвывать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "предавать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["доносить", "предавать", "ослеплять", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "пытка", "выдавать", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["ослеплять", "доносить", "предавать", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["выдавать", "доносить", "пытка", "беспощадный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "доносить", "пытка", "беспощадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["предавать", "выдавать", "жертвовать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "предавать", "ослеплять", "доносить"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["любовная связь", "соперничество", "завлекать", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["завлекать", "соперничество", "любовная связь", "играть"], "correct_index": 1}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["жонглировать", "похоть", "соперничество", "играть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["играть", "интрига", "использовать", "завлекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["любовная связь", "играть", "использовать", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "завлекать", "играть", "жонглировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["жонглировать", "интрига", "похоть", "завлекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "жонглировать", "соперничество", "похоть"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "падать", "поражение", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "дуэль", "сожалеть", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["падать", "сожалеть", "поражение", "падение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["сожалеть", "поражение", "конец", "проигрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["проигрывать", "падать", "признаваться", "падение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["конец", "дуэль", "проигрывать", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["конец", "поражение", "признаваться", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "дуэль", "падать", "сожалеть"], "correct_index": 0}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">внебрачный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «erben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,971 +1639,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["зависть", "амбиция", "бастард", "обделённый"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["бастард", "амбиция", "зависть", "обделённый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["природа", "амбиция", "обделённый", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["зависть", "природа", "обделённый", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["бастард", "внебрачный", "месть", "возвышаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["зависть", "возвышаться", "природа", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["обделённый", "бастард", "внебрачный", "возвышаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "природа", "месть", "обделённый"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["план", "интриговать", "обвинять", "подделывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["подделывать", "план", "интриговать", "обвинять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обвинять", "интриговать", "манипулировать", "подделывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["обман", "план", "письмо", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "письмо", "обвинять", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["манипулировать", "подделывать", "обвинять", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["интриговать", "обман", "лгать", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["манипулировать", "план", "обман", "интриговать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "изгонять", "наследовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["успех", "наследовать", "изгонять", "торжествовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erben»?", "choices": ["изгонять", "вытеснять", "выигрывать", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["успех", "победа", "наследовать", "торжествовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["выигрывать", "вытеснять", "победа", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["успех", "изгонять", "вытеснять", "награда"], "correct_index": 3}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["награда", "изгонять", "вытеснять", "выигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["победа", "наследовать", "выигрывать", "изгонять"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "завоёвывать", "союз", "объединяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "власть", "завоёвывать", "союз"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["соблазнять", "завоёвывать", "власть", "альянс"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["объединяться", "союз", "господствовать", "завоевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "объединяться", "господствовать", "завоевание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["завоевание", "соблазнять", "альянс", "господствовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["господствовать", "завоёвывать", "союз", "альянс"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["завоевание", "альянс", "объединяться", "союз"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "жестокость", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["жестокость", "доносить", "предавать", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["доносить", "предавать", "пытка", "жестокость"], "correct_index": 3}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["ослеплять", "жертвовать", "беспощадный", "доносить"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["выдавать", "доносить", "жестокость", "жертвовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["доносить", "пытка", "беспощадный", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["ослеплять", "беспощадный", "жертвовать", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["предавать", "жертвовать", "жестокость", "беспощадный"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["завлекать", "любовная связь", "играть", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["завлекать", "играть", "соперничество", "любовная связь"], "correct_index": 2}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["играть", "соперничество", "любовная связь", "похоть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["жонглировать", "завлекать", "играть", "любовная связь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["интрига", "любовная связь", "использовать", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["завлекать", "жонглировать", "использовать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["жонглировать", "играть", "интрига", "использовать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "похоть", "соперничество", "завлекать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "падать", "поражение", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "сожалеть", "дуэль", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["признаваться", "проигрывать", "сожалеть", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["проигрывать", "падение", "падать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["сожалеть", "признаваться", "проигрывать", "падать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["падение", "дуэль", "сожалеть", "признаваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["проигрывать", "признаваться", "сожалеть", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "падать", "поражение", "признаваться"], "correct_index": 0}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бастард</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">внебрачный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Natur»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">амбиция</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beschuldigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">манипулировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">план</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интриговать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Erfolg»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торжествовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">победа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Eroberung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">альянс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">господствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Allianz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жертвовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жонглировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «gestehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1995,82 +2028,82 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "зависть",
-                    "амбиция",
+                    "обделённый",
                     "бастард",
-                    "обделённый"
+                    "зависть",
+                    "амбиция"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
+                    "обделённый",
                     "бастард",
-                    "амбиция",
                     "зависть",
-                    "обделённый"
+                    "амбиция"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "природа",
-                    "амбиция",
                     "обделённый",
-                    "месть"
+                    "месть",
+                    "зависть",
+                    "амбиция"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
-                    "зависть",
-                    "природа",
                     "обделённый",
-                    "внебрачный"
+                    "природа",
+                    "бастард",
+                    "возвышаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "бастард",
-                    "внебрачный",
                     "месть",
-                    "возвышаться"
+                    "обделённый",
+                    "природа"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "зависть",
                     "возвышаться",
-                    "природа",
-                    "бастард"
+                    "обделённый",
+                    "амбиция",
+                    "месть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
                     "обделённый",
-                    "бастард",
-                    "внебрачный",
-                    "возвышаться"
+                    "амбиция",
+                    "возвышаться",
+                    "внебрачный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
+                    "внебрачный",
                     "амбиция",
-                    "природа",
-                    "месть",
-                    "обделённый"
+                    "зависть",
+                    "природа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2559,59 +2592,59 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
-                    "план",
-                    "интриговать",
                     "обвинять",
-                    "подделывать"
+                    "план",
+                    "подделывать",
+                    "интриговать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
-                    "подделывать",
-                    "план",
                     "интриговать",
-                    "обвинять"
+                    "план",
+                    "обвинять",
+                    "подделывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
                 "choices": [
                     "обвинять",
-                    "интриговать",
+                    "письмо",
                     "манипулировать",
-                    "подделывать"
+                    "лгать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "обман",
                     "план",
-                    "письмо",
-                    "манипулировать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «manipulieren»?",
-                "choices": [
-                    "манипулировать",
-                    "письмо",
-                    "обвинять",
-                    "план"
+                    "лгать",
+                    "подделывать",
+                    "обвинять"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «manipulieren»?",
+                "choices": [
+                    "интриговать",
+                    "манипулировать",
+                    "лгать",
+                    "подделывать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "манипулировать",
-                    "подделывать",
-                    "обвинять",
+                    "план",
+                    "интриговать",
+                    "лгать",
                     "письмо"
                 ],
                 "correctIndex": 3
@@ -2619,22 +2652,22 @@
             {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
+                    "манипулировать",
+                    "письмо",
                     "интриговать",
-                    "обман",
-                    "лгать",
-                    "письмо"
+                    "лгать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "манипулировать",
-                    "план",
-                    "обман",
-                    "интриговать"
+                    "подделывать",
+                    "обвинять",
+                    "письмо",
+                    "обман"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3106,80 +3139,80 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "торжествовать",
                     "изгонять",
+                    "торжествовать",
                     "наследовать",
                     "успех"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «triumphieren»?",
-                "choices": [
-                    "успех",
-                    "наследовать",
-                    "изгонять",
-                    "торжествовать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erben»?",
-                "choices": [
-                    "изгонять",
-                    "вытеснять",
-                    "выигрывать",
-                    "наследовать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Erfolg»?",
-                "choices": [
-                    "успех",
-                    "победа",
-                    "наследовать",
-                    "торжествовать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «gewinnen»?",
+                "question": "Что означает немецкое слово «triumphieren»?",
+                "choices": [
+                    "наследовать",
+                    "изгонять",
+                    "торжествовать",
+                    "успех"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «erben»?",
+                "choices": [
+                    "наследовать",
+                    "награда",
+                    "выигрывать",
+                    "вытеснять"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
                     "выигрывать",
-                    "вытеснять",
+                    "награда",
                     "победа",
+                    "успех"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «gewinnen»?",
+                "choices": [
+                    "награда",
+                    "выигрывать",
+                    "наследовать",
+                    "вытеснять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Belohnung»?",
+                "choices": [
+                    "награда",
+                    "выигрывать",
+                    "вытеснять",
                     "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Belohnung»?",
-                "choices": [
-                    "успех",
-                    "изгонять",
-                    "вытеснять",
-                    "награда"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «verdrängen»?",
                 "choices": [
-                    "награда",
-                    "изгонять",
+                    "торжествовать",
                     "вытеснять",
-                    "выигрывать"
+                    "успех",
+                    "изгонять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
                     "победа",
-                    "наследовать",
-                    "выигрывать",
-                    "изгонять"
+                    "изгонять",
+                    "торжествовать",
+                    "вытеснять"
                 ],
                 "correctIndex": 0
             }
@@ -3669,81 +3702,81 @@
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
                     "власть",
-                    "завоёвывать",
                     "союз",
-                    "объединяться"
+                    "объединяться",
+                    "завоёвывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
                     "объединяться",
-                    "власть",
+                    "союз",
                     "завоёвывать",
-                    "союз"
+                    "власть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
+                    "завоевание",
                     "соблазнять",
                     "завоёвывать",
-                    "власть",
                     "альянс"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
-                    "объединяться",
-                    "союз",
-                    "господствовать",
-                    "завоевание"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verführen»?",
-                "choices": [
                     "соблазнять",
-                    "объединяться",
-                    "господствовать",
-                    "завоевание"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Eroberung»?",
-                "choices": [
-                    "завоевание",
-                    "соблазнять",
-                    "альянс",
-                    "господствовать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «beherrschen»?",
-                "choices": [
-                    "господствовать",
                     "завоёвывать",
                     "союз",
                     "альянс"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verführen»?",
+                "choices": [
+                    "власть",
+                    "завоевание",
+                    "соблазнять",
+                    "объединяться"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Eroberung»?",
+                "choices": [
+                    "альянс",
+                    "союз",
+                    "господствовать",
+                    "завоевание"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «beherrschen»?",
+                "choices": [
+                    "объединяться",
+                    "господствовать",
+                    "завоёвывать",
+                    "союз"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
-                    "завоевание",
+                    "власть",
+                    "союз",
                     "альянс",
-                    "объединяться",
-                    "союз"
+                    "завоёвывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4268,80 +4301,80 @@
                 "choices": [
                     "доносить",
                     "ослеплять",
-                    "жестокость",
-                    "предавать"
+                    "предавать",
+                    "жестокость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "жестокость",
                     "доносить",
                     "предавать",
-                    "ослеплять"
+                    "ослеплять",
+                    "жестокость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "доносить",
-                    "предавать",
+                    "жестокость",
                     "пытка",
-                    "жестокость"
+                    "выдавать",
+                    "беспощадный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «denunzieren»?",
                 "choices": [
                     "ослеплять",
-                    "жертвовать",
-                    "беспощадный",
-                    "доносить"
+                    "доносить",
+                    "предавать",
+                    "пытка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausliefern»?",
                 "choices": [
                     "выдавать",
                     "доносить",
-                    "жестокость",
-                    "жертвовать"
+                    "пытка",
+                    "беспощадный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
+                    "ослеплять",
                     "доносить",
                     "пытка",
-                    "беспощадный",
-                    "ослеплять"
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
-                    "ослеплять",
-                    "беспощадный",
+                    "предавать",
+                    "выдавать",
                     "жертвовать",
-                    "предавать"
+                    "жестокость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
+                    "беспощадный",
                     "предавать",
-                    "жертвовать",
-                    "жестокость",
-                    "беспощадный"
+                    "ослеплять",
+                    "доносить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4830,48 +4863,48 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "завлекать",
                     "любовная связь",
-                    "играть",
-                    "соперничество"
+                    "соперничество",
+                    "завлекать",
+                    "играть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
                     "завлекать",
-                    "играть",
-                    "соперничество",
-                    "любовная связь"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «spielen»?",
-                "choices": [
-                    "играть",
                     "соперничество",
                     "любовная связь",
-                    "похоть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verlocken»?",
-                "choices": [
-                    "жонглировать",
-                    "завлекать",
-                    "играть",
-                    "любовная связь"
+                    "играть"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «spielen»?",
+                "choices": [
+                    "жонглировать",
+                    "похоть",
+                    "соперничество",
+                    "играть"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verlocken»?",
+                "choices": [
+                    "играть",
+                    "интрига",
+                    "использовать",
+                    "завлекать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "интрига",
                     "любовная связь",
+                    "играть",
                     "использовать",
                     "похоть"
                 ],
@@ -4880,20 +4913,20 @@
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "завлекать",
-                    "жонглировать",
                     "использовать",
-                    "интрига"
+                    "завлекать",
+                    "играть",
+                    "жонглировать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
                     "жонглировать",
-                    "играть",
                     "интрига",
-                    "использовать"
+                    "похоть",
+                    "завлекать"
                 ],
                 "correctIndex": 0
             },
@@ -4901,9 +4934,9 @@
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
                     "интрига",
-                    "похоть",
+                    "жонглировать",
                     "соперничество",
-                    "завлекать"
+                    "похоть"
                 ],
                 "correctIndex": 0
             }
@@ -5391,8 +5424,8 @@
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
                     "падать",
-                    "сожалеть",
                     "дуэль",
+                    "сожалеть",
                     "поражение"
                 ],
                 "correctIndex": 0
@@ -5400,60 +5433,60 @@
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "признаваться",
-                    "проигрывать",
+                    "падать",
                     "сожалеть",
-                    "поражение"
+                    "поражение",
+                    "падение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "проигрывать",
-                    "падение",
-                    "падать",
-                    "поражение"
+                    "сожалеть",
+                    "поражение",
+                    "конец",
+                    "проигрывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "сожалеть",
-                    "признаваться",
                     "проигрывать",
-                    "падать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Untergang»?",
-                "choices": [
-                    "падение",
-                    "дуэль",
-                    "сожалеть",
-                    "признаваться"
+                    "падать",
+                    "признаваться",
+                    "падение"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «der Untergang»?",
+                "choices": [
+                    "конец",
+                    "дуэль",
+                    "проигрывать",
+                    "падение"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «gestehen»?",
                 "choices": [
-                    "проигрывать",
+                    "конец",
+                    "поражение",
                     "признаваться",
-                    "сожалеть",
-                    "дуэль"
+                    "падение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "конец",
+                    "дуэль",
                     "падать",
-                    "поражение",
-                    "признаваться"
+                    "сожалеть"
                 ],
                 "correctIndex": 0
             }
@@ -5560,6 +5593,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6093,6 +6497,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -6147,6 +6552,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -6176,6 +6582,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6239,6 +6646,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6247,6 +6656,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6265,6 +6675,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6313,6 +6725,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6331,6 +6765,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6407,100 +6844,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6509,7 +6898,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6622,6 +7015,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6671,6 +7066,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7418,6 +7815,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7434,6 +7876,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Шута</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Шута</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="jester">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="jester">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="bitter_truths">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prophecies">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="mad_companion">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="songs">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="wisdom">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="vanishing">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["мудрость", "печаль", "шут", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шут", "печаль", "мудрость", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["забава", "остроумие", "умный", "печаль"], "correct_index": 3}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["скучать", "шутить", "умный", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["забава", "шут", "мудрость", "скучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "шутить", "забава", "умный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "печаль", "скучать", "шутить"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["шутить", "остроумие", "забава", "умный"], "correct_index": 1}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "правда", "предупреждение", "шутка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["горький", "правда", "предупреждение", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["дразнить", "раскрывать", "предупреждение", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["дразнить", "шутка", "горький", "раскрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["раскрывать", "предупреждение", "дразнить", "насмехаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «necken»?", "choices": ["дразнить", "насмехаться", "правда", "шутка"], "correct_index": 0}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["горький", "раскрывать", "шутка", "предупреждение"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "предчувствие", "загадка", "предсказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "предсказывать", "предчувствие", "загадка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадка", "предсказывать", "предчувствие", "знамение"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["загадка", "предсказывать", "пророчество", "предчувствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["знамение", "толковать", "пророчество", "загадка"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["пророчество", "предчувствовать", "предсказывать", "предчувствие"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["знамение", "предсказывать", "загадка", "толковать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["толковать", "знамение", "загадка", "загадочный"], "correct_index": 3}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["сопровождать", "безумие", "дружба", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "безумие", "дружба", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["дрожать", "сопровождать", "дружба", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "дрожать", "безумие", "дружба"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["безумие", "верный", "петь", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "безумие", "верный", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "дружба", "безумие", "мёрзнуть"], "correct_index": 0}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "ирония", "песня", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "напевать", "песня", "утешение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["песня", "мелодия", "утешение", "ирония"], "correct_index": 3}, {"question": "Что означает немецкое слово «summen»?", "choices": ["утешение", "свистеть", "напевать", "мелодия"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["утешение", "рифма", "звучать", "мелодия"], "correct_index": 3}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["песня", "звучать", "мелодия", "свистеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["рифма", "песня", "звучать", "свистеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["свистеть", "мелодия", "утешение", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["философия", "судьба", "размышлять", "бренность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["философия", "бренность", "размышлять", "судьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["познавать", "бренность", "размышлять", "преходящий"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["познавать", "судьба", "смысл", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["смысл", "судьба", "познавать", "бренность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["смысл", "бренность", "размышлять", "судьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["познавать", "смысл", "размышлять", "преходящий"], "correct_index": 3}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "растворяться", "пустота", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["тайна", "пустота", "растворяться", "исчезать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["пустота", "туман", "исчезать", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["туман", "тайна", "загадочный", "растворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "растворяться", "исчезать", "туман"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["тайна", "туман", "исчезать", "пустота"], "correct_index": 1}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "исчезать", "туман", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["растворяться", "исчезать", "бесследно", "уходить"], "correct_index": 3}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="jester">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">забава</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «klug»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="bitter_truths">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «necken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prophecies">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="mad_companion">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «singen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «treu»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="songs">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «summen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="wisdom">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="vanishing">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">туман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="bitter_truths">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="jester">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="bitter_truths">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prophecies">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="mad_companion">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="songs">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="wisdom">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="vanishing">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prophecies">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="mad_companion">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="songs">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="wisdom">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="vanishing">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="jester">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="bitter_truths">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prophecies">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="mad_companion">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="songs">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="wisdom">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="vanishing">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["печаль", "шутить", "мудрость", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["шутить", "мудрость", "печаль", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["печаль", "мудрость", "умный", "остроумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шут", "мудрость", "печаль", "шутить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["мудрость", "забава", "шут", "шутить"], "correct_index": 1}, {"question": "Что означает немецкое слово «klug»?", "choices": ["умный", "скучать", "остроумие", "забава"], "correct_index": 0}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["шут", "скучать", "шутить", "умный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["мудрость", "остроумие", "скучать", "забава"], "correct_index": 1}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["предупреждение", "горький", "правда", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["правда", "шутка", "горький", "предупреждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["раскрывать", "горький", "предупреждение", "дразнить"], "correct_index": 2}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["дразнить", "правда", "горький", "шутка"], "correct_index": 2}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["шутка", "насмехаться", "дразнить", "раскрывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «necken»?", "choices": ["правда", "шутка", "предупреждение", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["правда", "насмехаться", "раскрывать", "дразнить"], "correct_index": 2}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["загадка", "пророчество", "предсказывать", "предчувствие"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "предчувствие", "загадка", "предсказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["загадочный", "толковать", "предчувствие", "загадка"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предчувствие", "предчувствовать", "знамение", "предсказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["толковать", "загадочный", "предчувствие", "знамение"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["толковать", "загадка", "предчувствовать", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["предчувствовать", "загадочный", "знамение", "пророчество"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["знамение", "предсказывать", "загадочный", "толковать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "сопровождать", "мёрзнуть", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["мёрзнуть", "дружба", "безумие", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "мёрзнуть", "петь", "дружба"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["верный", "петь", "мёрзнуть", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «singen»?", "choices": ["петь", "верный", "безумие", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["петь", "дружба", "дрожать", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["сопровождать", "безумие", "верный", "мёрзнуть"], "correct_index": 2}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "песня", "утешение", "ирония"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "утешение", "напевать", "песня"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["песня", "ирония", "свистеть", "мелодия"], "correct_index": 1}, {"question": "Что означает немецкое слово «summen»?", "choices": ["ирония", "звучать", "напевать", "мелодия"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["рифма", "песня", "мелодия", "утешение"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "напевать", "звучать", "мелодия"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["звучать", "песня", "свистеть", "рифма"], "correct_index": 3}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["рифма", "свистеть", "звучать", "песня"], "correct_index": 2}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["судьба", "бренность", "размышлять", "философия"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["бренность", "судьба", "философия", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["философия", "смысл", "познавать", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["смысл", "философия", "преходящий", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["судьба", "философия", "бренность", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["смысл", "судьба", "размышлять", "философия"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["судьба", "философия", "смысл", "преходящий"], "correct_index": 3}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["тайна", "растворяться", "исчезать", "пустота"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["пустота", "исчезать", "тайна", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["загадочный", "исчезать", "пустота", "бесследно"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["загадочный", "бесследно", "пустота", "растворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "растворяться", "исчезать", "уходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["бесследно", "уходить", "туман", "пустота"], "correct_index": 2}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "бесследно", "пустота", "туман"], "correct_index": 0}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "тайна", "пустота", "растворяться"], "correct_index": 0}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="jester">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">забава</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «klug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">остроумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="bitter_truths">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «necken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prophecies">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">толковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="mad_companion">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «singen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «treu»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="songs">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «summen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="wisdom">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преходящий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="vanishing">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verschwinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1969,80 +2002,80 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "печаль",
-                    "шутить",
                     "мудрость",
-                    "шут"
+                    "печаль",
+                    "шут",
+                    "шутить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "шутить",
-                    "мудрость",
+                    "шут",
                     "печаль",
-                    "шут"
+                    "мудрость",
+                    "шутить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "печаль",
-                    "мудрость",
+                    "забава",
+                    "остроумие",
                     "умный",
-                    "остроумие"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «scherzen»?",
-                "choices": [
-                    "шут",
-                    "мудрость",
-                    "печаль",
-                    "шутить"
+                    "печаль"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «der Spaß»?",
+                "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
-                    "мудрость",
-                    "забава",
-                    "шут",
-                    "шутить"
+                    "скучать",
+                    "шутить",
+                    "умный",
+                    "остроумие"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «klug»?",
+                "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "умный",
-                    "скучать",
-                    "остроумие",
-                    "забава"
+                    "забава",
+                    "шут",
+                    "мудрость",
+                    "скучать"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «klug»?",
+                "choices": [
+                    "скучать",
+                    "шутить",
+                    "забава",
+                    "умный"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
                     "шут",
+                    "печаль",
                     "скучать",
-                    "шутить",
-                    "умный"
+                    "шутить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
-                    "мудрость",
+                    "шутить",
                     "остроумие",
-                    "скучать",
-                    "забава"
+                    "забава",
+                    "умный"
                 ],
                 "correctIndex": 1
             }
@@ -2480,30 +2513,30 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
+                    "горький",
+                    "правда",
                     "предупреждение",
-                    "горький",
-                    "правда",
                     "шутка"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Scherz»?",
-                "choices": [
-                    "правда",
-                    "шутка",
-                    "горький",
-                    "предупреждение"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Scherz»?",
+                "choices": [
+                    "горький",
+                    "правда",
+                    "предупреждение",
+                    "шутка"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
+                    "дразнить",
                     "раскрывать",
-                    "горький",
                     "предупреждение",
-                    "дразнить"
+                    "шутка"
                 ],
                 "correctIndex": 2
             },
@@ -2511,41 +2544,41 @@
                 "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
                     "дразнить",
-                    "правда",
+                    "шутка",
                     "горький",
-                    "шутка"
+                    "раскрывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
-                    "шутка",
-                    "насмехаться",
-                    "дразнить",
-                    "раскрывать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «necken»?",
-                "choices": [
-                    "правда",
-                    "шутка",
+                    "раскрывать",
                     "предупреждение",
-                    "дразнить"
+                    "дразнить",
+                    "насмехаться"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «necken»?",
+                "choices": [
+                    "дразнить",
+                    "насмехаться",
+                    "правда",
+                    "шутка"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "правда",
-                    "насмехаться",
+                    "горький",
                     "раскрывать",
-                    "дразнить"
+                    "шутка",
+                    "предупреждение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3017,82 +3050,82 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "загадка",
-                    "пророчество",
-                    "предсказывать",
-                    "предчувствие"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Rätsel»?",
-                "choices": [
                     "пророчество",
                     "предчувствие",
                     "загадка",
                     "предсказывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Rätsel»?",
+                "choices": [
+                    "пророчество",
+                    "предсказывать",
+                    "предчувствие",
+                    "загадка"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "загадочный",
-                    "толковать",
+                    "загадка",
+                    "предсказывать",
                     "предчувствие",
-                    "загадка"
+                    "знамение"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vorhersagen»?",
                 "choices": [
-                    "предчувствие",
-                    "предчувствовать",
-                    "знамение",
-                    "предсказывать"
+                    "загадка",
+                    "предсказывать",
+                    "пророчество",
+                    "предчувствовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
+                    "знамение",
                     "толковать",
-                    "загадочный",
-                    "предчувствие",
-                    "знамение"
+                    "пророчество",
+                    "загадка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ahnen»?",
                 "choices": [
-                    "толковать",
-                    "загадка",
+                    "пророчество",
                     "предчувствовать",
+                    "предсказывать",
                     "предчувствие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
-                    "предчувствовать",
-                    "загадочный",
                     "знамение",
-                    "пророчество"
+                    "предсказывать",
+                    "загадка",
+                    "толковать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
+                    "толковать",
                     "знамение",
-                    "предсказывать",
-                    "загадочный",
-                    "толковать"
+                    "загадка",
+                    "загадочный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3542,72 +3575,72 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "дружба",
                     "сопровождать",
-                    "мёрзнуть",
-                    "безумие"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Freundschaft»?",
-                "choices": [
-                    "мёрзнуть",
-                    "дружба",
                     "безумие",
-                    "сопровождать"
+                    "дружба",
+                    "мёрзнуть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «begleiten»?",
+                "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
                     "сопровождать",
-                    "мёрзнуть",
-                    "петь",
-                    "дружба"
+                    "безумие",
+                    "дружба",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «begleiten»?",
+                "choices": [
+                    "дрожать",
+                    "сопровождать",
+                    "дружба",
+                    "мёрзнуть"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "верный",
-                    "петь",
                     "мёрзнуть",
-                    "дружба"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «singen»?",
-                "choices": [
-                    "петь",
-                    "верный",
+                    "дрожать",
                     "безумие",
-                    "дрожать"
+                    "дружба"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «zittern»?",
+                "question": "Что означает немецкое слово «singen»?",
                 "choices": [
+                    "безумие",
+                    "верный",
                     "петь",
-                    "дружба",
-                    "дрожать",
-                    "сопровождать"
+                    "мёрзнуть"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «treu»?",
+                "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "сопровождать",
+                    "дрожать",
                     "безумие",
                     "верный",
+                    "сопровождать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «treu»?",
+                "choices": [
+                    "верный",
+                    "дружба",
+                    "безумие",
                     "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4072,37 +4105,37 @@
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
                     "напевать",
+                    "ирония",
                     "песня",
-                    "утешение",
-                    "ирония"
+                    "утешение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
                     "ирония",
-                    "утешение",
                     "напевать",
-                    "песня"
+                    "песня",
+                    "утешение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
                     "песня",
-                    "ирония",
-                    "свистеть",
-                    "мелодия"
+                    "мелодия",
+                    "утешение",
+                    "ирония"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
-                    "ирония",
-                    "звучать",
+                    "утешение",
+                    "свистеть",
                     "напевать",
                     "мелодия"
                 ],
@@ -4111,42 +4144,42 @@
             {
                 "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
+                    "утешение",
                     "рифма",
-                    "песня",
-                    "мелодия",
-                    "утешение"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «pfeifen»?",
-                "choices": [
-                    "свистеть",
-                    "напевать",
                     "звучать",
                     "мелодия"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Reim»?",
-                "choices": [
-                    "звучать",
-                    "песня",
-                    "свистеть",
-                    "рифма"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «klingen»?",
+                "question": "Что означает немецкое слово «pfeifen»?",
+                "choices": [
+                    "песня",
+                    "звучать",
+                    "мелодия",
+                    "свистеть"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
                     "рифма",
-                    "свистеть",
+                    "песня",
                     "звучать",
-                    "песня"
+                    "свистеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «klingen»?",
+                "choices": [
+                    "свистеть",
+                    "мелодия",
+                    "утешение",
+                    "звучать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4576,39 +4609,39 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
+                    "философия",
                     "судьба",
-                    "бренность",
                     "размышлять",
-                    "философия"
+                    "бренность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
+                    "философия",
                     "бренность",
-                    "судьба",
-                    "философия",
-                    "размышлять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Vergänglichkeit»?",
-                "choices": [
-                    "философия",
-                    "смысл",
-                    "познавать",
-                    "бренность"
+                    "размышлять",
+                    "судьба"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Vergänglichkeit»?",
+                "choices": [
+                    "познавать",
+                    "бренность",
+                    "размышлять",
+                    "преходящий"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
+                    "познавать",
+                    "судьба",
                     "смысл",
-                    "философия",
-                    "преходящий",
                     "размышлять"
                 ],
                 "correctIndex": 3
@@ -4616,29 +4649,29 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "смысл",
                     "судьба",
-                    "философия",
-                    "бренность",
-                    "познавать"
+                    "познавать",
+                    "бренность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sinn»?",
                 "choices": [
                     "смысл",
-                    "судьба",
+                    "бренность",
                     "размышлять",
-                    "философия"
+                    "судьба"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
-                    "судьба",
-                    "философия",
+                    "познавать",
                     "смысл",
+                    "размышлять",
                     "преходящий"
                 ],
                 "correctIndex": 3
@@ -5108,39 +5141,39 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "тайна",
-                    "растворяться",
                     "исчезать",
-                    "пустота"
+                    "растворяться",
+                    "пустота",
+                    "тайна"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
-                    "пустота",
-                    "исчезать",
                     "тайна",
-                    "растворяться"
+                    "пустота",
+                    "растворяться",
+                    "исчезать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
-                    "загадочный",
-                    "исчезать",
                     "пустота",
-                    "бесследно"
+                    "туман",
+                    "исчезать",
+                    "тайна"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sich auflösen»?",
                 "choices": [
+                    "туман",
+                    "тайна",
                     "загадочный",
-                    "бесследно",
-                    "пустота",
                     "растворяться"
                 ],
                 "correctIndex": 3
@@ -5151,39 +5184,39 @@
                     "бесследно",
                     "растворяться",
                     "исчезать",
-                    "уходить"
+                    "туман"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Nebel»?",
                 "choices": [
-                    "бесследно",
-                    "уходить",
+                    "тайна",
                     "туман",
+                    "исчезать",
                     "пустота"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
                     "загадочный",
-                    "бесследно",
-                    "пустота",
-                    "туман"
+                    "исчезать",
+                    "туман",
+                    "растворяться"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
-                    "уходить",
-                    "тайна",
-                    "пустота",
-                    "растворяться"
+                    "растворяться",
+                    "исчезать",
+                    "бесследно",
+                    "уходить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5289,6 +5322,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5822,6 +6226,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5876,6 +6281,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5905,6 +6311,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -5968,6 +6375,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -5976,6 +6385,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -5994,6 +6404,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6042,6 +6454,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6060,6 +6494,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6136,100 +6573,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6238,7 +6627,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6351,6 +6744,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6400,6 +6795,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7147,6 +7544,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7163,6 +7605,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Глостера</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Глостера</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1395 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["граф", "знать", "доверять", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["доверять", "служить", "граф", "знать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["служить", "долг", "доверять", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "уважать", "честь", "праведный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["честь", "служить", "доверять", "уважать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["служить", "праведный", "доверять", "уважать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["знать", "долг", "служить", "праведный"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["уважать", "служить", "праведный", "долг"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["верить", "письмо", "обманывать", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["письмо", "верить", "обман", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "подозревать", "легковерный", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["ловушка", "верить", "обман", "письмо"], "correct_index": 2}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["простодушный", "верить", "легковерный", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["обман", "верить", "подозревать", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["легковерный", "обманывать", "верить", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["обман", "верить", "обманывать", "ловушка"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["сожалеть", "изгонять", "заблуждение", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["заблуждение", "изгонять", "проклинать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["гнать", "проклинать", "несправедливость", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["несправедливость", "слепой", "гнать", "заблуждение"], "correct_index": 3}, {"question": "Что означает немецкое слово «blind»?", "choices": ["изгонять", "сожалеть", "заблуждение", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["изгонять", "сожалеть", "проклинать", "гнать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["слепой", "проклинать", "несправедливость", "гнать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["рисковать", "опасность", "помогать", "сострадание"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "сострадание", "помогать", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["защищать", "помогать", "рисковать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["измена", "осмеливаться", "тайно", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["защищать", "опасность", "тайно", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["сострадание", "рисковать", "измена", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["измена", "тайно", "защищать", "сострадание"], "correct_index": 0}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["помогать", "сострадание", "осмеливаться", "измена"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "пытка", "темнота", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["ослеплять", "боль", "темнота", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "пытка", "ослеплять", "кричать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "месть", "кричать", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "месть", "слепнуть", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["пытка", "ослеплять", "темнота", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["боль", "ослеплять", "пытка", "месть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["пропасть", "отчаяние", "обман", "прыгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «springen»?", "choices": ["отчаяние", "пропасть", "обман", "прыгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["отчаяние", "обман", "пропасть", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["падать", "отчаяние", "пропасть", "избавлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "пропасть", "прыгать", "избавлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["обман", "безнадёжность", "пропасть", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "отчаяние", "пропасть", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["пропасть", "безнадёжность", "избавлять", "прыгать"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["осознание", "прощать", "узнавать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["осознание", "узнавать", "умирать", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["раскаяние", "примирение", "прощать", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["сердце", "умирать", "осознание", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "прощать", "сердце", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["сердце", "прощать", "обнимать", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["сердце", "обнимать", "осознание", "примирение"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "умирать", "обнимать", "прощать"], "correct_index": 0}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «achten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слепнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «springen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,939 +1607,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "служить", "граф", "знать"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["знать", "служить", "доверять", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["граф", "знать", "честь", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["честь", "доверять", "праведный", "граф"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["знать", "честь", "праведный", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["долг", "честь", "праведный", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["честь", "знать", "долг", "уважать"], "correct_index": 2}, {"question": "Что означает немецкое слово «achten»?", "choices": ["честь", "служить", "уважать", "праведный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обманывать", "письмо", "верить", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["письмо", "верить", "обман", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ловушка", "обман", "подозревать", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["подозревать", "обман", "простодушный", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["подозревать", "легковерный", "простодушный", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["верить", "обман", "легковерный", "подозревать"], "correct_index": 3}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["легковерный", "ловушка", "обманывать", "простодушный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["простодушный", "ловушка", "подозревать", "легковерный"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["заблуждение", "изгонять", "проклинать", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "изгонять", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["заблуждение", "гнать", "сожалеть", "несправедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["гнать", "заблуждение", "слепой", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «blind»?", "choices": ["несправедливость", "гнать", "сожалеть", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["гнать", "несправедливость", "заблуждение", "слепой"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "слепой", "изгонять", "заблуждение"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["помогать", "сострадание", "рисковать", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["опасность", "сострадание", "помогать", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["защищать", "помогать", "рисковать", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["сострадание", "опасность", "осмеливаться", "тайно"], "correct_index": 1}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["сострадание", "осмеливаться", "тайно", "помогать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["рисковать", "измена", "осмеливаться", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["рисковать", "измена", "опасность", "тайно"], "correct_index": 1}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["опасность", "осмеливаться", "измена", "сострадание"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["темнота", "пытка", "ослеплять", "боль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["темнота", "боль", "ослеплять", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["месть", "кричать", "пытка", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["месть", "темнота", "пытка", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["боль", "месть", "темнота", "кричать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["темнота", "месть", "ослеплять", "слепнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "пытка", "боль", "слепнуть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["прыгать", "пропасть", "отчаяние", "обман"], "correct_index": 2}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "прыгать", "пропасть", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["отчаяние", "прыгать", "обман", "безнадёжность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["пропасть", "избавлять", "прыгать", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["обман", "избавлять", "сдаваться", "прыгать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["пропасть", "обман", "падать", "безнадёжность"], "correct_index": 3}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["падать", "отчаяние", "прыгать", "пропасть"], "correct_index": 0}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["пропасть", "избавлять", "прыгать", "падать"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "узнавать", "осознание", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["умирать", "прощать", "узнавать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["примирение", "умирать", "прощать", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["раскаяние", "осознание", "обнимать", "примирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "прощать", "раскаяние", "осознание"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["обнимать", "раскаяние", "примирение", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["осознание", "примирение", "узнавать", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["сердце", "раскаяние", "осознание", "примирение"], "correct_index": 0}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «achten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">простодушный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «blind»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осмеливаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осмеливаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">измена</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слепнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «springen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">избавлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1969,82 +2002,82 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "доверять",
-                    "служить",
                     "граф",
-                    "знать"
+                    "знать",
+                    "доверять",
+                    "служить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "знать",
-                    "служить",
                     "доверять",
-                    "граф"
+                    "служить",
+                    "граф",
+                    "знать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "граф",
-                    "знать",
-                    "честь",
-                    "доверять"
+                    "служить",
+                    "долг",
+                    "доверять",
+                    "граф"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
+                    "граф",
+                    "уважать",
                     "честь",
-                    "доверять",
-                    "праведный",
-                    "граф"
+                    "праведный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "знать",
                     "честь",
-                    "праведный",
-                    "доверять"
+                    "служить",
+                    "доверять",
+                    "уважать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "долг",
-                    "честь",
+                    "служить",
                     "праведный",
-                    "служить"
+                    "доверять",
+                    "уважать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "честь",
                     "знать",
                     "долг",
-                    "уважать"
+                    "служить",
+                    "праведный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "честь",
-                    "служить",
                     "уважать",
-                    "праведный"
+                    "служить",
+                    "праведный",
+                    "долг"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2520,9 +2553,9 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
-                    "обманывать",
-                    "письмо",
                     "верить",
+                    "письмо",
+                    "обманывать",
                     "обман"
                 ],
                 "correctIndex": 1
@@ -2540,62 +2573,62 @@
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
-                    "ловушка",
-                    "обман",
+                    "обманывать",
                     "подозревать",
-                    "обманывать"
+                    "легковерный",
+                    "обман"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "подозревать",
+                    "ловушка",
+                    "верить",
                     "обман",
-                    "простодушный",
-                    "верить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «arglos»?",
-                "choices": [
-                    "подозревать",
-                    "легковерный",
-                    "простодушный",
-                    "верить"
+                    "письмо"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «arglos»?",
+                "choices": [
+                    "простодушный",
+                    "верить",
+                    "легковерный",
+                    "обман"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "верить",
                     "обман",
-                    "легковерный",
-                    "подозревать"
+                    "верить",
+                    "подозревать",
+                    "обманывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
                     "легковерный",
-                    "ловушка",
                     "обманывать",
-                    "простодушный"
+                    "верить",
+                    "обман"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "простодушный",
-                    "ловушка",
-                    "подозревать",
-                    "легковерный"
+                    "обман",
+                    "верить",
+                    "обманывать",
+                    "ловушка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3048,49 +3081,49 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "заблуждение",
+                    "сожалеть",
                     "изгонять",
-                    "проклинать",
-                    "сожалеть"
+                    "заблуждение",
+                    "проклинать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "сожалеть",
-                    "проклинать",
-                    "изгонять",
-                    "заблуждение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
                     "заблуждение",
-                    "гнать",
-                    "сожалеть",
-                    "несправедливость"
+                    "изгонять",
+                    "проклинать",
+                    "сожалеть"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «der Irrtum»?",
+                "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "гнать",
-                    "заблуждение",
-                    "слепой",
-                    "изгонять"
+                    "проклинать",
+                    "несправедливость",
+                    "сожалеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Irrtum»?",
+                "choices": [
+                    "несправедливость",
+                    "слепой",
+                    "гнать",
+                    "заблуждение"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "несправедливость",
-                    "гнать",
+                    "изгонять",
                     "сожалеть",
+                    "заблуждение",
                     "слепой"
                 ],
                 "correctIndex": 3
@@ -3098,22 +3131,22 @@
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "гнать",
-                    "несправедливость",
-                    "заблуждение",
-                    "слепой"
+                    "изгонять",
+                    "сожалеть",
+                    "проклинать",
+                    "гнать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "несправедливость",
                     "слепой",
-                    "изгонять",
-                    "заблуждение"
+                    "проклинать",
+                    "несправедливость",
+                    "гнать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3569,12 +3602,12 @@
             {
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
-                    "помогать",
-                    "сострадание",
                     "рисковать",
-                    "опасность"
+                    "опасность",
+                    "помогать",
+                    "сострадание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Mitleid»?",
@@ -3592,36 +3625,36 @@
                     "защищать",
                     "помогать",
                     "рисковать",
-                    "осмеливаться"
+                    "опасность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "сострадание",
-                    "опасность",
+                    "измена",
                     "осмеливаться",
-                    "тайно"
+                    "тайно",
+                    "опасность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
-                    "сострадание",
-                    "осмеливаться",
+                    "защищать",
+                    "опасность",
                     "тайно",
-                    "помогать"
+                    "осмеливаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
+                    "сострадание",
                     "рисковать",
                     "измена",
-                    "осмеливаться",
                     "защищать"
                 ],
                 "correctIndex": 3
@@ -3629,22 +3662,22 @@
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "рисковать",
                     "измена",
-                    "опасность",
-                    "тайно"
+                    "тайно",
+                    "защищать",
+                    "сострадание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "опасность",
+                    "помогать",
+                    "сострадание",
                     "осмеливаться",
-                    "измена",
-                    "сострадание"
+                    "измена"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4087,19 +4120,19 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "темнота",
-                    "пытка",
                     "ослеплять",
+                    "пытка",
+                    "темнота",
                     "боль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "темнота",
-                    "боль",
                     "ослеплять",
+                    "боль",
+                    "темнота",
                     "пытка"
                 ],
                 "correctIndex": 3
@@ -4107,39 +4140,39 @@
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "месть",
-                    "кричать",
+                    "боль",
                     "пытка",
-                    "боль"
+                    "ослеплять",
+                    "кричать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
-                    "месть",
                     "темнота",
-                    "пытка",
-                    "ослеплять"
+                    "месть",
+                    "кричать",
+                    "пытка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "боль",
+                    "кричать",
                     "месть",
-                    "темнота",
-                    "кричать"
+                    "слепнуть",
+                    "пытка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
-                    "темнота",
-                    "месть",
+                    "пытка",
                     "ослеплять",
+                    "темнота",
                     "слепнуть"
                 ],
                 "correctIndex": 3
@@ -4147,12 +4180,12 @@
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
-                    "пытка",
                     "боль",
-                    "слепнуть"
+                    "ослеплять",
+                    "пытка",
+                    "месть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4628,70 +4661,70 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "прыгать",
                     "пропасть",
                     "отчаяние",
-                    "обман"
+                    "обман",
+                    "прыгать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «springen»?",
                 "choices": [
-                    "обман",
-                    "прыгать",
+                    "отчаяние",
                     "пропасть",
-                    "отчаяние"
+                    "обман",
+                    "прыгать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
                     "отчаяние",
-                    "прыгать",
                     "обман",
-                    "безнадёжность"
+                    "пропасть",
+                    "падать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
+                    "падать",
+                    "отчаяние",
                     "пропасть",
-                    "избавлять",
-                    "прыгать",
-                    "падать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «aufgeben»?",
-                "choices": [
-                    "обман",
-                    "избавлять",
-                    "сдаваться",
-                    "прыгать"
+                    "избавлять"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «aufgeben»?",
+                "choices": [
+                    "сдаваться",
+                    "пропасть",
+                    "прыгать",
+                    "избавлять"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "пропасть",
                     "обман",
-                    "падать",
-                    "безнадёжность"
+                    "безнадёжность",
+                    "пропасть",
+                    "падать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
                     "падать",
                     "отчаяние",
-                    "прыгать",
-                    "пропасть"
+                    "пропасть",
+                    "прыгать"
                 ],
                 "correctIndex": 0
             },
@@ -4699,11 +4732,11 @@
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
                     "пропасть",
+                    "безнадёжность",
                     "избавлять",
-                    "прыгать",
-                    "падать"
+                    "прыгать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5181,80 +5214,80 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "осознание",
                     "прощать",
                     "узнавать",
-                    "осознание",
                     "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "умирать",
-                    "прощать",
+                    "осознание",
                     "узнавать",
-                    "осознание"
+                    "умирать",
+                    "прощать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
+                    "раскаяние",
                     "примирение",
-                    "умирать",
                     "прощать",
-                    "сердце"
+                    "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "раскаяние",
+                    "сердце",
+                    "умирать",
                     "осознание",
-                    "обнимать",
-                    "примирение"
+                    "узнавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "узнавать",
-                    "прощать",
                     "раскаяние",
+                    "прощать",
+                    "сердце",
+                    "обнимать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «umarmen»?",
+                "choices": [
+                    "сердце",
+                    "прощать",
+                    "обнимать",
                     "осознание"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «umarmen»?",
-                "choices": [
-                    "обнимать",
-                    "раскаяние",
-                    "примирение",
-                    "умирать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
+                    "сердце",
+                    "обнимать",
                     "осознание",
-                    "примирение",
-                    "узнавать",
-                    "прощать"
+                    "примирение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
                     "сердце",
-                    "раскаяние",
-                    "осознание",
-                    "примирение"
+                    "умирать",
+                    "обнимать",
+                    "прощать"
                 ],
                 "correctIndex": 0
             }
@@ -5361,6 +5394,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5894,6 +6298,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5948,6 +6353,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5977,6 +6383,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6040,6 +6447,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6048,6 +6457,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6066,6 +6476,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6114,6 +6526,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6132,6 +6566,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6208,100 +6645,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6310,7 +6699,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6423,6 +6816,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6472,6 +6867,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7219,6 +7616,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7235,6 +7677,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Гонерильи</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Гонерильи</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1411 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["ложь", "клясться", "лицемерить", "наследство"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["клясться", "ложь", "наследство", "лицемерить"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["жадность", "льстить", "состояние", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["лицемерить", "ложь", "обманывать", "состояние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "льстить", "обманывать", "наследство"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "наследство", "ложь", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["жадность", "льстить", "лицемерить", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["жадность", "клясться", "льстить", "состояние"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "приказывать", "трон", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "править", "трон", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["приказывать", "власть", "завоёвывать", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "подчинять", "завоёвывать", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["приказывать", "господство", "подчинять", "завоёвывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["трон", "приказывать", "завоёвывать", "господство"], "correct_index": 3}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "управлять", "господство", "трон"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["подчинять", "трон", "править", "власть"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["изгонять", "жестокий", "унижать", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "жестокий", "месть", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["изгонять", "ограничивать", "месть", "жестокий"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["отказывать", "презирать", "ограничивать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["изгонять", "презирать", "ограничивать", "мучить"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["унижать", "отказывать", "изгонять", "жестокий"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["изгонять", "мучить", "месть", "ограничивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["ограничивать", "мучить", "унижать", "презирать"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "запирать", "безжалостный", "отвергать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["безжалостный", "буря", "запирать", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "беспощадный", "холод", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["ожесточаться", "запирать", "холод", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["отвергать", "буря", "запирать", "холод"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "беспощадный", "запирать", "ожесточаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["холод", "запирать", "ожесточаться", "беспощадный"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["ненавидеть", "раздор", "предавать", "ссориться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["ссориться", "раздор", "ненавидеть", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["разрушать", "ссориться", "предавать", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "предавать", "изменять", "презрение"], "correct_index": 0}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["ссориться", "изменять", "раздор", "презрение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["ссориться", "страсть", "презрение", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["раздор", "разрушать", "предавать", "ссориться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["предавать", "раздор", "страсть", "разрушать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["желать", "ревность", "бороться", "соперничать"], "correct_index": 1}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "бороться", "желать", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["яд", "ревность", "убивать", "бороться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["интрига", "соперничать", "яд", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["желать", "устранять", "соперничать", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["яд", "интрига", "ревность", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "яд", "желать", "ревность"], "correct_index": 0}, {"question": "Что означает немецкое слово «morden»?", "choices": ["устранять", "яд", "бороться", "убивать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отчаяние", "умирать", "отравлять", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "вина", "умирать", "отравлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["вина", "сожалеть", "отчаяние", "умирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "отравлять", "умирать", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["ад", "вина", "уничтожать", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["ад", "погибель", "вина", "отравлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["уничтожать", "ад", "сожалеть", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "уничтожать", "сожалеть", "отчаяние"], "correct_index": 0}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ограничивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ожесточаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «morden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отравлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">уничтожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уничтожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,955 +1623,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["лицемерить", "ложь", "наследство", "клясться"], "correct_index": 1}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["наследство", "клясться", "лицемерить", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["клясться", "обманывать", "наследство", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["льстить", "наследство", "состояние", "лицемерить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["состояние", "жадность", "льстить", "ложь"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "клясться", "наследство", "льстить"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["льстить", "жадность", "лицемерить", "клясться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["состояние", "жадность", "лицемерить", "наследство"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "править", "приказывать", "власть"], "correct_index": 3}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["править", "приказывать", "трон", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["приказывать", "править", "господство", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "трон", "власть", "управлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["власть", "господство", "завоёвывать", "приказывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["подчинять", "господство", "править", "приказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["власть", "приказывать", "управлять", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["подчинять", "управлять", "трон", "завоёвывать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["месть", "унижать", "жестокий", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["жестокий", "месть", "изгонять", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "унижать", "ограничивать", "презирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["ограничивать", "отказывать", "изгонять", "презирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["унижать", "мучить", "месть", "презирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["презирать", "отказывать", "унижать", "жестокий"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["месть", "мучить", "отказывать", "ограничивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["отказывать", "месть", "жестокий", "ограничивать"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "запирать", "отвергать", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["безжалостный", "буря", "отвергать", "запирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["безжалостный", "беспощадный", "холод", "запирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["буря", "запирать", "отвергать", "безжалостный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["ожесточаться", "буря", "холод", "запирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ожесточаться", "беспощадный", "запирать", "холод"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["холод", "ожесточаться", "беспощадный", "буря"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["раздор", "ненавидеть", "предавать", "ссориться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["раздор", "ссориться", "ненавидеть", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["изменять", "презрение", "раздор", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "изменять", "презрение", "страсть"], "correct_index": 0}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "раздор", "предавать", "разрушать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["раздор", "изменять", "ссориться", "презрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["ненавидеть", "ссориться", "раздор", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["раздор", "предавать", "страсть", "ненавидеть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["соперничать", "бороться", "желать", "ревность"], "correct_index": 3}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["соперничать", "бороться", "ревность", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["ревность", "интрига", "бороться", "убивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соперничать", "убивать", "бороться", "желать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "бороться", "желать", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["интрига", "устранять", "яд", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "соперничать", "устранять", "убивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «morden»?", "choices": ["соперничать", "убивать", "желать", "бороться"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отравлять", "отчаяние", "умирать", "вина"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["умирать", "вина", "отравлять", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["вина", "погибель", "умирать", "уничтожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["ад", "погибель", "вина", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["ад", "сожалеть", "отчаяние", "уничтожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["сожалеть", "погибель", "уничтожать", "вина"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["погибель", "вина", "отчаяние", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["умирать", "погибель", "ад", "отравлять"], "correct_index": 2}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Lüge»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">клясться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">приказывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beschränken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">устранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «morden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ад</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -2017,82 +2050,82 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "лицемерить",
                     "ложь",
-                    "наследство",
-                    "клясться"
+                    "клясться",
+                    "лицемерить",
+                    "наследство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
-                    "наследство",
                     "клясться",
-                    "лицемерить",
-                    "ложь"
+                    "ложь",
+                    "наследство",
+                    "лицемерить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
-                    "клясться",
-                    "обманывать",
-                    "наследство",
-                    "жадность"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «heucheln»?",
-                "choices": [
+                    "жадность",
                     "льстить",
-                    "наследство",
                     "состояние",
-                    "лицемерить"
+                    "наследство"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «heucheln»?",
+                "choices": [
+                    "лицемерить",
+                    "ложь",
+                    "обманывать",
+                    "состояние"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "состояние",
                     "жадность",
                     "льстить",
-                    "ложь"
+                    "обманывать",
+                    "наследство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
                     "обманывать",
-                    "клясться",
                     "наследство",
-                    "льстить"
+                    "ложь",
+                    "жадность"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "льстить",
                     "жадность",
+                    "льстить",
                     "лицемерить",
-                    "клясться"
+                    "ложь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
-                    "состояние",
                     "жадность",
-                    "лицемерить",
-                    "наследство"
+                    "клясться",
+                    "льстить",
+                    "состояние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2623,9 +2656,9 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "трон",
                     "править",
                     "приказывать",
+                    "трон",
                     "власть"
                 ],
                 "correctIndex": 3
@@ -2633,70 +2666,70 @@
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "править",
                     "приказывать",
+                    "править",
                     "трон",
                     "власть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
                     "приказывать",
-                    "править",
-                    "господство",
-                    "завоёвывать"
+                    "власть",
+                    "завоёвывать",
+                    "подчинять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "приказывать",
                     "трон",
-                    "власть",
-                    "управлять"
+                    "подчинять",
+                    "завоёвывать",
+                    "власть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "власть",
+                    "приказывать",
                     "господство",
-                    "завоёвывать",
-                    "приказывать"
+                    "подчинять",
+                    "завоёвывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "подчинять",
-                    "господство",
-                    "править",
-                    "приказывать"
+                    "трон",
+                    "приказывать",
+                    "завоёвывать",
+                    "господство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
                     "власть",
-                    "приказывать",
                     "управлять",
+                    "господство",
                     "трон"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
                     "подчинять",
-                    "управлять",
                     "трон",
-                    "завоёвывать"
+                    "править",
+                    "власть"
                 ],
                 "correctIndex": 0
             }
@@ -3243,59 +3276,59 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "месть",
+                    "изгонять",
+                    "жестокий",
+                    "унижать",
+                    "месть"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «grausam»?",
+                "choices": [
                     "унижать",
                     "жестокий",
+                    "месть",
                     "изгонять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «grausam»?",
-                "choices": [
-                    "жестокий",
-                    "месть",
-                    "изгонять",
-                    "унижать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "месть",
-                    "унижать",
-                    "ограничивать",
-                    "презирать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vertreiben»?",
-                "choices": [
-                    "ограничивать",
-                    "отказывать",
                     "изгонять",
-                    "презирать"
+                    "ограничивать",
+                    "месть",
+                    "жестокий"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verachten»?",
+                "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "унижать",
-                    "мучить",
-                    "месть",
-                    "презирать"
+                    "отказывать",
+                    "презирать",
+                    "ограничивать",
+                    "изгонять"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «verachten»?",
+                "choices": [
+                    "изгонять",
+                    "презирать",
+                    "ограничивать",
+                    "мучить"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «verweigern»?",
                 "choices": [
-                    "презирать",
-                    "отказывать",
                     "унижать",
+                    "отказывать",
+                    "изгонять",
                     "жестокий"
                 ],
                 "correctIndex": 1
@@ -3303,9 +3336,9 @@
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "месть",
+                    "изгонять",
                     "мучить",
-                    "отказывать",
+                    "месть",
                     "ограничивать"
                 ],
                 "correctIndex": 1
@@ -3313,12 +3346,12 @@
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
-                    "отказывать",
-                    "месть",
-                    "жестокий",
-                    "ограничивать"
+                    "ограничивать",
+                    "мучить",
+                    "унижать",
+                    "презирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3819,18 +3852,18 @@
                 "choices": [
                     "буря",
                     "запирать",
-                    "отвергать",
-                    "безжалостный"
+                    "безжалостный",
+                    "отвергать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "безжалостный",
                     "буря",
-                    "отвергать",
-                    "запирать"
+                    "запирать",
+                    "отвергать"
                 ],
                 "correctIndex": 1
             },
@@ -3840,37 +3873,37 @@
                     "безжалостный",
                     "беспощадный",
                     "холод",
-                    "запирать"
+                    "буря"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
-                    "буря",
+                    "ожесточаться",
                     "запирать",
-                    "отвергать",
-                    "безжалостный"
+                    "холод",
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "ожесточаться",
+                    "отвергать",
                     "буря",
-                    "холод",
-                    "запирать"
+                    "запирать",
+                    "холод"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "ожесточаться",
+                    "отвергать",
                     "беспощадный",
                     "запирать",
-                    "холод"
+                    "ожесточаться"
                 ],
                 "correctIndex": 1
             },
@@ -3878,11 +3911,11 @@
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
                     "холод",
+                    "запирать",
                     "ожесточаться",
-                    "беспощадный",
-                    "буря"
+                    "беспощадный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4393,8 +4426,8 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
-                    "раздор",
                     "ненавидеть",
+                    "раздор",
                     "предавать",
                     "ссориться"
                 ],
@@ -4403,8 +4436,8 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "раздор",
                     "ссориться",
+                    "раздор",
                     "ненавидеть",
                     "предавать"
                 ],
@@ -4413,60 +4446,60 @@
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
-                    "изменять",
-                    "презрение",
-                    "раздор",
-                    "предавать"
+                    "разрушать",
+                    "ссориться",
+                    "предавать",
+                    "раздор"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
                     "ненавидеть",
+                    "предавать",
                     "изменять",
-                    "презрение",
-                    "страсть"
+                    "презрение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
+                    "ссориться",
                     "изменять",
                     "раздор",
-                    "предавать",
-                    "разрушать"
+                    "презрение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
-                    "раздор",
-                    "изменять",
                     "ссориться",
-                    "презрение"
+                    "страсть",
+                    "презрение",
+                    "предавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
-                    "ненавидеть",
-                    "ссориться",
                     "раздор",
-                    "разрушать"
+                    "разрушать",
+                    "предавать",
+                    "ссориться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "раздор",
                     "предавать",
+                    "раздор",
                     "страсть",
-                    "ненавидеть"
+                    "разрушать"
                 ],
                 "correctIndex": 2
             }
@@ -4996,39 +5029,39 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "соперничать",
-                    "бороться",
                     "желать",
-                    "ревность"
+                    "ревность",
+                    "бороться",
+                    "соперничать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
-                    "соперничать",
-                    "бороться",
                     "ревность",
-                    "желать"
+                    "бороться",
+                    "желать",
+                    "соперничать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
+                    "яд",
                     "ревность",
-                    "интрига",
-                    "бороться",
-                    "убивать"
+                    "убивать",
+                    "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
+                    "интрига",
                     "соперничать",
-                    "убивать",
-                    "бороться",
+                    "яд",
                     "желать"
                 ],
                 "correctIndex": 3
@@ -5036,42 +5069,42 @@
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
-                    "устранять",
-                    "бороться",
                     "желать",
+                    "устранять",
+                    "соперничать",
                     "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
-                    "интрига",
-                    "устранять",
                     "яд",
-                    "желать"
+                    "интрига",
+                    "ревность",
+                    "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
                     "интрига",
-                    "соперничать",
-                    "устранять",
-                    "убивать"
+                    "яд",
+                    "желать",
+                    "ревность"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "соперничать",
-                    "убивать",
-                    "желать",
-                    "бороться"
+                    "устранять",
+                    "яд",
+                    "бороться",
+                    "убивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5598,82 +5631,82 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "отравлять",
                     "отчаяние",
                     "умирать",
+                    "отравлять",
                     "вина"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "умирать",
+                    "отчаяние",
                     "вина",
-                    "отравлять",
-                    "отчаяние"
+                    "умирать",
+                    "отравлять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
                     "вина",
-                    "погибель",
-                    "умирать",
-                    "уничтожать"
+                    "сожалеть",
+                    "отчаяние",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "ад",
-                    "погибель",
                     "вина",
-                    "сожалеть"
+                    "отравлять",
+                    "умирать",
+                    "отчаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
                     "ад",
-                    "сожалеть",
-                    "отчаяние",
-                    "уничтожать"
+                    "вина",
+                    "уничтожать",
+                    "сожалеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Verderben»?",
                 "choices": [
-                    "сожалеть",
+                    "ад",
                     "погибель",
-                    "уничтожать",
-                    "вина"
+                    "вина",
+                    "отравлять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "погибель",
-                    "вина",
-                    "отчаяние",
-                    "сожалеть"
+                    "уничтожать",
+                    "ад",
+                    "сожалеть",
+                    "вина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "умирать",
-                    "погибель",
                     "ад",
-                    "отравлять"
+                    "уничтожать",
+                    "сожалеть",
+                    "отчаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5794,6 +5827,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6327,6 +6731,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -6381,6 +6786,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -6410,6 +6816,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6473,6 +6880,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6481,6 +6890,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6499,6 +6909,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6547,6 +6959,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6565,6 +6999,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6641,100 +7078,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6743,7 +7132,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6856,6 +7249,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6905,6 +7300,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7652,6 +8049,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7668,6 +8110,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Кента</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Кента</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="loyalty">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="loyalty">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="banishment">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="disguise">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="service">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="stocks">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm_companion">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="final_loyalty">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "мужество", "верность", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "защищать", "верность", "возражать"], "correct_index": 0}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["искренний", "предупреждать", "возражать", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["мужество", "защищать", "верность", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["искренний", "защищать", "мужество", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["искренний", "предупреждать", "возражать", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["верность", "предупреждать", "мужество", "слуга"], "correct_index": 1}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["мужество", "предупреждать", "справедливый", "защищать"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнание", "изгнанный", "гнев", "несправедливость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "изгнанный", "гнев", "изгнание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["возвращаться", "изгнание", "изгнанный", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["наказание", "гнев", "изгнанный", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["гнев", "несправедливость", "изгнание", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["несправедливость", "прощание", "наказание", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["несправедливость", "наказание", "возвращаться", "изгнание"], "correct_index": 2}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["неузнанный", "переодевание", "притворяться", "хитрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "переодевание", "притворяться", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "переодевание", "наниматься", "притворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "изменять", "наниматься", "верный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["хитрость", "верный", "борода", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["изменять", "наниматься", "неузнанный", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["переодевание", "наниматься", "хитрость", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «treu»?", "choices": ["изменять", "наниматься", "верный", "хитрость"], "correct_index": 2}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "охранять", "защита", "служба"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "защита", "служба", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["советовать", "опасность", "служба", "защита"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["советовать", "сражаться", "служба", "охранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["советовать", "защита", "сражаться", "служба"], "correct_index": 2}, {"question": "Что означает немецкое слово «raten»?", "choices": ["сражаться", "опасность", "советовать", "охранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["стража", "защита", "опасность", "служба"], "correct_index": 0}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["унижение", "стойкость", "наказание", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["стойкость", "унижение", "сковывать", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["колодка", "выдерживать", "позор", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["позор", "стойкость", "наказание", "сковывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["стойкость", "унижение", "терпеть", "сковывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["терпеть", "стойкость", "выдерживать", "колодка"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["сковывать", "выдерживать", "унижение", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["наказание", "позор", "колодка", "унижение"], "correct_index": 1}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["утешать", "сопровождать", "буря", "поддержка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["поддержка", "буря", "утешать", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["поддержка", "буря", "сопровождать", "убежище"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["выдерживать", "холод", "утешать", "сопровождать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["сопровождать", "буря", "убежище", "выдерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["выдерживать", "буря", "поддержка", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["утешать", "холод", "буря", "сопровождать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["плакать", "прощание", "смерть", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["плакать", "смерть", "прощание", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["сдаваться", "следовать", "прощание", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["плакать", "вечный", "смерть", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["плакать", "истощение", "следовать", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "скорбь", "истощение", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["сдаваться", "следовать", "скорбь", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["прощание", "вечный", "следовать", "плакать"], "correct_index": 2}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="loyalty">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="banishment">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="disguise">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «treu»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="service">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «raten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="stocks">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm_companion">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="final_loyalty">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="banishment">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="loyalty">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="banishment">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="disguise">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="service">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="stocks">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm_companion">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="final_loyalty">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="disguise">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="service">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="stocks">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm_companion">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="final_loyalty">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="loyalty">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="banishment">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="disguise">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="service">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="stocks">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm_companion">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="final_loyalty">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["мужество", "защищать", "верность", "возражать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["защищать", "мужество", "верность", "возражать"], "correct_index": 1}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["предупреждать", "мужество", "возражать", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["возражать", "справедливый", "защищать", "предупреждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["возражать", "верность", "мужество", "искренний"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["справедливый", "слуга", "искренний", "предупреждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["предупреждать", "мужество", "справедливый", "искренний"], "correct_index": 0}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["верность", "искренний", "защищать", "справедливый"], "correct_index": 3}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["изгнанный", "гнев", "несправедливость", "изгнание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгнанный", "гнев", "несправедливость", "изгнание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["прощание", "гнев", "изгнание", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["несправедливость", "изгнанный", "прощание", "изгнание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["возвращаться", "прощание", "гнев", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгнание", "прощание", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["изгнание", "несправедливость", "прощание", "возвращаться"], "correct_index": 3}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["хитрость", "притворяться", "неузнанный", "переодевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "переодевание", "притворяться", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["борода", "изменять", "притворяться", "неузнанный"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["верный", "переодевание", "хитрость", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["переодевание", "притворяться", "изменять", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["неузнанный", "верный", "борода", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["верный", "хитрость", "наниматься", "неузнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «treu»?", "choices": ["верный", "неузнанный", "изменять", "хитрость"], "correct_index": 0}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "защита", "служба", "охранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "опасность", "служба", "защита"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["советовать", "опасность", "защита", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["стража", "защита", "сражаться", "охранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["опасность", "стража", "сражаться", "защита"], "correct_index": 2}, {"question": "Что означает немецкое слово «raten»?", "choices": ["охранять", "опасность", "служба", "советовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["опасность", "стража", "охранять", "сражаться"], "correct_index": 1}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["стойкость", "сковывать", "унижение", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["сковывать", "стойкость", "наказание", "унижение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["выдерживать", "терпеть", "наказание", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["наказание", "сковывать", "колодка", "унижение"], "correct_index": 1}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "позор", "сковывать", "унижение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["колодка", "выдерживать", "унижение", "позор"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["терпеть", "колодка", "унижение", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["колодка", "позор", "унижение", "терпеть"], "correct_index": 1}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["поддержка", "буря", "утешать", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["буря", "сопровождать", "утешать", "поддержка"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["поддержка", "выдерживать", "сопровождать", "буря"], "correct_index": 2}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "буря", "убежище", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["выдерживать", "убежище", "холод", "утешать"], "correct_index": 1}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["сопровождать", "холод", "утешать", "выдерживать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["убежище", "холод", "утешать", "выдерживать"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["плакать", "смерть", "прощание", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "смерть", "плакать", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "прощание", "смерть", "плакать"], "correct_index": 0}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["вечный", "смерть", "плакать", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["смерть", "истощение", "прощание", "плакать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["истощение", "сдаваться", "плакать", "скорбь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["плакать", "следовать", "вечный", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["следовать", "плакать", "смерть", "прощание"], "correct_index": 0}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="loyalty">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">искренний</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="banishment">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="disguise">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «treu»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="service">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">советовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «raten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">советовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="stocks">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm_companion">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поддержка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выдерживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="final_loyalty">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Erschöpfung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">следовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1943,82 +1976,82 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
+                    "возражать",
                     "мужество",
-                    "защищать",
                     "верность",
-                    "возражать"
+                    "защищать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "защищать",
                     "мужество",
+                    "защищать",
                     "верность",
                     "возражать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
+                    "искренний",
                     "предупреждать",
-                    "мужество",
                     "возражать",
-                    "слуга"
+                    "справедливый"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "возражать",
-                    "справедливый",
-                    "защищать",
-                    "предупреждать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «aufrichtig»?",
-                "choices": [
-                    "возражать",
-                    "верность",
                     "мужество",
-                    "искренний"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Diener»?",
-                "choices": [
-                    "справедливый",
-                    "слуга",
-                    "искренний",
-                    "предупреждать"
+                    "защищать",
+                    "верность",
+                    "возражать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «warnen»?",
+                "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "предупреждать",
+                    "искренний",
+                    "защищать",
                     "мужество",
-                    "справедливый",
-                    "искренний"
+                    "верность"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «gerecht»?",
+                "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "верность",
                     "искренний",
-                    "защищать",
-                    "справедливый"
+                    "предупреждать",
+                    "возражать",
+                    "слуга"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «warnen»?",
+                "choices": [
+                    "верность",
+                    "предупреждать",
+                    "мужество",
+                    "слуга"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «gerecht»?",
+                "choices": [
+                    "мужество",
+                    "предупреждать",
+                    "справедливый",
+                    "защищать"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2476,72 +2509,72 @@
             {
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
+                    "изгнание",
                     "изгнанный",
                     "гнев",
-                    "несправедливость",
-                    "изгнание"
+                    "несправедливость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
+                    "несправедливость",
                     "изгнанный",
                     "гнев",
-                    "несправедливость",
                     "изгнание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "прощание",
-                    "гнев",
+                    "возвращаться",
                     "изгнание",
-                    "наказание"
+                    "изгнанный",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
-                    "несправедливость",
+                    "наказание",
+                    "гнев",
                     "изгнанный",
-                    "прощание",
-                    "изгнание"
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "возвращаться",
-                    "прощание",
                     "гнев",
-                    "наказание"
+                    "несправедливость",
+                    "изгнание",
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "изгнание",
+                    "несправедливость",
                     "прощание",
-                    "гнев",
-                    "наказание"
+                    "наказание",
+                    "возвращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "изгнание",
                     "несправедливость",
-                    "прощание",
-                    "возвращаться"
+                    "наказание",
+                    "возвращаться",
+                    "изгнание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3037,12 +3070,12 @@
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "хитрость",
-                    "притворяться",
                     "неузнанный",
-                    "переодевание"
+                    "переодевание",
+                    "притворяться",
+                    "хитрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
@@ -3057,62 +3090,62 @@
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
-                    "борода",
-                    "изменять",
-                    "притворяться",
-                    "неузнанный"
+                    "неузнанный",
+                    "переодевание",
+                    "наниматься",
+                    "притворяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
-                    "верный",
-                    "переодевание",
-                    "хитрость",
-                    "притворяться"
+                    "притворяться",
+                    "изменять",
+                    "наниматься",
+                    "верный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstellen»?",
                 "choices": [
-                    "переодевание",
-                    "притворяться",
-                    "изменять",
-                    "хитрость"
+                    "хитрость",
+                    "верный",
+                    "борода",
+                    "изменять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bart»?",
                 "choices": [
+                    "изменять",
+                    "наниматься",
                     "неузнанный",
-                    "верный",
-                    "борода",
-                    "хитрость"
+                    "борода"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
-                    "верный",
-                    "хитрость",
+                    "переодевание",
                     "наниматься",
+                    "хитрость",
                     "неузнанный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "верный",
-                    "неузнанный",
                     "изменять",
+                    "наниматься",
+                    "верный",
                     "хитрость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3539,38 +3572,38 @@
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
                     "опасность",
+                    "охранять",
                     "защита",
-                    "служба",
-                    "охранять"
+                    "служба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
                     "охранять",
-                    "опасность",
+                    "защита",
                     "служба",
-                    "защита"
+                    "опасность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
                     "советовать",
                     "опасность",
-                    "защита",
-                    "охранять"
+                    "служба",
+                    "защита"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
-                    "стража",
-                    "защита",
+                    "советовать",
                     "сражаться",
+                    "служба",
                     "охранять"
                 ],
                 "correctIndex": 3
@@ -3578,32 +3611,32 @@
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "опасность",
-                    "стража",
+                    "советовать",
+                    "защита",
                     "сражаться",
-                    "защита"
+                    "служба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
-                    "охранять",
+                    "сражаться",
                     "опасность",
-                    "служба",
-                    "советовать"
+                    "советовать",
+                    "охранять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
-                    "опасность",
                     "стража",
-                    "охранять",
-                    "сражаться"
+                    "защита",
+                    "опасность",
+                    "служба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4072,29 +4105,29 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "стойкость",
-                    "сковывать",
                     "унижение",
-                    "наказание"
+                    "стойкость",
+                    "наказание",
+                    "сковывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
-                    "сковывать",
                     "стойкость",
-                    "наказание",
-                    "унижение"
+                    "унижение",
+                    "сковывать",
+                    "наказание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
+                    "колодка",
                     "выдерживать",
-                    "терпеть",
-                    "наказание",
+                    "позор",
                     "стойкость"
                 ],
                 "correctIndex": 3
@@ -4102,50 +4135,50 @@
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
-                    "наказание",
-                    "сковывать",
-                    "колодка",
-                    "унижение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erdulden»?",
-                "choices": [
-                    "терпеть",
                     "позор",
-                    "сковывать",
-                    "унижение"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Stock»?",
-                "choices": [
-                    "колодка",
-                    "выдерживать",
-                    "унижение",
-                    "позор"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «ausharren»?",
-                "choices": [
-                    "терпеть",
-                    "колодка",
-                    "унижение",
-                    "выдерживать"
+                    "стойкость",
+                    "наказание",
+                    "сковывать"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «erdulden»?",
+                "choices": [
+                    "стойкость",
+                    "унижение",
+                    "терпеть",
+                    "сковывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Stock»?",
+                "choices": [
+                    "терпеть",
+                    "стойкость",
+                    "выдерживать",
+                    "колодка"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «ausharren»?",
+                "choices": [
+                    "сковывать",
+                    "выдерживать",
+                    "унижение",
+                    "стойкость"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
-                    "колодка",
+                    "наказание",
                     "позор",
-                    "унижение",
-                    "терпеть"
+                    "колодка",
+                    "унижение"
                 ],
                 "correctIndex": 1
             }
@@ -4593,70 +4626,70 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
+                    "утешать",
+                    "сопровождать",
+                    "буря",
+                    "поддержка"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Beistand»?",
+                "choices": [
                     "поддержка",
                     "буря",
                     "утешать",
                     "сопровождать"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Beistand»?",
-                "choices": [
-                    "буря",
-                    "сопровождать",
-                    "утешать",
-                    "поддержка"
-                ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
                     "поддержка",
-                    "выдерживать",
+                    "буря",
                     "сопровождать",
-                    "буря"
+                    "убежище"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
+                    "выдерживать",
+                    "холод",
                     "утешать",
-                    "буря",
-                    "убежище",
-                    "поддержка"
+                    "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "выдерживать",
+                    "сопровождать",
+                    "буря",
                     "убежище",
-                    "холод",
-                    "утешать"
+                    "выдерживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "сопровождать",
-                    "холод",
-                    "утешать",
-                    "выдерживать"
+                    "выдерживать",
+                    "буря",
+                    "поддержка",
+                    "утешать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "убежище",
-                    "холод",
                     "утешать",
-                    "выдерживать"
+                    "холод",
+                    "буря",
+                    "сопровождать"
                 ],
                 "correctIndex": 1
             }
@@ -5158,81 +5191,81 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "плакать",
-                    "смерть",
                     "прощание",
+                    "смерть",
                     "вечный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Abschied»?",
-                "choices": [
-                    "вечный",
-                    "смерть",
-                    "плакать",
-                    "прощание"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ewig»?",
-                "choices": [
-                    "вечный",
-                    "прощание",
-                    "смерть",
-                    "плакать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «weinen»?",
-                "choices": [
-                    "вечный",
-                    "смерть",
-                    "плакать",
-                    "прощание"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «der Abschied»?",
+                "choices": [
+                    "плакать",
+                    "смерть",
+                    "прощание",
+                    "вечный"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «ewig»?",
+                "choices": [
+                    "сдаваться",
+                    "следовать",
+                    "прощание",
+                    "вечный"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «weinen»?",
+                "choices": [
+                    "плакать",
+                    "вечный",
+                    "смерть",
+                    "прощание"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
-                    "смерть",
+                    "плакать",
                     "истощение",
-                    "прощание",
-                    "плакать"
+                    "следовать",
+                    "вечный"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "истощение",
                     "сдаваться",
-                    "плакать",
-                    "скорбь"
+                    "скорбь",
+                    "истощение",
+                    "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "плакать",
+                    "сдаваться",
                     "следовать",
-                    "вечный",
-                    "скорбь"
+                    "скорбь",
+                    "прощание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
+                    "прощание",
+                    "вечный",
                     "следовать",
-                    "плакать",
-                    "смерть",
-                    "прощание"
+                    "плакать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5337,6 +5370,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5870,6 +6274,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5924,6 +6329,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5953,6 +6359,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6016,6 +6423,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6024,6 +6433,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6042,6 +6452,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6090,6 +6502,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6108,6 +6542,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6184,100 +6621,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6286,7 +6675,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6399,6 +6792,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6448,6 +6843,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7195,6 +7592,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7211,6 +7653,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путешествие Короля Лира</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путешествие Короля Лира</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1427 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "власть", "королевство", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["трон", "королевство", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "церемония", "власть", "корона"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["трон", "править", "церемония", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["трон", "провозглашать", "церемония", "корона"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["великолепный", "церемония", "корона", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "провозглашать", "власть", "великолепный"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["королевство", "трон", "великолепный", "церемония"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "проклинать", "гнев", "неблагодарность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["гнев", "неблагодарность", "унижать", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["изгонять", "неблагодарность", "проклятие", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "унижать", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["сожалеть", "обида", "изгонять", "неблагодарность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["гнев", "унижать", "проклинать", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "проклятие", "проклинать", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["унижать", "неблагодарность", "сожалеть", "проклятие"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отвергать", "жестокость", "покидать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "покидать", "отвергать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["нужда", "слеза", "жестокость", "одиночество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["просить", "отчаяние", "слеза", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["одиночество", "жестокость", "нужда", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["слеза", "отвергать", "одиночество", "просить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["нужда", "слеза", "одиночество", "просить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["нужда", "отвергать", "жестокость", "просить"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "безумие", "бушевать", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["гром", "бушевать", "буря", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «toben»?", "choices": ["бушевать", "гром", "буря", "хаос"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "голый", "хаос", "бушевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["безумие", "молния", "голый", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["буря", "кричать", "голый", "бушевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["гром", "бушевать", "голый", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["буря", "гром", "хаос", "голый"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["бедный", "нищий", "мёрзнуть", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищий", "бедный", "мёрзнуть", "нищета"], "correct_index": 0}, {"question": "Что означает немецкое слово «arm»?", "choices": ["мёрзнуть", "шут", "страдать", "бедный"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищий", "шут", "хижина", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["страдать", "хижина", "бедный", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["шут", "страдать", "нищета", "познание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "нищий", "страдать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["шут", "нищета", "познание", "страдать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["правда", "раскаяние", "понимать", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["понимать", "узнавать", "правда", "раскаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["узнавать", "мудрость", "понимать", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["прозрение", "мудрость", "раскаяние", "прощать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["раскаяние", "прозрение", "правда", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["узнавать", "виновный", "правда", "прощать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["понимать", "правда", "мудрость", "прозрение"], "correct_index": 3}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["виновный", "раскаяние", "прозрение", "прощать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["конец", "смерть", "прощать", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "прощать", "смерть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["скорбь", "умирать", "сердце", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["прощание", "вечный", "конец", "сердце"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["смерть", "прощание", "сердце", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["конец", "скорбь", "умирать", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["прощание", "прощать", "умирать", "вечный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["конец", "скорбь", "прощание", "вечный"], "correct_index": 3}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">великолепный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «toben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хаос</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «arm»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,971 +1639,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["трон", "власть", "королевство", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["править", "трон", "власть", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "корона", "власть", "провозглашать"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["трон", "великолепный", "церемония", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["великолепный", "церемония", "провозглашать", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["провозглашать", "корона", "королевство", "трон"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["трон", "церемония", "королевство", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "королевство", "церемония", "провозглашать"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "неблагодарность", "проклинать", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "гнев", "унижать", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["гнев", "проклинать", "неблагодарность", "обида"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["проклинать", "сожалеть", "гнев", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["унижать", "обида", "изгонять", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["сожалеть", "гнев", "неблагодарность", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["проклинать", "сожалеть", "проклятие", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "обида", "изгонять", "гнев"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отчаяние", "покидать", "отвергать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отвергать", "отчаяние", "жестокость", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["покидать", "жестокость", "отвергать", "слеза"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "одиночество", "просить", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["просить", "покидать", "слеза", "одиночество"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["нужда", "жестокость", "одиночество", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["жестокость", "одиночество", "нужда", "слеза"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["покидать", "отчаяние", "жестокость", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "бушевать", "гром", "безумие"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["гром", "буря", "бушевать", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «toben»?", "choices": ["хаос", "безумие", "молния", "бушевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["молния", "гром", "бушевать", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["кричать", "молния", "безумие", "бушевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["молния", "кричать", "хаос", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["бушевать", "безумие", "голый", "гром"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "бушевать", "безумие", "кричать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "мёрзнуть", "нищий", "бедный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищета", "мёрзнуть", "нищий", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «arm»?", "choices": ["нищета", "бедный", "шут", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищий", "мёрзнуть", "хижина", "нищета"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["мёрзнуть", "хижина", "бедный", "шут"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["нищий", "хижина", "познание", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["нищий", "нищета", "шут", "хижина"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["шут", "познание", "страдать", "хижина"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["понимать", "раскаяние", "узнавать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["узнавать", "правда", "понимать", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["понимать", "правда", "раскаяние", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["раскаяние", "понимать", "прозрение", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["правда", "прозрение", "мудрость", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прозрение", "прощать", "раскаяние", "понимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["прощать", "понимать", "прозрение", "раскаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["прозрение", "узнавать", "виновный", "раскаяние"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "прощать", "конец", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "умирать", "прощать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["смерть", "скорбь", "умирать", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["прощание", "вечный", "умирать", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["вечный", "конец", "сердце", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скорбь", "конец", "сердце", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["конец", "прощание", "прощать", "сердце"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["конец", "сердце", "вечный", "скорбь"], "correct_index": 2}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">править</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Undankbarkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «toben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">молния</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">кричать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «arm»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">виновный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -2063,20 +2096,20 @@
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "править",
                     "трон",
-                    "власть",
-                    "королевство"
+                    "королевство",
+                    "править",
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "трон",
-                    "корона",
+                    "править",
+                    "церемония",
                     "власть",
-                    "провозглашать"
+                    "корона"
                 ],
                 "correctIndex": 2
             },
@@ -2084,51 +2117,51 @@
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
                     "трон",
-                    "великолепный",
+                    "править",
                     "церемония",
-                    "править"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verkünden»?",
-                "choices": [
-                    "великолепный",
-                    "церемония",
-                    "провозглашать",
-                    "королевство"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Krone»?",
-                "choices": [
-                    "провозглашать",
-                    "корона",
-                    "королевство",
-                    "трон"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Zeremonie»?",
-                "choices": [
-                    "трон",
-                    "церемония",
-                    "королевство",
                     "власть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «prächtig»?",
+                "question": "Что означает немецкое слово «verkünden»?",
+                "choices": [
+                    "трон",
+                    "провозглашать",
+                    "церемония",
+                    "корона"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
                     "великолепный",
-                    "королевство",
                     "церемония",
-                    "провозглашать"
+                    "корона",
+                    "править"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Zeremonie»?",
+                "choices": [
+                    "церемония",
+                    "провозглашать",
+                    "власть",
+                    "великолепный"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «prächtig»?",
+                "choices": [
+                    "королевство",
+                    "трон",
+                    "великолепный",
+                    "церемония"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2672,58 +2705,58 @@
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
                     "унижать",
-                    "неблагодарность",
                     "проклинать",
-                    "гнев"
+                    "гнев",
+                    "неблагодарность"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "неблагодарность",
                     "гнев",
+                    "неблагодарность",
                     "унижать",
                     "проклинать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Undankbarkeit»?",
-                "choices": [
-                    "гнев",
-                    "проклинать",
-                    "неблагодарность",
-                    "обида"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «verfluchen»?",
-                "choices": [
-                    "проклинать",
-                    "сожалеть",
-                    "гнев",
-                    "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Undankbarkeit»?",
+                "choices": [
+                    "изгонять",
+                    "неблагодарность",
+                    "проклятие",
+                    "унижать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «verfluchen»?",
+                "choices": [
+                    "сожалеть",
+                    "проклинать",
+                    "унижать",
+                    "проклятие"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "унижать",
+                    "сожалеть",
                     "обида",
                     "изгонять",
-                    "сожалеть"
+                    "неблагодарность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "сожалеть",
                     "гнев",
-                    "неблагодарность",
+                    "унижать",
+                    "проклинать",
                     "обида"
                 ],
                 "correctIndex": 3
@@ -2731,22 +2764,22 @@
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "проклинать",
                     "сожалеть",
                     "проклятие",
+                    "проклинать",
                     "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "проклятие",
-                    "обида",
-                    "изгонять",
-                    "гнев"
+                    "унижать",
+                    "неблагодарность",
+                    "сожалеть",
+                    "проклятие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3300,82 +3333,82 @@
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "отчаяние",
-                    "покидать",
                     "отвергать",
-                    "жестокость"
+                    "жестокость",
+                    "покидать",
+                    "отчаяние"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "отвергать",
                     "отчаяние",
-                    "жестокость",
-                    "покидать"
+                    "покидать",
+                    "отвергать",
+                    "жестокость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "покидать",
+                    "нужда",
+                    "слеза",
                     "жестокость",
-                    "отвергать",
-                    "слеза"
+                    "одиночество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "отчаяние",
-                    "одиночество",
                     "просить",
+                    "отчаяние",
+                    "слеза",
                     "жестокость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "просить",
-                    "покидать",
-                    "слеза",
-                    "одиночество"
+                    "одиночество",
+                    "жестокость",
+                    "нужда",
+                    "просить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "нужда",
-                    "жестокость",
+                    "слеза",
+                    "отвергать",
                     "одиночество",
-                    "покидать"
+                    "просить"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "жестокость",
-                    "одиночество",
                     "нужда",
-                    "слеза"
+                    "слеза",
+                    "одиночество",
+                    "просить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "покидать",
-                    "отчаяние",
+                    "нужда",
+                    "отвергать",
                     "жестокость",
-                    "нужда"
+                    "просить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3917,9 +3950,9 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "буря",
+                    "безумие",
                     "бушевать",
-                    "гром",
-                    "безумие"
+                    "гром"
                 ],
                 "correctIndex": 0
             },
@@ -3927,8 +3960,8 @@
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
                     "гром",
-                    "буря",
                     "бушевать",
+                    "буря",
                     "безумие"
                 ],
                 "correctIndex": 3
@@ -3936,62 +3969,62 @@
             {
                 "question": "Что означает немецкое слово «toben»?",
                 "choices": [
-                    "хаос",
-                    "безумие",
-                    "молния",
-                    "бушевать"
+                    "бушевать",
+                    "гром",
+                    "буря",
+                    "хаос"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "молния",
                     "гром",
-                    "бушевать",
-                    "кричать"
+                    "голый",
+                    "хаос",
+                    "бушевать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "кричать",
-                    "молния",
                     "безумие",
-                    "бушевать"
+                    "молния",
+                    "голый",
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "молния",
+                    "буря",
                     "кричать",
-                    "хаос",
-                    "голый"
+                    "голый",
+                    "бушевать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
+                    "гром",
                     "бушевать",
-                    "безумие",
                     "голый",
-                    "гром"
+                    "кричать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
+                    "буря",
+                    "гром",
                     "хаос",
-                    "бушевать",
-                    "безумие",
-                    "кричать"
+                    "голый"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4549,82 +4582,82 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "нищета",
-                    "мёрзнуть",
+                    "бедный",
                     "нищий",
-                    "бедный"
+                    "мёрзнуть",
+                    "нищета"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "нищета",
-                    "мёрзнуть",
                     "нищий",
-                    "бедный"
+                    "бедный",
+                    "мёрзнуть",
+                    "нищета"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «arm»?",
                 "choices": [
-                    "нищета",
-                    "бедный",
+                    "мёрзнуть",
                     "шут",
-                    "мёрзнуть"
+                    "страдать",
+                    "бедный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
                     "нищий",
-                    "мёрзнуть",
+                    "шут",
                     "хижина",
-                    "нищета"
+                    "мёрзнуть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "мёрзнуть",
+                    "страдать",
                     "хижина",
                     "бедный",
-                    "шут"
+                    "нищий"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "нищий",
-                    "хижина",
-                    "познание",
-                    "страдать"
+                    "шут",
+                    "страдать",
+                    "нищета",
+                    "познание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "нищий",
-                    "нищета",
                     "шут",
-                    "хижина"
+                    "нищий",
+                    "страдать",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
                     "шут",
+                    "нищета",
                     "познание",
-                    "страдать",
-                    "хижина"
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5172,82 +5205,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "понимать",
+                    "правда",
                     "раскаяние",
-                    "узнавать",
-                    "правда"
+                    "понимать",
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
+                    "понимать",
                     "узнавать",
                     "правда",
-                    "понимать",
                     "раскаяние"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Wahrheit»?",
-                "choices": [
-                    "понимать",
-                    "правда",
-                    "раскаяние",
-                    "мудрость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Reue»?",
-                "choices": [
-                    "раскаяние",
-                    "понимать",
-                    "прозрение",
-                    "мудрость"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Weisheit»?",
+                "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "правда",
+                    "узнавать",
+                    "мудрость",
+                    "понимать",
+                    "правда"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Reue»?",
+                "choices": [
                     "прозрение",
                     "мудрость",
-                    "раскаяние"
+                    "раскаяние",
+                    "прощать"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Weisheit»?",
+                "choices": [
+                    "раскаяние",
+                    "прозрение",
+                    "правда",
+                    "мудрость"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "прозрение",
-                    "прощать",
-                    "раскаяние",
-                    "понимать"
+                    "узнавать",
+                    "виновный",
+                    "правда",
+                    "прощать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Einsicht»?",
                 "choices": [
-                    "прощать",
                     "понимать",
-                    "прозрение",
-                    "раскаяние"
+                    "правда",
+                    "мудрость",
+                    "прозрение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
-                    "прозрение",
-                    "узнавать",
                     "виновный",
-                    "раскаяние"
+                    "раскаяние",
+                    "прозрение",
+                    "прощать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5813,82 +5846,82 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "умирать",
-                    "прощать",
                     "конец",
-                    "смерть"
+                    "смерть",
+                    "прощать",
+                    "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "конец",
-                    "умирать",
                     "прощать",
-                    "смерть"
+                    "смерть",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "смерть",
                     "скорбь",
                     "умирать",
+                    "сердце",
                     "конец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "прощание",
                     "вечный",
-                    "умирать",
-                    "конец"
+                    "конец",
+                    "сердце"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "вечный",
-                    "конец",
+                    "смерть",
+                    "прощание",
                     "сердце",
-                    "смерть"
+                    "конец"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
+                    "конец",
                     "скорбь",
-                    "конец",
-                    "сердце",
-                    "смерть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Abschied»?",
-                "choices": [
-                    "конец",
-                    "прощание",
-                    "прощать",
+                    "умирать",
                     "сердце"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Abschied»?",
+                "choices": [
+                    "прощание",
+                    "прощать",
+                    "умирать",
+                    "вечный"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "конец",
-                    "сердце",
-                    "вечный",
-                    "скорбь"
+                    "скорбь",
+                    "прощание",
+                    "вечный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6009,6 +6042,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -6542,6 +6946,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -6596,6 +7001,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -6625,6 +7031,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6688,6 +7095,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6696,6 +7105,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6714,6 +7124,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6762,6 +7174,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6780,6 +7214,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6856,100 +7293,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6958,7 +7347,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -7071,6 +7464,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -7120,6 +7515,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7867,6 +8264,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7883,6 +8325,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Освальда</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Освальда</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="steward">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="steward">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="messenger">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="insult">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="spy">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="schemer">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="pursuer">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="coward_death">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["послушание", "преданность", "служить", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["служить", "слуга", "послушание", "преданность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["исполнять", "управляющий", "послушание", "преданность"], "correct_index": 3}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["послушание", "слуга", "управляющий", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["послушание", "служить", "слуга", "управляющий"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["слуга", "служить", "покорный", "послушание"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["служить", "слуга", "раболепный", "исполнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["раболепный", "преданность", "слуга", "исполнять"], "correct_index": 3}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["поручение", "спешка", "передавать", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["поручение", "гонец", "спешка", "передавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["поручение", "спешка", "передавать", "спешить"], "correct_index": 1}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["торопиться", "спешить", "гонец", "передавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "спешка", "передавать", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["спешка", "торопиться", "спешить", "послание"], "correct_index": 3}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["послание", "гонец", "поручение", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорблять", "неуважение", "оскорбление"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["неуважение", "трусость", "оскорбление", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусость", "оскорблять", "оскорбление", "трусливый"], "correct_index": 0}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["неуважение", "оскорбление", "оскорблять", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["оскорблять", "пренебрегать", "высмеивать", "трусливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «frech»?", "choices": ["неуважение", "трусость", "дерзкий", "оскорбление"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["оскорбление", "дерзкий", "трусость", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["неуважение", "оскорблять", "трусливый", "высмеивать"], "correct_index": 2}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "шпион", "скрытность", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["предательство", "шпион", "шпионить", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["вынюхивать", "скрытность", "выдавать", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["выдавать", "вынюхивать", "шпионить", "подслушивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["вынюхивать", "скрытность", "подслушивать", "шпион"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["выдавать", "шпион", "предательство", "вынюхивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "скрытность", "выдавать", "предательство"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "ковать", "план", "коварство"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "коварство", "план", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["план", "коварный", "обманывать", "коварство"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["коварный", "ковать", "коварство", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["ловушка", "план", "интрига", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["план", "интрига", "коварный", "ловушка"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ловушка", "хитрый", "коварный", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["интрига", "коварный", "ловушка", "коварство"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["охота", "преследование", "преследовать", "гнаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["гнаться", "преследовать", "охота", "преследование"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["добыча", "преследование", "преследовать", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["охота", "гнаться", "преследование", "добыча"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["гнаться", "выслеживать", "травить", "охота"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["гнаться", "травить", "преследовать", "добыча"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["добыча", "преследовать", "гнаться", "охота"], "correct_index": 0}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "смерть", "трусость", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["смерть", "трусость", "падать", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["хныкать", "умолять", "жалкий", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["смерть", "падать", "проигрывать", "хныкать"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["умолять", "проигрывать", "смерть", "хныкать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["хныкать", "поражение", "умолять", "трусость"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["поражение", "проигрывать", "трусость", "умолять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "умолять", "хныкать", "жалкий"], "correct_index": 3}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="steward">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">управляющий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">исполнять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="messenger">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спешить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">послание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="insult">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «feige»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трусливый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="spy">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="schemer">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="pursuer">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="coward_death">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="messenger">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="steward">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="messenger">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="insult">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="spy">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="schemer">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="pursuer">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="coward_death">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="insult">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="spy">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="schemer">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="pursuer">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="coward_death">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="steward">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="messenger">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="insult">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="spy">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="schemer">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="pursuer">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="coward_death">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "преданность", "служить", "послушание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "слуга", "преданность", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["послушание", "преданность", "исполнять", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["раболепный", "преданность", "исполнять", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["управляющий", "послушание", "слуга", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["покорный", "преданность", "раболепный", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["раболепный", "слуга", "служить", "управляющий"], "correct_index": 0}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["преданность", "исполнять", "покорный", "управляющий"], "correct_index": 1}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["поручение", "передавать", "гонец", "спешка"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["гонец", "спешка", "поручение", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["гонец", "спешить", "спешка", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["поручение", "послание", "передавать", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["торопиться", "спешка", "спешить", "передавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["спешить", "передавать", "послание", "торопиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["торопиться", "послание", "передавать", "спешка"], "correct_index": 0}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорбление", "неуважение", "оскорблять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорбление", "трусость", "оскорблять", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["оскорблять", "трусость", "неуважение", "высмеивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["дерзкий", "трусливый", "трусость", "оскорблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["трусливый", "пренебрегать", "высмеивать", "трусость"], "correct_index": 2}, {"question": "Что означает немецкое слово «frech»?", "choices": ["трусость", "дерзкий", "неуважение", "оскорбление"], "correct_index": 1}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["пренебрегать", "оскорбление", "высмеивать", "оскорблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусость", "трусливый", "оскорблять", "пренебрегать"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "скрытность", "шпион", "предательство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпионить", "шпион", "скрытность", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпион", "скрытность", "вынюхивать", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["скрытность", "выдавать", "шпионить", "вынюхивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["шпион", "выдавать", "вынюхивать", "подслушивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["шпион", "предательство", "выдавать", "подслушивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["шпион", "вынюхивать", "предательство", "шпионить"], "correct_index": 1}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["ковать", "план", "интрига", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["коварство", "план", "ковать", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["обманывать", "хитрый", "коварство", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["интрига", "коварство", "ковать", "коварный"], "correct_index": 2}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["план", "интрига", "обманывать", "хитрый"], "correct_index": 2}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварный", "ковать", "коварство", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["хитрый", "обманывать", "план", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["хитрый", "обманывать", "ловушка", "коварство"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["охота", "преследовать", "гнаться", "преследование"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследование", "гнаться", "охота", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "травить", "выслеживать", "гнаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["выслеживать", "гнаться", "охота", "травить"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["преследовать", "выслеживать", "травить", "добыча"], "correct_index": 1}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["преследование", "выслеживать", "травить", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["выслеживать", "преследовать", "добыча", "гнаться"], "correct_index": 2}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "трусость", "падать", "поражение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["падать", "смерть", "трусость", "поражение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["проигрывать", "жалкий", "умолять", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "проигрывать", "смерть", "умолять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["умолять", "трусость", "проигрывать", "хныкать"], "correct_index": 2}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["падать", "трусость", "жалкий", "хныкать"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["трусость", "хныкать", "умолять", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["умолять", "жалкий", "смерть", "хныкать"], "correct_index": 1}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="steward">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Ergebenheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">исполнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="messenger">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Auftrag»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">послание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="insult">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «frech»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">высмеивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «feige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="spy">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «lauschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="schemer">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">коварный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ковать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">план</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="pursuer">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">травить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «hetzen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выслеживать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="coward_death">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хныкать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1951,39 +1984,39 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "слуга",
+                    "послушание",
                     "преданность",
                     "служить",
-                    "послушание"
+                    "слуга"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
-                    "послушание",
+                    "служить",
                     "слуга",
-                    "преданность",
-                    "служить"
+                    "послушание",
+                    "преданность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
-                    "послушание",
-                    "преданность",
                     "исполнять",
-                    "служить"
+                    "управляющий",
+                    "послушание",
+                    "преданность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "раболепный",
-                    "преданность",
-                    "исполнять",
+                    "послушание",
+                    "слуга",
+                    "управляющий",
                     "служить"
                 ],
                 "correctIndex": 3
@@ -1991,42 +2024,42 @@
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "управляющий",
                     "послушание",
+                    "служить",
                     "слуга",
-                    "служить"
+                    "управляющий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
+                    "слуга",
+                    "служить",
                     "покорный",
-                    "преданность",
-                    "раболепный",
-                    "служить"
+                    "послушание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "раболепный",
-                    "слуга",
                     "служить",
-                    "управляющий"
+                    "слуга",
+                    "раболепный",
+                    "исполнять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
+                    "раболепный",
                     "преданность",
-                    "исполнять",
-                    "покорный",
-                    "управляющий"
+                    "слуга",
+                    "исполнять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2453,71 +2486,71 @@
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
                     "поручение",
+                    "спешка",
                     "передавать",
-                    "гонец",
-                    "спешка"
+                    "гонец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
+                    "поручение",
                     "гонец",
                     "спешка",
-                    "поручение",
                     "передавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "гонец",
-                    "спешить",
+                    "поручение",
                     "спешка",
-                    "торопиться"
+                    "передавать",
+                    "спешить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
-                    "поручение",
-                    "послание",
-                    "передавать",
-                    "торопиться"
+                    "торопиться",
+                    "спешить",
+                    "гонец",
+                    "передавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
-                    "торопиться",
-                    "спешка",
                     "спешить",
-                    "передавать"
+                    "спешка",
+                    "передавать",
+                    "торопиться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
                 "choices": [
+                    "спешка",
+                    "торопиться",
                     "спешить",
-                    "передавать",
-                    "послание",
-                    "торопиться"
+                    "послание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "торопиться",
                     "послание",
-                    "передавать",
-                    "спешка"
+                    "гонец",
+                    "поручение",
+                    "торопиться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2993,81 +3026,81 @@
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
                     "трусость",
-                    "оскорбление",
+                    "оскорблять",
                     "неуважение",
-                    "оскорблять"
+                    "оскорбление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорбление",
+                    "неуважение",
                     "трусость",
-                    "оскорблять",
-                    "неуважение"
+                    "оскорбление",
+                    "оскорблять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "оскорблять",
                     "трусость",
-                    "неуважение",
-                    "высмеивать"
+                    "оскорблять",
+                    "оскорбление",
+                    "трусливый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
-                    "дерзкий",
-                    "трусливый",
-                    "трусость",
-                    "оскорблять"
+                    "неуважение",
+                    "оскорбление",
+                    "оскорблять",
+                    "трусость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "трусливый",
+                    "оскорблять",
                     "пренебрегать",
                     "высмеивать",
-                    "трусость"
+                    "трусливый"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «frech»?",
                 "choices": [
+                    "неуважение",
                     "трусость",
                     "дерзкий",
-                    "неуважение",
                     "оскорбление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «missachten»?",
                 "choices": [
-                    "пренебрегать",
                     "оскорбление",
-                    "высмеивать",
-                    "оскорблять"
+                    "дерзкий",
+                    "трусость",
+                    "пренебрегать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "трусость",
-                    "трусливый",
+                    "неуважение",
                     "оскорблять",
-                    "пренебрегать"
+                    "трусливый",
+                    "высмеивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3499,28 +3532,28 @@
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
                     "шпионить",
-                    "скрытность",
                     "шпион",
+                    "скрытность",
                     "предательство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "шпионить",
+                    "предательство",
                     "шпион",
-                    "скрытность",
-                    "предательство"
+                    "шпионить",
+                    "скрытность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "шпион",
-                    "скрытность",
                     "вынюхивать",
+                    "скрытность",
+                    "выдавать",
                     "предательство"
                 ],
                 "correctIndex": 1
@@ -3528,42 +3561,42 @@
             {
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
-                    "скрытность",
                     "выдавать",
+                    "вынюхивать",
                     "шпионить",
-                    "вынюхивать"
+                    "подслушивать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
-                    "шпион",
-                    "выдавать",
                     "вынюхивать",
-                    "подслушивать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verraten»?",
-                "choices": [
-                    "шпион",
-                    "предательство",
-                    "выдавать",
-                    "подслушивать"
+                    "скрытность",
+                    "подслушивать",
+                    "шпион"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «verraten»?",
+                "choices": [
+                    "выдавать",
+                    "шпион",
+                    "предательство",
+                    "вынюхивать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
-                    "шпион",
                     "вынюхивать",
-                    "предательство",
-                    "шпионить"
+                    "скрытность",
+                    "выдавать",
+                    "предательство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4050,78 +4083,78 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
+                    "интрига",
                     "ковать",
                     "план",
-                    "интрига",
                     "коварство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
+                    "ковать",
                     "коварство",
                     "план",
+                    "интрига"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Hinterlist»?",
+                "choices": [
+                    "план",
+                    "коварный",
+                    "обманывать",
+                    "коварство"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «schmieden»?",
+                "choices": [
+                    "коварный",
                     "ковать",
+                    "коварство",
                     "интрига"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Hinterlist»?",
-                "choices": [
-                    "обманывать",
-                    "хитрый",
-                    "коварство",
-                    "ковать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schmieden»?",
-                "choices": [
-                    "интрига",
-                    "коварство",
-                    "ковать",
-                    "коварный"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
+                    "ловушка",
                     "план",
                     "интрига",
-                    "обманывать",
-                    "хитрый"
+                    "обманывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
+                    "план",
+                    "интрига",
                     "коварный",
-                    "ковать",
-                    "коварство",
                     "ловушка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
+                    "ловушка",
                     "хитрый",
-                    "обманывать",
-                    "план",
-                    "ловушка"
+                    "коварный",
+                    "коварство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "хитрый",
-                    "обманывать",
+                    "интрига",
+                    "коварный",
                     "ловушка",
                     "коварство"
                 ],
@@ -4562,71 +4595,71 @@
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
                     "охота",
+                    "преследование",
                     "преследовать",
-                    "гнаться",
-                    "преследование"
+                    "гнаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
-                    "преследование",
                     "гнаться",
+                    "преследовать",
                     "охота",
-                    "преследовать"
+                    "преследование"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
+                    "добыча",
+                    "преследование",
                     "преследовать",
-                    "травить",
-                    "выслеживать",
-                    "гнаться"
+                    "охота"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
-                    "выслеживать",
-                    "гнаться",
                     "охота",
-                    "травить"
+                    "гнаться",
+                    "преследование",
+                    "добыча"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
-                    "преследовать",
+                    "гнаться",
                     "выслеживать",
                     "травить",
-                    "добыча"
+                    "охота"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
-                    "преследование",
-                    "выслеживать",
+                    "гнаться",
                     "травить",
-                    "преследовать"
+                    "преследовать",
+                    "добыча"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "выслеживать",
-                    "преследовать",
                     "добыча",
-                    "гнаться"
+                    "преследовать",
+                    "гнаться",
+                    "охота"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5112,29 +5145,29 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
+                    "падать",
                     "смерть",
                     "трусость",
-                    "падать",
                     "поражение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "падать",
                     "смерть",
                     "трусость",
+                    "падать",
                     "поражение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "проигрывать",
-                    "жалкий",
+                    "хныкать",
                     "умолять",
+                    "жалкий",
                     "поражение"
                 ],
                 "correctIndex": 3
@@ -5142,52 +5175,52 @@
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
+                    "смерть",
                     "падать",
                     "проигрывать",
-                    "смерть",
-                    "умолять"
+                    "хныкать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
                     "умолять",
-                    "трусость",
                     "проигрывать",
-                    "хныкать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «wimmern»?",
-                "choices": [
-                    "падать",
-                    "трусость",
-                    "жалкий",
-                    "хныкать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «betteln»?",
-                "choices": [
-                    "трусость",
-                    "хныкать",
-                    "умолять",
-                    "проигрывать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «erbärmlich»?",
-                "choices": [
-                    "умолять",
-                    "жалкий",
                     "смерть",
                     "хныкать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «wimmern»?",
+                "choices": [
+                    "хныкать",
+                    "поражение",
+                    "умолять",
+                    "трусость"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «betteln»?",
+                "choices": [
+                    "поражение",
+                    "проигрывать",
+                    "трусость",
+                    "умолять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «erbärmlich»?",
+                "choices": [
+                    "трусость",
+                    "умолять",
+                    "хныкать",
+                    "жалкий"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5292,6 +5325,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5825,6 +6229,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5879,6 +6284,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5908,6 +6314,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -5971,6 +6378,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -5979,6 +6388,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -5997,6 +6407,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6045,6 +6457,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6063,6 +6497,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6139,100 +6576,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6241,7 +6630,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6354,6 +6747,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6403,6 +6798,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7150,6 +7547,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7166,6 +7608,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 Путь Реганы</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 Путь Реганы</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">
@@ -151,435 +157,1379 @@
             </div>
         </div>
 
-        <div class="constructor-section">
-            <h2>🧩 Конструктор предложений</h2>
-            <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
+        <div class="exercises-section">
+            <h2>📝 Упражнения</h2>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-            
-            <section class="constructor-panel active" data-phase="throne">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🔗 Подбор слов
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="relations-wrapper">
+                        
+                        
+                        
+                        <section class="relations-container active" data-phase="throne">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="goneril">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="regan">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="storm">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="hut">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="dover">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
+                        
+                        
+                        <section class="relations-container" data-phase="prison">
+                            <h3 class="relations-title">🔗 Подбор слов</h3>
+                            <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+
+                            <div class="relation-section word-families-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>👪 Семья слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section synonyms-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🔗 Подбор слов</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            <div class="relation-section collocations-section" data-has-content="true">
+                                <button class="relation-toggle" type="button">
+                                    <span>🧩 Коллокации</span>
+                                    <span class="toggle-icon">▼</span>
+                                </button>
+                                <div class="relations-content"></div>
+                            </div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
+            </div>
 
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧠 Викторина по фазам
+                </button>
+                <div class="exercise-content collapsed">
+                    
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["фальшь", "состязаться", "притворяться", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "фальшь", "состязаться", "превосходить"], "correct_index": 3}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "алчность", "фальшь", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["притворяться", "состязаться", "фальшь", "алчность"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["выманивать", "притворяться", "хитрость", "разыгрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["разыгрывать", "фальшь", "хитрость", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["хитрость", "фальшь", "выманивать", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["состязаться", "фальшь", "притворяться", "алчность"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["делить", "планировать", "заговорить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["планировать", "союз", "заговорить", "делить"], "correct_index": 3}, {"question": "Что означает немецкое слово «planen»?", "choices": ["сговор", "стратегия", "планировать", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["сговор", "договариваться", "делить", "заговорить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["стратегия", "сговор", "союз", "планировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "планировать", "стратегия", "сговор"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["союз", "сговор", "планировать", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "злоба", "унижать", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "пытать", "унижать", "насмехаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["насмехаться", "жестоко обращаться", "жёсткость", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["насмехаться", "злоба", "жестоко обращаться", "жёсткость"], "correct_index": 1}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["отвергать", "жестоко обращаться", "пытать", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["насмехаться", "унижать", "жёсткость", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жестокость", "отвергать", "насмехаться", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестокость", "унижать", "жёсткость", "насмехаться"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["наслаждаться", "садизм", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "садизм", "ослеплять", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["выкалывать", "беспощадный", "садизм", "наслаждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["растаптывать", "садизм", "ослеплять", "выкалывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "выкалывать", "брутальность", "садизм"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["выкалывать", "беспощадный", "садизм", "наслаждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["пытка", "наслаждаться", "беспощадный", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "ослеплять", "наслаждаться", "растаптывать"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вожделение", "вдова", "вожделеть", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вдова", "вожделеть", "вожделение", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["заманивать", "вдова", "соблазнять", "вожделение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделение", "заманивать", "вожделеть", "похоть"], "correct_index": 0}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "похоть", "вдова", "добиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделение", "вожделеть", "вдова", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «werben»?", "choices": ["соблазнять", "похоть", "добиваться", "вдова"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "ненавидеть", "угрожать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["соперничество", "ненавидеть", "угрожать", "соревноваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["подозревать", "не доверять", "угрожать", "соперничество"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["подозревать", "соперничество", "не доверять", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["не доверять", "угрожать", "соперничество", "бороться"], "correct_index": 3}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["не доверять", "соперничество", "угрожать", "соревноваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["подозревать", "бороться", "ненавидеть", "соревноваться"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "страдать", "издыхать", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "издыхать", "отравленный", "мучение"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклинать", "рок", "издыхать", "мучение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["отравленный", "мучение", "рок", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["страдать", "проклятый", "мучение", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "проклятый", "издыхать", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["расплачиваться", "отравленный", "проклинать", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["страдать", "проклятый", "проклинать", "издыхать"], "correct_index": 1}]}'>
+                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
+                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
+                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
+                            <div class="quiz-progress-row">
+                                <span class="quiz-progress-label">Прогресс:</span>
+                                <span class="quiz-progress-value" data-quiz-progress>—</span>
+                            </div>
+                            <div class="quiz-errors-container" data-quiz-errors>
+                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                            </div>
+                        </div>
+                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
+
+                        
+                        <div class="quiz-phase-container active" data-phase="throne">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="goneril">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">делить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «planen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">договариваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="regan">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="storm">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наслаждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="hut">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вдова</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «locken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добиваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «werben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="dover">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                        <div class="quiz-phase-container" data-phase="prison">
+                            
+                                
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рок</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                            
+                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
+                        </div>
+                        
+                    </div>
+                    
                 </div>
+            </div>
 
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
+            <div class="exercise-item">
+                <button class="exercise-toggle" type="button">
+                    <span class="toggle-icon">▶</span>
+                    🧩 Конструктор предложений
+                </button>
+                <div class="exercise-content collapsed">
+                    <div class="constructor-section">
+                        <p class="constructor-intro">Соберите немецкое предложение из фрагментов и проверьте себя по переводу.</p>
 
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="goneril">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+                        
+                        <section class="constructor-panel active" data-phase="throne">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
 
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="goneril">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="regan">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="storm">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="hut">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="dover">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
+                        <section class="constructor-panel" data-phase="prison">
+                            <div class="constructor-header">
+                                <div class="constructor-word" data-constructor-word>—</div>
+                                <div class="constructor-translation" data-constructor-translation></div>
+                                <div class="constructor-progress" data-constructor-progress></div>
+                            </div>
+                            <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
+
+                            <div class="constructor-areas">
+                                <div class="constructor-source" data-constructor-source></div>
+                                <div class="constructor-target" data-constructor-target>
+                                    <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
+                                </div>
+                            </div>
+
+                            <div class="constructor-controls">
+                                <button class="constructor-control constructor-check" type="button">Проверить</button>
+                                <button class="constructor-control constructor-reset" type="button">Сбросить</button>
+                                <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
+                            </div>
+
+                            <div class="constructor-feedback" aria-live="polite"></div>
+                            <div class="constructor-original" data-constructor-original></div>
+
+                            
+                        </section>
+                        
                     </div>
                 </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="regan">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="storm">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="hut">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="dover">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-            <section class="constructor-panel" data-phase="prison">
-                <div class="constructor-header">
-                    <div class="constructor-word" data-constructor-word>—</div>
-                    <div class="constructor-translation" data-constructor-translation></div>
-                    <div class="constructor-progress" data-constructor-progress></div>
-                </div>
-                <p class="constructor-hint" data-constructor-hint>Выберите следующую фразу, чтобы начать тренировку.</p>
-
-                <div class="constructor-areas">
-                    <div class="constructor-source" data-constructor-source></div>
-                    <div class="constructor-target" data-constructor-target>
-                        <div class="constructor-placeholder">Перетащите или нажмите на фрагменты, чтобы собрать предложение.</div>
-                    </div>
-                </div>
-
-                <div class="constructor-controls">
-                    <button class="constructor-control constructor-check" type="button">Проверить</button>
-                    <button class="constructor-control constructor-reset" type="button">Сбросить</button>
-                    <button class="constructor-control constructor-next" type="button">Следующее предложение</button>
-                </div>
-
-                <div class="constructor-feedback" aria-live="polite"></div>
-                <div class="constructor-original" data-constructor-original></div>
-
-                
-            </section>
-            
-        </div>
-
-        <div class="relations-wrapper">
-            
-            
-            
-            <section class="relations-container active" data-phase="throne">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="goneril">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="regan">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="storm">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="hut">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="dover">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
-            
-            
-            <section class="relations-container" data-phase="prison">
-                <h3 class="relations-title">🔗 Связи слов</h3>
-                <p class="relations-subtitle">Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
-
-                <div class="relation-section word-families-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>👪 Семья слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section synonyms-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🔗 Подбор слов</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                <div class="relation-section collocations-section" data-has-content="true">
-                    <button class="relation-toggle" type="button">
-                        <span>🧩 Коллокации</span>
-                        <span class="toggle-icon">▼</span>
-                    </button>
-                    <div class="relations-content"></div>
-                </div>
-
-                
-            </section>
-            
+            </div>
         </div>
 
         <div class="exercises-container">
@@ -641,923 +1591,6 @@
             </div>
             
         </div>
-
-        
-        <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["фальшь", "состязаться", "притворяться", "превосходить"], "correct_index": 2}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "состязаться", "превосходить", "фальшь"], "correct_index": 2}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "алчность", "разыгрывать", "превосходить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["разыгрывать", "притворяться", "состязаться", "фальшь"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["состязаться", "хитрость", "разыгрывать", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die List»?", "choices": ["выманивать", "разыгрывать", "фальшь", "хитрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["состязаться", "алчность", "превосходить", "выманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["фальшь", "состязаться", "алчность", "хитрость"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["делить", "планировать", "союз", "заговорить"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["делить", "заговорить", "союз", "планировать"], "correct_index": 0}, {"question": "Что означает немецкое слово «planen»?", "choices": ["союз", "делить", "планировать", "стратегия"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["сговор", "планировать", "союз", "заговорить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["сговор", "стратегия", "делить", "договариваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["договариваться", "стратегия", "планировать", "сговор"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["договариваться", "делить", "заговорить", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["злоба", "насмехаться", "унижать", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "унижать", "насмехаться", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["отвергать", "насмехаться", "жёсткость", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["злоба", "отвергать", "жёсткость", "жестокость"], "correct_index": 0}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["унижать", "пытать", "жестоко обращаться", "жёсткость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жестокость", "жёсткость", "отвергать", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["отвергать", "унижать", "пытать", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жестоко обращаться", "жестокость", "пытать", "отвергать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "наслаждаться", "садизм", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "ослеплять", "наслаждаться", "садизм"], "correct_index": 3}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["садизм", "наслаждаться", "беспощадный", "растаптывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["растаптывать", "беспощадный", "выкалывать", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["растаптывать", "ослеплять", "пытка", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["беспощадный", "растаптывать", "пытка", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "выкалывать", "брутальность", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["пытка", "садизм", "ослеплять", "растаптывать"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вожделеть", "вдова", "соблазнять", "вожделение"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделение", "вожделеть", "соблазнять", "вдова"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "вдова", "похоть", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["вожделение", "вдова", "заманивать", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «locken»?", "choices": ["добиваться", "вожделение", "вдова", "заманивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["заманивать", "похоть", "добиваться", "соблазнять"], "correct_index": 1}, {"question": "Что означает немецкое слово «werben»?", "choices": ["добиваться", "вожделение", "заманивать", "вожделеть"], "correct_index": 0}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["угрожать", "соперничество", "соревноваться", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["угрожать", "ненавидеть", "соперничество", "соревноваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "подозревать", "угрожать", "не доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соперничество", "не доверять", "угрожать", "подозревать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["соперничество", "ненавидеть", "бороться", "угрожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["бороться", "соперничество", "подозревать", "не доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["бороться", "соревноваться", "не доверять", "подозревать"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["издыхать", "страдать", "мучение", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "мучение", "отравленный", "издыхать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["рок", "мучение", "издыхать", "расплачиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["отравленный", "мучение", "проклинать", "расплачиваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["мучение", "страдать", "рок", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["проклинать", "отравленный", "расплачиваться", "рок"], "correct_index": 3}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["мучение", "издыхать", "расплачиваться", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["расплачиваться", "проклятый", "рок", "страдать"], "correct_index": 1}]}'>
-            <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
-                <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                <div class="quiz-progress-row">
-                    <span class="quiz-progress-label">Прогресс:</span>
-                    <span class="quiz-progress-value" data-quiz-progress>—</span>
-                </div>
-                <div class="quiz-errors-container" data-quiz-errors>
-                    <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
-                </div>
-            </div>
-            <h2>🧠 Викторина по фазам</h2>
-            <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">8</span> вопрос(ов).</p>
-
-            
-            <div class="quiz-phase-container active" data-phase="throne">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «wetteifern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="goneril">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «planen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заговорить</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">договариваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="regan">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="storm">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">растаптывать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="hut">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «locken»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">заманивать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «werben»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">добиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">заманивать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="dover">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">не доверять</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">не доверять</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">подозревать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-            <div class="quiz-phase-container" data-phase="prison">
-                
-                    
-                    <div class="quiz-card active" data-question-index="0" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                        <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">рок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                        <div class="quiz-question">Что означает немецкое слово «das Verhängnis»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                        <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                    <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                        <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
-                        <div class="quiz-choices">
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="1">проклятый</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
-                            
-                            <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                            
-                        </div>
-                        <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                    </div>
-                    
-                
-                <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-            </div>
-            
-        </div>
-        
 
         <nav class="bottom-nav">
             <a href="../index.html" class="nav-link">← К главной</a>
@@ -1978,71 +2011,71 @@
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
                     "притворяться",
+                    "фальшь",
                     "состязаться",
-                    "превосходить",
-                    "фальшь"
+                    "превосходить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
                     "состязаться",
                     "алчность",
-                    "разыгрывать",
-                    "превосходить"
+                    "фальшь",
+                    "выманивать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
-                    "разыгрывать",
                     "притворяться",
                     "состязаться",
-                    "фальшь"
+                    "фальшь",
+                    "алчность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "состязаться",
+                    "выманивать",
+                    "притворяться",
                     "хитрость",
-                    "разыгрывать",
-                    "выманивать"
+                    "разыгрывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "выманивать",
                     "разыгрывать",
                     "фальшь",
-                    "хитрость"
+                    "хитрость",
+                    "выманивать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
-                    "состязаться",
-                    "алчность",
-                    "превосходить",
-                    "выманивать"
+                    "хитрость",
+                    "фальшь",
+                    "выманивать",
+                    "превосходить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
-                    "фальшь",
                     "состязаться",
-                    "алчность",
-                    "хитрость"
+                    "фальшь",
+                    "притворяться",
+                    "алчность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2472,28 +2505,28 @@
                 "choices": [
                     "делить",
                     "планировать",
-                    "союз",
-                    "заговорить"
+                    "заговорить",
+                    "союз"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
-                    "делить",
-                    "заговорить",
+                    "планировать",
                     "союз",
-                    "планировать"
+                    "заговорить",
+                    "делить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «planen»?",
                 "choices": [
-                    "союз",
-                    "делить",
+                    "сговор",
+                    "стратегия",
                     "планировать",
-                    "стратегия"
+                    "заговорить"
                 ],
                 "correctIndex": 2
             },
@@ -2501,8 +2534,8 @@
                 "question": "Что означает немецкое слово «verschwören»?",
                 "choices": [
                     "сговор",
-                    "планировать",
-                    "союз",
+                    "договариваться",
+                    "делить",
                     "заговорить"
                 ],
                 "correctIndex": 3
@@ -2510,19 +2543,19 @@
             {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "сговор",
                     "стратегия",
-                    "делить",
-                    "договариваться"
+                    "сговор",
+                    "союз",
+                    "планировать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
                     "договариваться",
-                    "стратегия",
                     "планировать",
+                    "стратегия",
                     "сговор"
                 ],
                 "correctIndex": 0
@@ -2530,9 +2563,9 @@
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
-                    "договариваться",
-                    "делить",
-                    "заговорить",
+                    "союз",
+                    "сговор",
+                    "планировать",
                     "стратегия"
                 ],
                 "correctIndex": 3
@@ -3061,8 +3094,8 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "злоба",
                     "насмехаться",
+                    "злоба",
                     "унижать",
                     "пытать"
                 ],
@@ -3072,71 +3105,71 @@
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
                     "злоба",
-                    "унижать",
-                    "насмехаться",
-                    "пытать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verhöhnen»?",
-                "choices": [
-                    "отвергать",
-                    "насмехаться",
-                    "жёсткость",
-                    "жестокость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "злоба",
-                    "отвергать",
-                    "жёсткость",
-                    "жестокость"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «misshandeln»?",
-                "choices": [
-                    "унижать",
                     "пытать",
-                    "жестоко обращаться",
-                    "жёсткость"
+                    "унижать",
+                    "насмехаться"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «verhöhnen»?",
+                "choices": [
+                    "насмехаться",
+                    "жестоко обращаться",
+                    "жёсткость",
+                    "жестокость"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Bosheit»?",
+                "choices": [
+                    "насмехаться",
+                    "злоба",
+                    "жестоко обращаться",
+                    "жёсткость"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «misshandeln»?",
+                "choices": [
+                    "отвергать",
+                    "жестоко обращаться",
+                    "пытать",
+                    "насмехаться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "жестокость",
+                    "насмехаться",
+                    "унижать",
                     "жёсткость",
+                    "пытать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «abweisen»?",
+                "choices": [
+                    "жестокость",
                     "отвергать",
+                    "насмехаться",
                     "пытать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «abweisen»?",
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "отвергать",
+                    "жестокость",
                     "унижать",
-                    "пытать",
+                    "жёсткость",
                     "насмехаться"
                 ],
                 "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
-                    "жестоко обращаться",
-                    "жестокость",
-                    "пытать",
-                    "отвергать"
-                ],
-                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3646,79 +3679,79 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "выкалывать",
                     "наслаждаться",
                     "садизм",
-                    "ослеплять"
+                    "ослеплять",
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
                     "выкалывать",
+                    "садизм",
                     "ослеплять",
-                    "наслаждаться",
-                    "садизм"
+                    "наслаждаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "садизм",
-                    "наслаждаться",
+                    "выкалывать",
                     "беспощадный",
-                    "растаптывать"
+                    "садизм",
+                    "наслаждаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
                     "растаптывать",
-                    "беспощадный",
-                    "выкалывать",
-                    "ослеплять"
+                    "садизм",
+                    "ослеплять",
+                    "выкалывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "растаптывать",
-                    "ослеплять",
                     "пытка",
+                    "выкалывать",
+                    "брутальность",
                     "садизм"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
-                "choices": [
-                    "беспощадный",
-                    "растаптывать",
-                    "пытка",
-                    "ослеплять"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "выкалывать",
+                    "беспощадный",
+                    "садизм",
+                    "наслаждаться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Brutalität»?",
                 "choices": [
-                    "садизм",
-                    "выкалывать",
-                    "брутальность",
-                    "пытка"
+                    "пытка",
+                    "наслаждаться",
+                    "беспощадный",
+                    "брутальность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
                     "пытка",
-                    "садизм",
                     "ослеплять",
+                    "наслаждаться",
                     "растаптывать"
                 ],
                 "correctIndex": 3
@@ -4162,72 +4195,72 @@
             {
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
-                    "вожделеть",
+                    "вожделение",
                     "вдова",
-                    "соблазнять",
-                    "вожделение"
+                    "вожделеть",
+                    "соблазнять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "вожделение",
+                    "вдова",
                     "вожделеть",
-                    "соблазнять",
-                    "вдова"
+                    "вожделение",
+                    "соблазнять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "соблазнять",
+                    "заманивать",
                     "вдова",
-                    "похоть",
-                    "вожделеть"
+                    "соблазнять",
+                    "вожделение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
                     "вожделение",
-                    "вдова",
                     "заманивать",
-                    "вожделеть"
+                    "вожделеть",
+                    "похоть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "добиваться",
-                    "вожделение",
+                    "заманивать",
+                    "похоть",
                     "вдова",
-                    "заманивать"
+                    "добиваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "заманивать",
-                    "похоть",
-                    "добиваться",
-                    "соблазнять"
+                    "вожделение",
+                    "вожделеть",
+                    "вдова",
+                    "похоть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
+                    "соблазнять",
+                    "похоть",
                     "добиваться",
-                    "вожделение",
-                    "заманивать",
-                    "вожделеть"
+                    "вдова"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4655,19 +4688,19 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
-                    "угрожать",
-                    "соперничество",
                     "соревноваться",
-                    "ненавидеть"
+                    "ненавидеть",
+                    "угрожать",
+                    "соперничество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "угрожать",
-                    "ненавидеть",
                     "соперничество",
+                    "ненавидеть",
+                    "угрожать",
                     "соревноваться"
                 ],
                 "correctIndex": 1
@@ -4675,52 +4708,52 @@
             {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "соперничество",
                     "подозревать",
+                    "не доверять",
                     "угрожать",
-                    "не доверять"
+                    "соперничество"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
+                    "подозревать",
                     "соперничество",
                     "не доверять",
-                    "угрожать",
-                    "подозревать"
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
+                    "не доверять",
+                    "угрожать",
                     "соперничество",
-                    "ненавидеть",
-                    "бороться",
-                    "угрожать"
+                    "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
-                    "бороться",
+                    "не доверять",
                     "соперничество",
-                    "подозревать",
-                    "не доверять"
+                    "угрожать",
+                    "соревноваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
+                    "подозревать",
                     "бороться",
-                    "соревноваться",
-                    "не доверять",
-                    "подозревать"
+                    "ненавидеть",
+                    "соревноваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5202,9 +5235,9 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "издыхать",
-                    "страдать",
                     "мучение",
+                    "страдать",
+                    "издыхать",
                     "отравленный"
                 ],
                 "correctIndex": 3
@@ -5213,19 +5246,19 @@
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
                     "страдать",
-                    "мучение",
+                    "издыхать",
                     "отравленный",
-                    "издыхать"
+                    "мучение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
+                    "проклинать",
                     "рок",
-                    "мучение",
                     "издыхать",
-                    "расплачиваться"
+                    "мучение"
                 ],
                 "correctIndex": 2
             },
@@ -5234,17 +5267,17 @@
                 "choices": [
                     "отравленный",
                     "мучение",
-                    "проклинать",
-                    "расплачиваться"
+                    "рок",
+                    "страдать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "мучение",
                     "страдать",
-                    "рок",
+                    "проклятый",
+                    "мучение",
                     "проклинать"
                 ],
                 "correctIndex": 3
@@ -5252,9 +5285,9 @@
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
-                    "проклинать",
-                    "отравленный",
-                    "расплачиваться",
+                    "мучение",
+                    "проклятый",
+                    "издыхать",
                     "рок"
                 ],
                 "correctIndex": 3
@@ -5262,20 +5295,20 @@
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
                     "расплачиваться",
-                    "проклинать"
+                    "отравленный",
+                    "проклинать",
+                    "издыхать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
-                    "расплачиваться",
+                    "страдать",
                     "проклятый",
-                    "рок",
-                    "страдать"
+                    "проклинать",
+                    "издыхать"
                 ],
                 "correctIndex": 1
             }
@@ -5382,6 +5415,377 @@ let progressLineElement = null;
 let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
+
+const studyQueueState = {
+    queue: [],
+    lookup: new Map(),
+    initialized: false,
+};
+
+function sanitizeStudyExample(example) {
+    if (!example || typeof example !== 'object') {
+        return null;
+    }
+
+    const german = typeof example.german === 'string' ? example.german : '';
+    const russian = typeof example.russian === 'string' ? example.russian : '';
+
+    if (!german && !russian) {
+        return null;
+    }
+
+    return {
+        german: german,
+        russian: russian,
+    };
+}
+
+function sanitizeStudyEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const sanitized = { ...entry };
+
+    sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
+    sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
+    sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
+        ? sanitized.characterId
+        : (typeof sanitized.character_id === 'string' ? sanitized.character_id : (typeof characterId === 'string' ? characterId : ''));
+    sanitized.phaseKey = typeof sanitized.phaseKey === 'string'
+        ? sanitized.phaseKey
+        : (typeof sanitized.phase_id === 'string' ? sanitized.phase_id : '');
+    sanitized.sentence = typeof sanitized.sentence === 'string' ? sanitized.sentence : '';
+    sanitized.sentenceTranslation = typeof sanitized.sentenceTranslation === 'string'
+        ? sanitized.sentenceTranslation
+        : '';
+    sanitized.emoji = typeof sanitized.emoji === 'string' && sanitized.emoji ? sanitized.emoji : '📝';
+
+    if (Array.isArray(sanitized.examples)) {
+        sanitized.examples = sanitized.examples
+            .map(sanitizeStudyExample)
+            .filter(Boolean);
+    } else {
+        sanitized.examples = [];
+    }
+
+    if (!sanitized.examples.length && (sanitized.sentence || sanitized.sentenceTranslation)) {
+        sanitized.examples.push({
+            german: sanitized.sentence || '',
+            russian: sanitized.sentenceTranslation || '',
+        });
+    }
+
+    if (typeof sanitized.example !== 'string' || !sanitized.example) {
+        sanitized.example = sanitized.sentence || '';
+    }
+
+    return sanitized;
+}
+
+function readStudyQueueFromStorage() {
+    if (typeof localStorage === 'undefined') {
+        return [];
+    }
+
+    let storedValue = null;
+    try {
+        storedValue = localStorage.getItem(REVIEW_QUEUE_KEY);
+    } catch (error) {
+        console.warn('[StudyQueue] Unable to read stored queue', error);
+        return [];
+    }
+
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(storedValue);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.map(sanitizeStudyEntry).filter(Boolean);
+    } catch (error) {
+        console.warn('[StudyQueue] Failed to parse stored queue', error);
+        return [];
+    }
+}
+
+function rebuildStudyLookup() {
+    studyQueueState.lookup = new Map();
+    studyQueueState.queue.forEach(entry => {
+        const key = getStudyWordKey(entry);
+        if (key) {
+            studyQueueState.lookup.set(key, entry);
+        }
+    });
+}
+
+function ensureStudyQueueLoaded(forceReload = false) {
+    if (!studyQueueState.initialized || forceReload) {
+        studyQueueState.queue = readStudyQueueFromStorage();
+        rebuildStudyLookup();
+        studyQueueState.initialized = true;
+    }
+    return studyQueueState.queue;
+}
+
+function getStudyWordKey(source) {
+    if (!source) {
+        return null;
+    }
+
+    const wordValue = typeof source.word === 'string' ? source.word.trim().toLowerCase() : '';
+    const characterValue =
+        (typeof source.characterId === 'string' && source.characterId.trim()) ? source.characterId.trim() :
+        (typeof source.character_id === 'string' && source.character_id.trim()) ? source.character_id.trim() :
+        (typeof characterId === 'string' ? characterId : '');
+
+    if (!wordValue) {
+        return null;
+    }
+
+    return `${characterValue || 'unknown'}::${wordValue}`;
+}
+
+function isWordInStudyQueue(source) {
+    ensureStudyQueueLoaded();
+    const key = getStudyWordKey(source);
+    if (!key) {
+        return false;
+    }
+    return studyQueueState.lookup.has(key);
+}
+
+function createStudyEntry(rawData) {
+    const sanitized = sanitizeStudyEntry(rawData);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (!sanitized.characterId) {
+        sanitized.characterId = typeof characterId === 'string' ? characterId : '';
+    }
+
+    if (typeof sanitized.phaseKey !== 'string') {
+        sanitized.phaseKey = '';
+    }
+
+    return sanitized;
+}
+
+function persistStudyQueue(queue) {
+    if (typeof localStorage === 'undefined') {
+        return true;
+    }
+
+    try {
+        localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(queue));
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new Event('storage'));
+        }
+        return true;
+    } catch (error) {
+        console.error('[StudyQueue] Unable to persist queue', error);
+        return false;
+    }
+}
+
+function updateStudyCounterBadge() {
+    const counter = document.querySelector('[data-study-count]');
+    if (!counter) {
+        return;
+    }
+
+    const count = Array.isArray(studyQueueState.queue) ? studyQueueState.queue.length : 0;
+    counter.textContent = String(count);
+
+    const container = counter.closest('[data-study-counter]');
+    if (container) {
+        container.classList.toggle('study-counter-badge--active', count > 0);
+
+        let wordForm = 'слов';
+        if (count > 0) {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (mod10 === 1 && mod100 !== 11) {
+                wordForm = 'слово';
+            } else if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+                wordForm = 'слова';
+            }
+        }
+
+        const label = count > 0
+            ? `В списке изучения ${count} ${wordForm}`
+            : 'Список изучения пуст';
+        container.setAttribute('aria-label', label);
+    }
+}
+
+function applyStudyButtonState(button, isActive) {
+    if (!button) {
+        return;
+    }
+
+    const defaultLabel = button.dataset.defaultLabel || 'Изучить';
+    const activeLabel = button.dataset.activeLabel || 'В списке';
+    const inactiveTitle = button.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    const activeTitle = button.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    button.disabled = false;
+    button.style.background = '';
+    button.classList.toggle('added', Boolean(isActive));
+    button.dataset.inStudy = isActive ? 'true' : 'false';
+    button.textContent = isActive ? activeLabel : defaultLabel;
+    button.title = isActive ? activeTitle : inactiveTitle;
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+}
+
+function updateAllStudyButtons() {
+    const buttons = document.querySelectorAll('.btn-study');
+    if (!buttons || buttons.length === 0) {
+        return;
+    }
+
+    buttons.forEach(button => {
+        const key = getStudyWordKey({
+            word: button.dataset.word || '',
+            characterId: button.dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        });
+        const isActive = key ? studyQueueState.lookup.has(key) : false;
+        applyStudyButtonState(button, isActive);
+    });
+}
+
+function refreshStudyUI() {
+    updateStudyCounterBadge();
+    updateAllStudyButtons();
+}
+
+function addWordToStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const entry = createStudyEntry(wordData);
+    if (!entry) {
+        return false;
+    }
+
+    const key = getStudyWordKey(entry);
+    if (!key) {
+        return false;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.concat([entry]);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.set(key, entry);
+    refreshStudyUI();
+    return true;
+}
+
+function removeWordFromStudyQueue(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return false;
+    }
+
+    if (!studyQueueState.lookup.has(key)) {
+        return true;
+    }
+
+    const newQueue = studyQueueState.queue.filter(item => getStudyWordKey(item) !== key);
+    if (!persistStudyQueue(newQueue)) {
+        return false;
+    }
+
+    studyQueueState.queue = newQueue;
+    studyQueueState.lookup.delete(key);
+    refreshStudyUI();
+    return true;
+}
+
+function toggleStudyWord(wordData) {
+    ensureStudyQueueLoaded();
+
+    const key = getStudyWordKey(wordData);
+    if (!key) {
+        return null;
+    }
+
+    if (studyQueueState.lookup.has(key)) {
+        return removeWordFromStudyQueue(wordData) ? false : null;
+    }
+
+    return addWordToStudyQueue(wordData) ? true : null;
+}
+
+function buildStudyPayloadFromButton(button, item) {
+    const dataset = button ? button.dataset || {} : {};
+    const payload = {
+        word: dataset.word || (item && item.word) || '',
+        translation: dataset.translation || (item && item.translation) || '',
+        transcription: dataset.transcription || (item && item.transcription) || '',
+        characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
+        phaseKey: dataset.phaseKey || '',
+        sentence: dataset.sentence || (item && item.sentence) || '',
+        sentenceTranslation: dataset.sentenceTranslation || (item && item.sentenceTranslation) || '',
+        emoji: dataset.emoji || (item && item.visual_hint) || '📝',
+    };
+
+    const examples = [];
+    if (payload.sentence || payload.sentenceTranslation) {
+        examples.push({
+            german: payload.sentence,
+            russian: payload.sentenceTranslation,
+        });
+    }
+
+    payload.examples = examples;
+    payload.example = payload.example || payload.sentence || '';
+
+    if (item && item.russian_hint && !payload.russian_hint) {
+        payload.russian_hint = item.russian_hint;
+    }
+
+    if (item && Array.isArray(item.themes)) {
+        payload.themes = item.themes.slice();
+    }
+
+    if (item && Array.isArray(item.wordFamily)) {
+        payload.wordFamily = item.wordFamily.slice();
+    }
+
+    if (item && Array.isArray(item.collocations)) {
+        payload.collocations = item.collocations.slice();
+    }
+
+    if (item && Array.isArray(item.sentenceParts)) {
+        payload.sentenceParts = item.sentenceParts.slice();
+    }
+
+    return payload;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('storage', function(event) {
+        if (event && event.key && event.key !== REVIEW_QUEUE_KEY) {
+            return;
+        }
+        ensureStudyQueueLoaded(true);
+        refreshStudyUI();
+    });
+}
 
 function getPhaseStorageKey(phaseKey) {
     const safePhase = phaseKey || 'unknown';
@@ -5915,6 +6319,7 @@ function renderConstructorForPhase(phaseKey) {
                 btn.disabled = true;
             }
         });
+        refreshActiveExerciseContentHeight();
         return;
     }
 
@@ -5969,6 +6374,7 @@ function renderConstructorForPhase(phaseKey) {
     });
 
     panel.dataset.constructorIndex = String(state.index);
+    refreshActiveExerciseContentHeight();
 }
 
 function toggleConstructorFragment(panel, fragment) {
@@ -5998,6 +6404,7 @@ function toggleConstructorFragment(panel, fragment) {
     }
 
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorCheck(panel) {
@@ -6061,6 +6468,8 @@ function handleConstructorCheck(panel) {
             navigator.vibrate(40);
         }
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorReset(panel) {
@@ -6069,6 +6478,7 @@ function handleConstructorReset(panel) {
     if (!phaseKey) return;
     renderConstructorForPhase(phaseKey);
     updateConstructorPlaceholder(panel);
+    refreshActiveExerciseContentHeight();
 }
 
 function handleConstructorNext(panel) {
@@ -6087,6 +6497,8 @@ function handleConstructorNext(panel) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(15);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function initializeConstructorSection() {
@@ -6135,6 +6547,28 @@ function activateConstructorPhase(phaseKey) {
     });
 }
 
+function refreshActiveExerciseContentHeight() {
+    const activeToggle = document.querySelector('.exercise-toggle.active');
+    if (!activeToggle) {
+        return;
+    }
+
+    const content = activeToggle.nextElementSibling;
+    if (!(content instanceof HTMLElement) || content.classList.contains('collapsed')) {
+        return;
+    }
+
+    const previousTransition = content.style.transition;
+    content.style.transition = 'none';
+    content.style.maxHeight = 'auto';
+    const newHeight = content.scrollHeight;
+
+    requestAnimationFrame(() => {
+        content.style.transition = previousTransition || '';
+        content.style.maxHeight = `${newHeight}px`;
+    });
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -6153,6 +6587,9 @@ function displayVocabulary(phaseKey) {
     }
     
     phaseTitle.textContent = phase.title;
+
+    ensureStudyQueueLoaded();
+    updateStudyCounterBadge();
     
     // Update theatrical scene with smooth transition
     const scenes = document.querySelectorAll('.theatrical-scene');
@@ -6229,100 +6666,52 @@ function displayVocabulary(phaseKey) {
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"
                     data-phase-key="${phaseKey || ''}"
+                    data-emoji="${item.visual_hint || '📝'}"
                 >Изучить</button>
             `;
-            
+
             // Добавляем обработчик для кнопки
             const studyBtn = card.querySelector('.btn-study');
             if (studyBtn) {
+                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+                const initialState = isWordInStudyQueue({
+                    word: item.word,
+                    characterId: characterId,
+                });
+                applyStudyButtonState(studyBtn, initialState);
+
                 studyBtn.addEventListener('click', function(e) {
                     e.preventDefault();
                     e.stopPropagation();
-                    
-                    // Создаем объект с данными слова
-                    const fullWordData = {
-                        word: this.dataset.word,
-                        translation: this.dataset.translation,
-                        transcription: this.dataset.transcription,
-                        characterId: this.dataset.characterId,
-                        phaseKey: this.dataset.phaseKey,
-                        examples: []
-                    };
-                    
-                    // Добавляем примеры и sentence_translation
-                    fullWordData.sentenceTranslation = this.dataset.sentenceTranslation || '';
-                    
-                    if (this.dataset.sentence || this.dataset.sentenceTranslation) {
-                        fullWordData.examples.push({
-                            german: this.dataset.sentence || '',
-                            russian: this.dataset.sentenceTranslation || ''
-                        });
+
+                    const payload = buildStudyPayloadFromButton(this, item);
+                    const toggled = toggleStudyWord(payload);
+
+                    if (toggled === null) {
+                        alert('Не удалось обновить список изучения');
+                        applyStudyButtonState(this, isWordInStudyQueue(payload));
+                        return;
                     }
-                    
-                    // Получаем существующий список из localStorage
-                    let reviewQueue = [];
-                    try {
-                        const stored = localStorage.getItem(REVIEW_QUEUE_KEY);
-                        if (stored) {
-                            reviewQueue = JSON.parse(stored);
-                            if (!Array.isArray(reviewQueue)) {
-                                reviewQueue = [];
-                            }
-                        }
-                    } catch (error) {
-                        console.error('[ReviewQueue] Error reading from localStorage:', error);
-                        reviewQueue = [];
-                    }
-                    
-                    // Проверяем, не добавлено ли уже это слово
-                    const exists = reviewQueue.some(w => 
-                        w.word === fullWordData.word && 
-                        w.characterId === fullWordData.characterId
-                    );
-                    
-                    if (!exists && reviewQueue.length < 5) {
-                        // Добавляем emoji и примеры
-                        fullWordData.emoji = item.visual_hint || '📝';
-                        fullWordData.sentence = item.sentence || '';
-                        fullWordData.example = item.sentence || '';
-                        reviewQueue.push(fullWordData);
-                        
-                        try {
-                            localStorage.setItem(REVIEW_QUEUE_KEY, JSON.stringify(reviewQueue));
-                            
-                            // Визуальная обратная связь - кнопка становится зеленой
-                            this.style.background = 'linear-gradient(135deg, #22c55e, #16a34a)';
-                            this.textContent = '✓ Добавлено';
-                            this.disabled = true;
-                            
-                            // Haptic feedback для мобильных
-                            if (navigator.vibrate && isTouchDevice) {
-                                navigator.vibrate(20);
-                            }
-                            
-                            console.log('[ReviewQueue] Added word to review:', fullWordData);
-                            
-                            // Отправляем событие для обновления главной страницы
-                            window.dispatchEvent(new Event('storage'));
-                        } catch (error) {
-                            console.error('[ReviewQueue] Error saving to localStorage:', error);
-                            alert('Не удалось сохранить слово для изучения');
-                        }
-                    } else if (exists) {
-                        this.textContent = 'Уже добавлено';
-                        this.disabled = true;
-                    } else {
-                        this.textContent = 'Максимум 5 слов';
-                        this.style.background = 'linear-gradient(135deg, #ef4444, #dc2626)';
-                        this.disabled = true;
+
+                    if (navigator.vibrate && isTouchDevice) {
+                        navigator.vibrate(20);
                     }
                 });
             }
-            
+
             grid.appendChild(card);
         }, index * 50);
     });
-    
+
+    // Ensure UI reflects current queue after rendering
+    setTimeout(() => {
+        updateAllStudyButtons();
+    }, phase.words.length * 50 + 20);
+
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;
     if (progressFill) progressFill.style.width = progress + '%';
@@ -6331,7 +6720,11 @@ function displayVocabulary(phaseKey) {
 
     // Update navigation buttons state
     updateNavigationButtons();
-    
+
+    setTimeout(() => {
+        refreshActiveExerciseContentHeight();
+    }, 80);
+
     // Reset transition flag
     setTimeout(() => {
         isTransitioning = false;
@@ -6444,6 +6837,8 @@ function advanceQuiz(currentCard) {
     if (phaseKey) {
         updateQuizStatsUI(phaseKey);
     }
+
+    refreshActiveExerciseContentHeight();
 }
 
 function handleQuizChoiceSelection(button) {
@@ -6493,6 +6888,8 @@ function handleQuizChoiceSelection(button) {
     if (navigator.vibrate && isTouchDevice) {
         navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
     }
+
+    refreshActiveExerciseContentHeight();
 
     setTimeout(() => {
         advanceQuiz(quizCard);
@@ -7240,6 +7637,51 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeConstructorSection();
     attachQuizHandlers();
 
+    const exerciseToggles = document.querySelectorAll('.exercise-toggle');
+    const exerciseContents = document.querySelectorAll('.exercise-content');
+
+    const collapseAllExercises = () => {
+        exerciseContents.forEach(content => {
+            content.classList.add('collapsed');
+            if (content instanceof HTMLElement) {
+                content.style.maxHeight = '0px';
+            }
+        });
+        exerciseToggles.forEach(toggle => toggle.classList.remove('active'));
+    };
+
+    exerciseToggles.forEach(toggle => {
+        toggle.addEventListener('click', () => {
+            const content = toggle.nextElementSibling;
+            if (!(content instanceof HTMLElement)) {
+                return;
+            }
+
+            const isCollapsed = content.classList.contains('collapsed');
+            collapseAllExercises();
+
+            if (isCollapsed) {
+                content.classList.remove('collapsed');
+                toggle.classList.add('active');
+                requestAnimationFrame(() => {
+                    content.style.maxHeight = content.scrollHeight + 'px';
+                });
+            }
+        });
+    });
+
+    if (exerciseToggles.length > 0) {
+        const firstToggle = exerciseToggles[0];
+        const firstContent = firstToggle.nextElementSibling;
+        if (firstContent instanceof HTMLElement) {
+            firstToggle.classList.add('active');
+            firstContent.classList.remove('collapsed');
+            requestAnimationFrame(() => {
+                firstContent.style.maxHeight = firstContent.scrollHeight + 'px';
+            });
+        }
+    }
+
     // Initialize relation toggles
     const relationToggles = document.querySelectorAll('.relation-toggle');
     relationToggles.forEach(toggle => {
@@ -7256,6 +7698,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                 }
             }
+            refreshActiveExerciseContentHeight();
         });
     });
 

--- a/output/static/css/index.css
+++ b/output/static/css/index.css
@@ -18,51 +18,28 @@ body {
     padding: 20px;
 }
 
-.header {
+.main-header {
     text-align: center;
     color: white;
-    padding: 60px 20px 40px;
+    padding: 60px 20px 30px;
     animation: fadeInDown 0.8s ease;
 }
 
-.header h1 {
-    font-size: 4em;
+.main-title {
+    font-size: 3.75em;
     font-weight: 900;
     text-shadow: 3px 3px 6px rgba(0, 0, 0, 0.3);
-    margin-bottom: 20px;
     letter-spacing: -2px;
+    display: inline-flex;
+    align-items: center;
+    gap: 16px;
 }
 
-.header .subtitle {
-    font-size: 1.4em;
-    opacity: 0.95;
-    max-width: 700px;
-    margin: 0 auto 30px;
-    line-height: 1.6;
-}
-
-.stats {
-    display: flex;
+.crown-icon {
+    font-size: 1.2em;
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
-    gap: 40px;
-    margin-top: 30px;
-}
-
-.stat {
-    text-align: center;
-}
-
-.stat-number {
-    font-size: 2.5em;
-    font-weight: 700;
-    display: block;
-}
-
-.stat-label {
-    font-size: 0.9em;
-    opacity: 0.9;
-    text-transform: uppercase;
-    letter-spacing: 1px;
 }
 
 .review-section {
@@ -416,8 +393,9 @@ body {
 }
 
 @media (max-width: 768px) {
-    .header h1 {
+    .main-title {
         font-size: 2.5em;
+        gap: 12px;
     }
 
     .review-section {
@@ -445,14 +423,10 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .stats {
-        flex-direction: column;
-        gap: 20px;
-    }
 }
 
 @media (max-width: 480px) {
-    .header h1 {
+    .main-title {
         font-size: 2.2em;
     }
 

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -61,14 +61,23 @@
 }
 
 .btn-study:disabled {
-    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    background: linear-gradient(135deg, #94a3b8 0%, #64748b 100%);
     cursor: not-allowed;
-    opacity: 0.9;
+    opacity: 0.75;
 }
 
 /* Состояние кнопки после добавления */
 .btn-study.added {
     background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    box-shadow: 0 10px 25px rgba(22, 163, 74, 0.35);
+}
+
+.btn-study.added:hover {
+    background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+}
+
+.btn-study.added:active {
+    transform: scale(0.98);
 }
 
 /* Анимация появления карточек */
@@ -115,22 +124,86 @@ body {
 }
 
 .page-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
     text-align: center;
     color: white;
     margin-bottom: 40px;
     animation: fadeInDown 0.8s ease;
 }
 
+.page-header-text {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
 .page-header h1 {
     font-size: 3em;
     font-weight: 700;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-    margin-bottom: 10px;
 }
 
 .subtitle {
     font-size: 1.2em;
     opacity: 0.95;
+}
+
+.study-counter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 18px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    color: #f9fafb;
+}
+
+.study-counter-badge--active {
+    background: rgba(34, 197, 94, 0.3);
+    box-shadow: 0 12px 32px rgba(34, 197, 94, 0.35);
+}
+
+.study-counter-badge:hover {
+    transform: translateY(-2px);
+}
+
+.study-counter-label {
+    font-size: 0.95em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.study-counter-value {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.28);
+    font-size: 1.1em;
+}
+
+@media (min-width: 768px) {
+    .page-header {
+        flex-direction: row;
+        align-items: flex-end;
+        text-align: left;
+    }
+
+    .page-header-text {
+        align-items: flex-start;
+        text-align: left;
+    }
 }
 
 .journey-section {

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -61,14 +61,23 @@
 }
 
 .btn-study:disabled {
-    background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    background: linear-gradient(135deg, #94a3b8 0%, #64748b 100%);
     cursor: not-allowed;
-    opacity: 0.9;
+    opacity: 0.75;
 }
 
 /* Состояние кнопки после добавления */
 .btn-study.added {
     background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+    box-shadow: 0 10px 25px rgba(22, 163, 74, 0.35);
+}
+
+.btn-study.added:hover {
+    background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+}
+
+.btn-study.added:active {
+    transform: scale(0.98);
 }
 
 /* Анимация появления карточек */
@@ -115,22 +124,86 @@ body {
 }
 
 .page-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
     text-align: center;
     color: white;
     margin-bottom: 40px;
     animation: fadeInDown 0.8s ease;
 }
 
+.page-header-text {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
 .page-header h1 {
     font-size: 3em;
     font-weight: 700;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-    margin-bottom: 10px;
 }
 
 .subtitle {
     font-size: 1.2em;
     opacity: 0.95;
+}
+
+.study-counter-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 18px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    color: #f9fafb;
+}
+
+.study-counter-badge--active {
+    background: rgba(34, 197, 94, 0.3);
+    box-shadow: 0 12px 32px rgba(34, 197, 94, 0.35);
+}
+
+.study-counter-badge:hover {
+    transform: translateY(-2px);
+}
+
+.study-counter-label {
+    font-size: 0.95em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.study-counter-value {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.28);
+    font-size: 1.1em;
+}
+
+@media (min-width: 768px) {
+    .page-header {
+        flex-direction: row;
+        align-items: flex-end;
+        text-align: left;
+    }
+
+    .page-header-text {
+        align-items: flex-start;
+        text-align: left;
+    }
 }
 
 .journey-section {

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -11,8 +11,14 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <h1>👑 {{ character.title }}</h1>
-            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="page-header-text">
+                <h1>👑 {{ character.title }}</h1>
+                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            </div>
+            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
+                <span class="study-counter-label">Список изучения</span>
+                <span class="study-counter-value" data-study-count>0</span>
+            </div>
         </header>
 
         <div class="journey-section">


### PR DESCRIPTION
## Summary
- remove the five-word restriction from the study queue, add helper utilities, and keep the journey study buttons in sync with storage state
- surface a header badge that shows the live study count and refresh the journey page styles for the new UI
- regenerate the journey outputs and static assets so the built site ships the updated runtime and styling

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68ced6a6d0388320b906a3cc8ee45c31