### PR TITLE
Add journey header navigation with home link and counter

### DIFF
--- a/generators/html/template_engine.py
+++ b/generators/html/template_engine.py
@@ -18,6 +18,7 @@ class TemplateContext:
     quizzes: List[Dict[str, Any]]
     quizzes_json: str
     head: HeadContext
+    navigation: Dict[str, Any]
     relations_metadata: Dict[str, Dict[str, bool]]
     js_bundle: str
 
@@ -41,4 +42,5 @@ class JourneyTemplateEngine:
             first_phase_title=context.head.first_phase_title,
             relations_metadata=context.relations_metadata,
             js=context.js_bundle,
+            navigation=context.navigation,
         )

--- a/generators/html_lira.py
+++ b/generators/html_lira.py
@@ -33,6 +33,12 @@ class LiraHTMLGenerator(BaseGenerator):
         progress = JourneyBuilder.initial_progress(assets.phases)
         head_context = self.head_generator.build(assets.phases, progress)
         js_bundle = LiraJSGenerator.generate(character)
+        navigation = {
+            "home_href": "../index.html",
+            "home_label": "На главную",
+            "home_icon": "←",
+            "study_label": "СПИСОК ИЗУЧЕНИЯ",
+        }
         context = TemplateContext(
             character=character,
             phases=assets.phases,
@@ -40,6 +46,7 @@ class LiraHTMLGenerator(BaseGenerator):
             quizzes=assets.quizzes,
             quizzes_json=assets.quizzes_json,
             head=head_context,
+            navigation=navigation,
             relations_metadata=assets.relations_metadata,
             js_bundle=js_bundle,
         )

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Олбани</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Олбани</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["брак", "молчание", "терпеть", "слабость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["молчание", "слабость", "брак", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["брак", "мягкий", "колебаться", "терпеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["слабость", "уступать", "мягкий", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["слабость", "пассивный", "уступать", "мягкий"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["уступать", "мягкий", "терпеть", "пассивный"], "correct_index": 0}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["колебаться", "уступать", "пассивный", "молчание"], "correct_index": 0}, {"question": "Что означает немецкое слово «mild»?", "choices": ["слабость", "молчание", "мягкий", "пассивный"], "correct_index": 2}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["подвергать сомнению", "сомнение", "совесть", "беспокойство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["подвергать сомнению", "сомнение", "беспокойство", "совесть"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["беспокойство", "размышлять", "неуверенный", "сомнение"], "correct_index": 0}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "беспокойство", "размышлять", "сомнение"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["тревожить", "неуверенный", "размышлять", "совесть"], "correct_index": 0}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["совесть", "размышлять", "беспокойство", "неуверенный"], "correct_index": 3}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["неуверенный", "тревожить", "размышлять", "совесть"], "correct_index": 2}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["понимать", "осознание", "пробуждаться", "ужас"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["осознание", "понимать", "ужас", "пробуждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["понимать", "пугаться", "превращение", "пробуждаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["пугаться", "понимать", "просыпаться", "пробуждаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "понимать", "ясно видеть", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["превращение", "просыпаться", "ужас", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["ужас", "ясно видеть", "превращение", "пугаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["понимать", "ясно видеть", "превращение", "пробуждаться"], "correct_index": 2}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["противостоять", "сопротивление", "мужество", "спор"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["противостоять", "сопротивление", "мужество", "спор"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["обвинять", "мужество", "противостоять", "сопротивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["спор", "противостоять", "восставать", "защищаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["спор", "обвинять", "противостоять", "сопротивление"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["защищаться", "сопротивление", "восставать", "спор"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["защищаться", "противостоять", "восставать", "спор"], "correct_index": 2}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["мораль", "решение", "справедливость", "выбирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["справедливость", "решение", "выбирать", "мораль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["решение", "принцип", "благородный", "мораль"], "correct_index": 0}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["решение", "мораль", "справедливость", "выбирать"], "correct_index": 3}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["выбирать", "добродетель", "мораль", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["решение", "выбирать", "принцип", "праведный"], "correct_index": 2}, {"question": "Что означает немецкое слово «edel»?", "choices": ["добродетель", "праведный", "мораль", "благородный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["принцип", "благородный", "добродетель", "праведный"], "correct_index": 2}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "доброта", "право", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["право", "доброта", "борьба", "наказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["право", "доброта", "борьба", "наказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["наказывать", "судить", "вмешиваться", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «richten»?", "choices": ["судить", "защищать", "наказывать", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["право", "защищать", "доброта", "судить"], "correct_index": 1}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["защищать", "вмешиваться", "доброта", "право"], "correct_index": 1}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["направлять", "мудрость", "правление", "новое начало"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новое начало", "направлять", "мудрость", "правление"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "новое начало", "мир", "направлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["примирять", "новое начало", "направлять", "правление"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "направлять", "правление", "мир"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["мудрость", "новое начало", "направлять", "обновлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["примирять", "строить", "мудрость", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["строить", "мудрость", "правление", "мир"], "correct_index": 3}]}'>
+                    <div class="quiz-section" data-quiz-map='{"passive_duke": [{"question": "Что означает немецкое слово «das Schweigen»?", "choices": ["молчание", "терпеть", "брак", "слабость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schwäche»?", "choices": ["молчание", "терпеть", "брак", "слабость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ehe»?", "choices": ["уступать", "колебаться", "брак", "слабость"], "correct_index": 2}, {"question": "Что означает немецкое слово «dulden»?", "choices": ["брак", "молчание", "пассивный", "терпеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «passiv»?", "choices": ["слабость", "молчание", "уступать", "пассивный"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachgeben»?", "choices": ["брак", "терпеть", "мягкий", "уступать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zögern»?", "choices": ["мягкий", "колебаться", "брак", "пассивный"], "correct_index": 1}, {"question": "Что означает немецкое слово «mild»?", "choices": ["брак", "мягкий", "пассивный", "терпеть"], "correct_index": 1}], "first_doubts": [{"question": "Что означает немецкое слово «der Zweifel»?", "choices": ["беспокойство", "сомнение", "подвергать сомнению", "совесть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gewissen»?", "choices": ["совесть", "сомнение", "подвергать сомнению", "беспокойство"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Unbehagen»?", "choices": ["подвергать сомнению", "беспокойство", "совесть", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «hinterfragen»?", "choices": ["подвергать сомнению", "неуверенный", "совесть", "сомнение"], "correct_index": 0}, {"question": "Что означает немецкое слово «beunruhigen»?", "choices": ["сомнение", "тревожить", "беспокойство", "неуверенный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unsicher»?", "choices": ["подвергать сомнению", "неуверенный", "сомнение", "совесть"], "correct_index": 1}, {"question": "Что означает немецкое слово «grübeln»?", "choices": ["беспокойство", "сомнение", "совесть", "размышлять"], "correct_index": 3}], "awakening": [{"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["осознание", "ужас", "понимать", "пробуждаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Entsetzen»?", "choices": ["пробуждаться", "ужас", "понимать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «erwachen»?", "choices": ["пробуждаться", "ужас", "ясно видеть", "просыпаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «begreifen»?", "choices": ["ужас", "пугаться", "просыпаться", "понимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erschrecken»?", "choices": ["пугаться", "пробуждаться", "ясно видеть", "просыпаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufwachen»?", "choices": ["превращение", "пугаться", "пробуждаться", "просыпаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «klar sehen»?", "choices": ["просыпаться", "ясно видеть", "ужас", "превращение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verwandlung»?", "choices": ["осознание", "пробуждаться", "превращение", "просыпаться"], "correct_index": 2}], "confrontation": [{"question": "Что означает немецкое слово «der Streit»?", "choices": ["мужество", "спор", "сопротивление", "противостоять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["сопротивление", "мужество", "спор", "противостоять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Widerstand»?", "choices": ["защищаться", "сопротивление", "обвинять", "восставать"], "correct_index": 1}, {"question": "Что означает немецкое слово «konfrontieren»?", "choices": ["сопротивление", "противостоять", "восставать", "мужество"], "correct_index": 1}, {"question": "Что означает немецкое слово «anklagen»?", "choices": ["мужество", "обвинять", "сопротивление", "защищаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «sich wehren»?", "choices": ["противостоять", "защищаться", "сопротивление", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbegehren»?", "choices": ["спор", "противостоять", "защищаться", "восставать"], "correct_index": 3}], "moral_stand": [{"question": "Что означает немецкое слово «die Moral»?", "choices": ["справедливость", "решение", "мораль", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["решение", "мораль", "справедливость", "выбирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Entscheidung»?", "choices": ["добродетель", "праведный", "справедливость", "решение"], "correct_index": 3}, {"question": "Что означает немецкое слово «wählen»?", "choices": ["добродетель", "праведный", "выбирать", "благородный"], "correct_index": 2}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["принцип", "справедливость", "выбирать", "праведный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Prinzip»?", "choices": ["решение", "принцип", "мораль", "благородный"], "correct_index": 1}, {"question": "Что означает немецкое слово «edel»?", "choices": ["справедливость", "принцип", "благородный", "добродетель"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Tugend»?", "choices": ["благородный", "добродетель", "справедливость", "праведный"], "correct_index": 1}], "justice_seeker": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["наказывать", "доброта", "право", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Recht»?", "choices": ["право", "доброта", "наказывать", "борьба"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Güte»?", "choices": ["наказывать", "вмешиваться", "право", "доброта"], "correct_index": 3}, {"question": "Что означает немецкое слово «strafen»?", "choices": ["борьба", "защищать", "наказывать", "доброта"], "correct_index": 2}, {"question": "Что означает немецкое слово «richten»?", "choices": ["судить", "право", "борьба", "вмешиваться"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["вмешиваться", "доброта", "защищать", "судить"], "correct_index": 2}, {"question": "Что означает немецкое слово «eingreifen»?", "choices": ["вмешиваться", "наказывать", "доброта", "борьба"], "correct_index": 0}], "new_ruler": [{"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["правление", "новое начало", "направлять", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "направлять", "правление", "новое начало"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Neuanfang»?", "choices": ["правление", "мир", "обновлять", "новое начало"], "correct_index": 3}, {"question": "Что означает немецкое слово «lenken»?", "choices": ["правление", "направлять", "мир", "примирять"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufbauen»?", "choices": ["строить", "мудрость", "направлять", "мир"], "correct_index": 0}, {"question": "Что означает немецкое слово «erneuern»?", "choices": ["мир", "обновлять", "направлять", "примирять"], "correct_index": 1}, {"question": "Что означает немецкое слово «versöhnen»?", "choices": ["новое начало", "обновлять", "направлять", "примирять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Friede»?", "choices": ["обновлять", "правление", "мир", "направлять"], "correct_index": 2}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Пассивный герцог</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,15 +433,15 @@
                         <div class="quiz-phase-container active" data-phase="passive_duke">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «das Schweigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                                         
@@ -445,33 +449,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Schwäche»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">молчание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слабость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Ehe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">колебаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слабость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -481,11 +485,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «dulden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                                         
@@ -493,65 +497,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «passiv»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пассивный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мягкий</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">уступать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">колебаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">уступать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">молчание</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «mild»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">слабость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">молчание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">уступать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «nachgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уступать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «zögern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">колебаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брак</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пассивный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «mild»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брак</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мягкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пассивный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -568,27 +572,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Zweifel»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
                                         
@@ -596,17 +584,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gewissen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспокойство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Unbehagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">неуверенный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -618,9 +622,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">беспокойство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">сомнение</button>
                                         
@@ -628,29 +632,13 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «beunruhigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">тревожить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сомнение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">совесть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">беспокойство</button>
                                         
@@ -660,17 +648,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «unsicher»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подвергать сомнению</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неуверенный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сомнение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «grübeln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">неуверенный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспокойство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">тревожить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сомнение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">совесть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">совесть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -683,31 +687,15 @@
                         <div class="quiz-phase-container" data-phase="awakening">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ужас</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
                                         
@@ -715,33 +703,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Entsetzen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «erwachen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пробуждаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ужас</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «begreifen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">просыпаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -753,27 +757,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">пугаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ясно видеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «aufwachen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">превращение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">просыпаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пугаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пробуждаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -783,13 +787,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «klar sehen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ужас</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">просыпаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ужас</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пугаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превращение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -799,13 +803,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Verwandlung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ясно видеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пробуждаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">превращение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пробуждаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просыпаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -818,49 +822,49 @@
                         <div class="quiz-phase-container" data-phase="confrontation">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Streit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">противостоять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Widerstand»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,13 +874,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «konfrontieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопротивление</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -886,45 +890,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «anklagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">обвинять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">противостоять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сопротивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «sich wehren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">противостоять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сопротивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопротивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «aufbegehren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спор</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">противостоять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">восставать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">восставать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -937,15 +941,15 @@
                         <div class="quiz-phase-container" data-phase="moral_stand">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Moral»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мораль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">выбирать</button>
                                         
@@ -953,40 +957,8 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">решение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мораль</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
@@ -1001,45 +973,61 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">выбирать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выбирать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">принцип</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Entscheidung»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">решение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «wählen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">добродетель</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">благородный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выбирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Prinzip»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">решение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">мораль</button>
                                         
@@ -1049,15 +1037,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «edel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">принцип</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">благородный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добродетель</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Tugend»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">принцип</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">благородный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">благородный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">добродетель</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">добродетель</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
                                         
@@ -1096,41 +1100,41 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Güte»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">право</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">судить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вмешиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">право</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «strafen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доброта</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1142,25 +1146,25 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">судить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">право</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вмешиваться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">право</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доброта</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">судить</button>
                                         
@@ -1168,17 +1172,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «eingreifen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вмешиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вмешиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">доброта</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">право</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1191,13 +1195,29 @@
                         <div class="quiz-phase-container" data-phase="new_ruler">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Herrschaft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">направлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
                                         
@@ -1207,49 +1227,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Neuanfang»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мир</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обновлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «lenken»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1261,59 +1265,59 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">направлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">новое начало</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обновлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erneuern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мир</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «versöhnen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">примирять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">новое начало</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">строить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обновлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">направлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">новое начало</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">примирять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Friede»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">строить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обновлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мир</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мир</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">направлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1985,39 +1989,39 @@
             {
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
-                    "брак",
                     "молчание",
                     "терпеть",
+                    "брак",
                     "слабость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
                     "молчание",
-                    "слабость",
+                    "терпеть",
                     "брак",
-                    "терпеть"
+                    "слабость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
-                    "брак",
-                    "мягкий",
+                    "уступать",
                     "колебаться",
-                    "терпеть"
+                    "брак",
+                    "слабость"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
-                    "слабость",
-                    "уступать",
-                    "мягкий",
+                    "брак",
+                    "молчание",
+                    "пассивный",
                     "терпеть"
                 ],
                 "correctIndex": 3
@@ -2026,41 +2030,41 @@
                 "question": "Что означает немецкое слово «passiv»?",
                 "choices": [
                     "слабость",
-                    "пассивный",
+                    "молчание",
                     "уступать",
-                    "мягкий"
+                    "пассивный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
-                    "уступать",
-                    "мягкий",
+                    "брак",
                     "терпеть",
-                    "пассивный"
+                    "мягкий",
+                    "уступать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
+                    "мягкий",
                     "колебаться",
-                    "уступать",
-                    "пассивный",
-                    "молчание"
+                    "брак",
+                    "пассивный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «mild»?",
                 "choices": [
-                    "слабость",
-                    "молчание",
+                    "брак",
                     "мягкий",
-                    "пассивный"
+                    "пассивный",
+                    "терпеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2487,39 +2491,39 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "подвергать сомнению",
+                    "беспокойство",
                     "сомнение",
-                    "совесть",
-                    "беспокойство"
+                    "подвергать сомнению",
+                    "совесть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "подвергать сомнению",
+                    "совесть",
                     "сомнение",
-                    "беспокойство",
-                    "совесть"
+                    "подвергать сомнению",
+                    "беспокойство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
+                    "подвергать сомнению",
                     "беспокойство",
-                    "размышлять",
-                    "неуверенный",
-                    "сомнение"
+                    "совесть",
+                    "размышлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
                     "подвергать сомнению",
-                    "беспокойство",
-                    "размышлять",
+                    "неуверенный",
+                    "совесть",
                     "сомнение"
                 ],
                 "correctIndex": 0
@@ -2527,32 +2531,32 @@
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
+                    "сомнение",
                     "тревожить",
-                    "неуверенный",
-                    "размышлять",
-                    "совесть"
+                    "беспокойство",
+                    "неуверенный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
-                    "совесть",
-                    "размышлять",
-                    "беспокойство",
-                    "неуверенный"
+                    "подвергать сомнению",
+                    "неуверенный",
+                    "сомнение",
+                    "совесть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
-                    "неуверенный",
-                    "тревожить",
-                    "размышлять",
-                    "совесть"
+                    "беспокойство",
+                    "сомнение",
+                    "совесть",
+                    "размышлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3012,50 +3016,50 @@
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "понимать",
                     "осознание",
-                    "пробуждаться",
-                    "ужас"
+                    "ужас",
+                    "понимать",
+                    "пробуждаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
-                    "осознание",
-                    "понимать",
+                    "пробуждаться",
                     "ужас",
-                    "пробуждаться"
+                    "понимать",
+                    "осознание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
-                    "понимать",
-                    "пугаться",
-                    "превращение",
-                    "пробуждаться"
+                    "пробуждаться",
+                    "ужас",
+                    "ясно видеть",
+                    "просыпаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
+                    "ужас",
                     "пугаться",
-                    "понимать",
                     "просыпаться",
-                    "пробуждаться"
+                    "понимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
                     "пугаться",
-                    "понимать",
+                    "пробуждаться",
                     "ясно видеть",
-                    "осознание"
+                    "просыпаться"
                 ],
                 "correctIndex": 0
             },
@@ -3063,29 +3067,29 @@
                 "question": "Что означает немецкое слово «aufwachen»?",
                 "choices": [
                     "превращение",
-                    "просыпаться",
-                    "ужас",
-                    "осознание"
+                    "пугаться",
+                    "пробуждаться",
+                    "просыпаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «klar sehen»?",
                 "choices": [
-                    "ужас",
+                    "просыпаться",
                     "ясно видеть",
-                    "превращение",
-                    "пугаться"
+                    "ужас",
+                    "превращение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
-                    "понимать",
-                    "ясно видеть",
+                    "осознание",
+                    "пробуждаться",
                     "превращение",
-                    "пробуждаться"
+                    "просыпаться"
                 ],
                 "correctIndex": 2
             }
@@ -3515,72 +3519,72 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "противостоять",
-                    "сопротивление",
                     "мужество",
-                    "спор"
+                    "спор",
+                    "сопротивление",
+                    "противостоять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "противостоять",
                     "сопротивление",
                     "мужество",
-                    "спор"
+                    "спор",
+                    "противостоять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
+                    "защищаться",
+                    "сопротивление",
                     "обвинять",
-                    "мужество",
-                    "противостоять",
-                    "сопротивление"
+                    "восставать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
-                    "спор",
+                    "сопротивление",
                     "противостоять",
                     "восставать",
-                    "защищаться"
+                    "мужество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "спор",
+                    "мужество",
                     "обвинять",
-                    "противостоять",
-                    "сопротивление"
+                    "сопротивление",
+                    "защищаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
+                    "противостоять",
                     "защищаться",
                     "сопротивление",
-                    "восставать",
-                    "спор"
+                    "обвинять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
-                    "защищаться",
+                    "спор",
                     "противостоять",
-                    "восставать",
-                    "спор"
+                    "защищаться",
+                    "восставать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4044,49 +4048,49 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "мораль",
-                    "решение",
                     "справедливость",
+                    "решение",
+                    "мораль",
                     "выбирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "справедливость",
-                    "решение",
-                    "выбирать",
-                    "мораль"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Entscheidung»?",
-                "choices": [
-                    "решение",
-                    "принцип",
-                    "благородный",
-                    "мораль"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «wählen»?",
-                "choices": [
                     "решение",
                     "мораль",
                     "справедливость",
                     "выбирать"
                 ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Entscheidung»?",
+                "choices": [
+                    "добродетель",
+                    "праведный",
+                    "справедливость",
+                    "решение"
+                ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «wählen»?",
+                "choices": [
+                    "добродетель",
+                    "праведный",
+                    "выбирать",
+                    "благородный"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
+                    "принцип",
+                    "справедливость",
                     "выбирать",
-                    "добродетель",
-                    "мораль",
                     "праведный"
                 ],
                 "correctIndex": 3
@@ -4095,31 +4099,31 @@
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
                     "решение",
-                    "выбирать",
                     "принцип",
-                    "праведный"
+                    "мораль",
+                    "благородный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
-                    "добродетель",
-                    "праведный",
-                    "мораль",
-                    "благородный"
+                    "справедливость",
+                    "принцип",
+                    "благородный",
+                    "добродетель"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
-                    "принцип",
                     "благородный",
                     "добродетель",
+                    "справедливость",
                     "праведный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4555,60 +4559,60 @@
                 "choices": [
                     "право",
                     "доброта",
-                    "борьба",
-                    "наказывать"
+                    "наказывать",
+                    "борьба"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
+                    "наказывать",
+                    "вмешиваться",
                     "право",
-                    "доброта",
-                    "борьба",
-                    "наказывать"
+                    "доброта"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «strafen»?",
                 "choices": [
+                    "борьба",
+                    "защищать",
                     "наказывать",
-                    "судить",
-                    "вмешиваться",
-                    "борьба"
+                    "доброта"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «richten»?",
                 "choices": [
                     "судить",
-                    "защищать",
-                    "наказывать",
-                    "борьба"
+                    "право",
+                    "борьба",
+                    "вмешиваться"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "право",
-                    "защищать",
+                    "вмешиваться",
                     "доброта",
+                    "защищать",
                     "судить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "защищать",
                     "вмешиваться",
+                    "наказывать",
                     "доброта",
-                    "право"
+                    "борьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5097,49 +5101,49 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "направлять",
-                    "мудрость",
                     "правление",
-                    "новое начало"
+                    "новое начало",
+                    "направлять",
+                    "мудрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "новое начало",
-                    "направлять",
                     "мудрость",
-                    "правление"
+                    "направлять",
+                    "правление",
+                    "новое начало"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
                     "правление",
-                    "новое начало",
                     "мир",
-                    "направлять"
+                    "обновлять",
+                    "новое начало"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
-                    "примирять",
-                    "новое начало",
+                    "правление",
                     "направлять",
-                    "правление"
+                    "мир",
+                    "примирять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
                     "строить",
+                    "мудрость",
                     "направлять",
-                    "правление",
                     "мир"
                 ],
                 "correctIndex": 0
@@ -5147,32 +5151,32 @@
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "мудрость",
-                    "новое начало",
+                    "мир",
+                    "обновлять",
                     "направлять",
-                    "обновлять"
+                    "примирять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
-                    "примирять",
-                    "строить",
-                    "мудрость",
-                    "новое начало"
+                    "новое начало",
+                    "обновлять",
+                    "направлять",
+                    "примирять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "строить",
-                    "мудрость",
+                    "обновлять",
                     "правление",
-                    "мир"
+                    "мир",
+                    "направлять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Корделии</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Корделии</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["церемония", "провозглашать", "власть", "правда"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "провозглашать", "власть", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["повиноваться", "церемония", "провозглашать", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["правда", "власть", "торжественный", "повиноваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["верность", "власть", "церемония", "повиноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["провозглашать", "торжественный", "долг", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["торжественный", "повиноваться", "долг", "церемония"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["верность", "провозглашать", "власть", "церемония"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "наказание", "гнев", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["наказание", "покидать", "гнев", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["чужой", "гнев", "принимать", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "наказание", "покидать", "надежда"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["наказание", "изгонять", "гнев", "чужой"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["принимать", "наказание", "приданое", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["приданое", "гнев", "наказание", "принимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["изгонять", "наказание", "принимать", "надежда"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["страх", "забота", "одиночество", "известие"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["страх", "забота", "одиночество", "известие"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["известие", "страдать", "одиночество", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["известие", "забота", "одиночество", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["забота", "одиночество", "страх", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["защищать", "одиночество", "известие", "тоска"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["тоска", "страдать", "известие", "защищать"], "correct_index": 0}, {"question": "Что означает немецкое слово «beten»?", "choices": ["тоска", "забота", "молиться", "одиночество"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "спасать", "битва", "возвращаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "битва", "спасать", "борьба"], "correct_index": 3}, {"question": "Что означает немецкое слово «retten»?", "choices": ["справедливость", "спасать", "армия", "храбрый"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["армия", "справедливость", "битва", "спасать"], "correct_index": 2}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "армия", "справедливость", "побеждать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["спасать", "битва", "побеждать", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["справедливость", "борьба", "спасать", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["побеждать", "армия", "битва", "справедливость"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "узнавать", "слёзы", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["прощать", "слёзы", "обнимать", "узнавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощать", "обнимать", "исцелять", "нежный"], "correct_index": 1}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "исцелять", "слёзы", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["раскаяние", "прощение", "обнимать", "исцелять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "раскаяние", "обнимать", "слёзы"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["нежный", "исцелять", "слёзы", "прощение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "слёзы", "прощение", "узнавать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["тюрьма", "достоинство", "утешать", "пленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["утешать", "пленный", "тюрьма", "достоинство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["честь", "достоинство", "отважный", "тюрьма"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["достоинство", "утешать", "тюрьма", "судьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["утешать", "отважный", "тюрьма", "смирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["тюрьма", "смирение", "достоинство", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["смирение", "судьба", "честь", "отважный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["судьба", "пленный", "тюрьма", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "душа", "жертва", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["жертва", "смерть", "умирать", "душа"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["спасение", "вечный", "жертва", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["жертва", "спасение", "прощание", "душа"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["жертва", "душа", "вечный", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "спасение", "умирать", "прощание"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["смерть", "прощание", "спасение", "душа"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["конец", "умирать", "спасение", "вечный"], "correct_index": 2}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["провозглашать", "церемония", "правда", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "правда", "власть", "провозглашать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["власть", "торжественный", "провозглашать", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["провозглашать", "правда", "власть", "торжественный"], "correct_index": 2}, {"question": "Что означает немецкое слово «gehorchen»?", "choices": ["повиноваться", "провозглашать", "долг", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["правда", "церемония", "долг", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «feierlich»?", "choices": ["власть", "торжественный", "верность", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Treue»?", "choices": ["власть", "торжественный", "верность", "провозглашать"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["изгонять", "покидать", "гнев", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlassen»?", "choices": ["гнев", "покидать", "наказание", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["принимать", "изгонять", "гнев", "приданое"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["изгонять", "наказание", "чужой", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fremd»?", "choices": ["гнев", "наказание", "чужой", "принимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Mitgift»?", "choices": ["изгонять", "наказание", "приданое", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufnehmen»?", "choices": ["наказание", "покидать", "принимать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hoffnung»?", "choices": ["надежда", "покидать", "гнев", "изгонять"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «die Sorge»?", "choices": ["известие", "страх", "одиночество", "забота"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "страх", "известие", "забота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Nachricht»?", "choices": ["забота", "молиться", "одиночество", "известие"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Angst»?", "choices": ["страх", "страдать", "молиться", "тоска"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["забота", "страдать", "известие", "тоска"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["забота", "страдать", "защищать", "молиться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Sehnsucht»?", "choices": ["тоска", "молиться", "забота", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «beten»?", "choices": ["одиночество", "тоска", "защищать", "молиться"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["борьба", "возвращаться", "спасать", "битва"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Kampf»?", "choices": ["возвращаться", "спасать", "борьба", "битва"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["битва", "армия", "борьба", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Schlacht»?", "choices": ["побеждать", "борьба", "битва", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «mutig»?", "choices": ["храбрый", "справедливость", "армия", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["возвращаться", "армия", "храбрый", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["битва", "борьба", "возвращаться", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Armee»?", "choices": ["битва", "храбрый", "борьба", "армия"], "correct_index": 3}], "hut": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "слёзы", "обнимать", "узнавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Tränen»?", "choices": ["обнимать", "прощать", "слёзы", "узнавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощать", "прощение", "исцелять", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["нежный", "узнавать", "обнимать", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heilen»?", "choices": ["узнавать", "исцелять", "прощать", "прощение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["исцелять", "раскаяние", "прощение", "прощать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sanft»?", "choices": ["прощать", "узнавать", "нежный", "обнимать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergebung»?", "choices": ["обнимать", "раскаяние", "прощение", "узнавать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «gefangen»?", "choices": ["достоинство", "пленный", "утешать", "тюрьма"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Gefängnis»?", "choices": ["достоинство", "тюрьма", "утешать", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Würde»?", "choices": ["тюрьма", "судьба", "честь", "достоинство"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["честь", "утешать", "судьба", "пленный"], "correct_index": 1}, {"question": "Что означает немецкое слово «tapfer»?", "choices": ["пленный", "достоинство", "судьба", "отважный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Demut»?", "choices": ["смирение", "отважный", "судьба", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["пленный", "тюрьма", "судьба", "отважный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["тюрьма", "пленный", "утешать", "честь"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["душа", "жертва", "умирать", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["душа", "смерть", "умирать", "жертва"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Opfer»?", "choices": ["смерть", "вечный", "жертва", "душа"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Seele»?", "choices": ["смерть", "конец", "умирать", "душа"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["смерть", "конец", "спасение", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "прощание", "смерть", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["конец", "умирать", "вечный", "прощание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erlösung»?", "choices": ["душа", "конец", "вечный", "спасение"], "correct_index": 3}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,17 +433,17 @@
                         <div class="quiz-phase-container active" data-phase="throne">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -451,11 +455,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -465,45 +469,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">торжественный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">торжественный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «gehorchen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">повиноваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">повиноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -513,45 +517,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">провозглашать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «feierlich»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">торжественный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">повиноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Treue»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торжественный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">провозглашать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -570,11 +574,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -584,11 +588,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                                         
@@ -596,17 +600,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">чужой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">приданое</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -616,29 +620,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «fremd»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">чужой</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">чужой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -648,7 +652,7 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Mitgift»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">принимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
                                         
@@ -660,33 +664,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «aufnehmen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">приданое</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">принимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Hoffnung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">надежда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">принимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">надежда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -699,29 +703,45 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Sorge»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">известие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">забота</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
                                         
@@ -731,65 +751,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Nachricht»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Angst»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">известие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">забота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">тоска</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -801,27 +805,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молиться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">известие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «beten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">тоска</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">забота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тоска</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">молиться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молиться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -834,49 +838,49 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">борьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">битва</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «retten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">храбрый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -886,13 +890,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Schlacht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">армия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -904,11 +908,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">храбрый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">справедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">армия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -918,11 +922,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">битва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">храбрый</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                                         
@@ -934,11 +938,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                                         
@@ -946,17 +950,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Armee»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">битва</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">армия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">храбрый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">битва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">армия</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -975,22 +979,6 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
@@ -1001,31 +989,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Tränen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">нежный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исцелять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                                         
@@ -1033,17 +1021,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">исцелять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «heilen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1053,29 +1057,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">исцелять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">слёзы</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «sanft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">нежный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">исцелять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">слёзы</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нежный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прощение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1087,7 +1091,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слёзы</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">прощение</button>
                                         
@@ -1104,13 +1108,29 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «gefangen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                                         
@@ -1120,33 +1140,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Gefängnis»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Würde»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отважный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">тюрьма</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">достоинство</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1156,43 +1160,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">достоинство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смирение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">смирение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">достоинство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пленный</button>
                                         
@@ -1200,15 +1172,47 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «tapfer»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">достоинство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Demut»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">смирение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отважный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">утешать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тюрьма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">отважный</button>
                                         
@@ -1220,11 +1224,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тюрьма</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">пленный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">тюрьма</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
                                         
@@ -1239,17 +1243,17 @@
                         <div class="quiz-phase-container" data-phase="prison">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жертва</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1259,13 +1263,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жертва</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1275,13 +1279,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Opfer»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">спасение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">жертва</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1291,11 +1295,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Seele»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
                                         
@@ -1303,17 +1307,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жертва</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">душа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1325,9 +1329,25 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спасение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                                         
@@ -1335,33 +1355,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">душа</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Erlösung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">душа</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спасение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">спасение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2087,82 +2091,82 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "церемония",
                     "провозглашать",
-                    "власть",
-                    "правда"
+                    "церемония",
+                    "правда",
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
                     "церемония",
-                    "провозглашать",
+                    "правда",
                     "власть",
-                    "правда"
+                    "провозглашать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "повиноваться",
-                    "церемония",
+                    "власть",
+                    "торжественный",
                     "провозглашать",
-                    "правда"
+                    "церемония"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
+                    "провозглашать",
                     "правда",
                     "власть",
-                    "торжественный",
-                    "повиноваться"
+                    "торжественный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gehorchen»?",
                 "choices": [
-                    "верность",
-                    "власть",
-                    "церемония",
-                    "повиноваться"
+                    "повиноваться",
+                    "провозглашать",
+                    "долг",
+                    "правда"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "провозглашать",
-                    "торжественный",
+                    "правда",
+                    "церемония",
                     "долг",
-                    "церемония"
+                    "власть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
+                    "власть",
                     "торжественный",
-                    "повиноваться",
-                    "долг",
-                    "церемония"
+                    "верность",
+                    "долг"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "верность",
-                    "провозглашать",
                     "власть",
-                    "церемония"
+                    "торжественный",
+                    "верность",
+                    "провозглашать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2697,18 +2701,18 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "изгонять",
-                    "наказание",
+                    "покидать",
                     "гнев",
-                    "покидать"
+                    "наказание"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "наказание",
-                    "покидать",
                     "гнев",
+                    "покидать",
+                    "наказание",
                     "изгонять"
                 ],
                 "correctIndex": 1
@@ -2716,37 +2720,37 @@
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "чужой",
-                    "гнев",
                     "принимать",
-                    "покидать"
+                    "изгонять",
+                    "гнев",
+                    "приданое"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "гнев",
+                    "изгонять",
                     "наказание",
-                    "покидать",
-                    "надежда"
+                    "чужой",
+                    "покидать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
-                    "наказание",
-                    "изгонять",
                     "гнев",
-                    "чужой"
+                    "наказание",
+                    "чужой",
+                    "принимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
-                    "принимать",
+                    "изгонять",
                     "наказание",
                     "приданое",
                     "гнев"
@@ -2756,22 +2760,22 @@
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
-                    "приданое",
-                    "гнев",
                     "наказание",
-                    "принимать"
+                    "покидать",
+                    "принимать",
+                    "гнев"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "изгонять",
-                    "наказание",
-                    "принимать",
-                    "надежда"
+                    "надежда",
+                    "покидать",
+                    "гнев",
+                    "изгонять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3301,82 +3305,82 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
+                    "известие",
                     "страх",
-                    "забота",
                     "одиночество",
-                    "известие"
+                    "забота"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
+                    "одиночество",
                     "страх",
-                    "забота",
-                    "одиночество",
-                    "известие"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Nachricht»?",
-                "choices": [
                     "известие",
-                    "страдать",
-                    "одиночество",
-                    "страх"
+                    "забота"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Nachricht»?",
+                "choices": [
+                    "забота",
+                    "молиться",
+                    "одиночество",
+                    "известие"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
-                    "известие",
-                    "забота",
-                    "одиночество",
-                    "страх"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
-                    "забота",
-                    "одиночество",
                     "страх",
-                    "страдать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «beschützen»?",
-                "choices": [
-                    "защищать",
-                    "одиночество",
-                    "известие",
+                    "страдать",
+                    "молиться",
                     "тоска"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "забота",
+                    "страдать",
+                    "известие",
+                    "тоска"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «beschützen»?",
+                "choices": [
+                    "забота",
+                    "страдать",
+                    "защищать",
+                    "молиться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
                     "тоска",
-                    "страдать",
-                    "известие",
-                    "защищать"
+                    "молиться",
+                    "забота",
+                    "страх"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
+                    "одиночество",
                     "тоска",
-                    "забота",
-                    "молиться",
-                    "одиночество"
+                    "защищать",
+                    "молиться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3904,39 +3908,39 @@
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
                     "борьба",
+                    "возвращаться",
                     "спасать",
-                    "битва",
-                    "возвращаться"
+                    "битва"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
                     "возвращаться",
-                    "битва",
                     "спасать",
-                    "борьба"
+                    "борьба",
+                    "битва"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "справедливость",
-                    "спасать",
+                    "битва",
                     "армия",
-                    "храбрый"
+                    "борьба",
+                    "спасать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "армия",
-                    "справедливость",
+                    "побеждать",
+                    "борьба",
                     "битва",
-                    "спасать"
+                    "справедливость"
                 ],
                 "correctIndex": 2
             },
@@ -3944,18 +3948,18 @@
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
                     "храбрый",
-                    "армия",
                     "справедливость",
-                    "побеждать"
+                    "армия",
+                    "спасать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "спасать",
-                    "битва",
-                    "побеждать",
+                    "возвращаться",
+                    "армия",
+                    "храбрый",
                     "справедливость"
                 ],
                 "correctIndex": 3
@@ -3963,9 +3967,9 @@
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "справедливость",
+                    "битва",
                     "борьба",
-                    "спасать",
+                    "возвращаться",
                     "побеждать"
                 ],
                 "correctIndex": 3
@@ -3973,12 +3977,12 @@
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
-                    "побеждать",
-                    "армия",
                     "битва",
-                    "справедливость"
+                    "храбрый",
+                    "борьба",
+                    "армия"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4521,77 +4525,77 @@
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
                     "прощать",
-                    "узнавать",
                     "слёзы",
-                    "обнимать"
+                    "обнимать",
+                    "узнавать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
+                    "обнимать",
                     "прощать",
                     "слёзы",
-                    "обнимать",
                     "узнавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
                     "прощать",
-                    "обнимать",
-                    "исцелять",
-                    "нежный"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
-                    "узнавать",
-                    "исцелять",
-                    "слёзы",
-                    "обнимать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «heilen»?",
-                "choices": [
-                    "раскаяние",
                     "прощение",
-                    "обнимать",
-                    "исцелять"
+                    "исцелять",
+                    "обнимать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Reue»?",
+                "question": "Что означает немецкое слово «erkennen»?",
+                "choices": [
+                    "нежный",
+                    "узнавать",
+                    "обнимать",
+                    "прощать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «heilen»?",
                 "choices": [
                     "узнавать",
+                    "исцелять",
+                    "прощать",
+                    "прощение"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Reue»?",
+                "choices": [
+                    "исцелять",
                     "раскаяние",
-                    "обнимать",
-                    "слёзы"
+                    "прощение",
+                    "прощать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
+                    "прощать",
+                    "узнавать",
                     "нежный",
-                    "исцелять",
-                    "слёзы",
-                    "прощение"
+                    "обнимать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
                     "обнимать",
-                    "слёзы",
+                    "раскаяние",
                     "прощение",
                     "узнавать"
                 ],
@@ -5123,79 +5127,79 @@
             {
                 "question": "Что означает немецкое слово «gefangen»?",
                 "choices": [
-                    "тюрьма",
                     "достоинство",
-                    "утешать",
-                    "пленный"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Gefängnis»?",
-                "choices": [
-                    "утешать",
                     "пленный",
-                    "тюрьма",
-                    "достоинство"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Würde»?",
-                "choices": [
-                    "честь",
-                    "достоинство",
-                    "отважный",
+                    "утешать",
                     "тюрьма"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «trösten»?",
+                "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
                     "достоинство",
-                    "утешать",
                     "тюрьма",
-                    "судьба"
+                    "утешать",
+                    "пленный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Würde»?",
+                "choices": [
+                    "тюрьма",
+                    "судьба",
+                    "честь",
+                    "достоинство"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «trösten»?",
+                "choices": [
+                    "честь",
+                    "утешать",
+                    "судьба",
+                    "пленный"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
-                    "утешать",
-                    "отважный",
-                    "тюрьма",
-                    "смирение"
+                    "пленный",
+                    "достоинство",
+                    "судьба",
+                    "отважный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
-                    "тюрьма",
                     "смирение",
-                    "достоинство",
-                    "пленный"
+                    "отважный",
+                    "судьба",
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "смирение",
+                    "пленный",
+                    "тюрьма",
                     "судьба",
-                    "честь",
                     "отважный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "судьба",
-                    "пленный",
                     "тюрьма",
+                    "пленный",
+                    "утешать",
                     "честь"
                 ],
                 "correctIndex": 3
@@ -5760,39 +5764,39 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "смерть",
                     "душа",
                     "жертва",
-                    "умирать"
+                    "умирать",
+                    "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "жертва",
+                    "душа",
                     "смерть",
                     "умирать",
-                    "душа"
+                    "жертва"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
-                    "спасение",
+                    "смерть",
                     "вечный",
                     "жертва",
-                    "умирать"
+                    "душа"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
-                    "жертва",
-                    "спасение",
-                    "прощание",
+                    "смерть",
+                    "конец",
+                    "умирать",
                     "душа"
                 ],
                 "correctIndex": 3
@@ -5800,42 +5804,42 @@
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "жертва",
-                    "душа",
-                    "вечный",
-                    "конец"
+                    "смерть",
+                    "конец",
+                    "спасение",
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "вечный",
-                    "спасение",
-                    "умирать",
-                    "прощание"
+                    "прощание",
+                    "смерть",
+                    "умирать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "смерть",
-                    "прощание",
-                    "спасение",
-                    "душа"
+                    "конец",
+                    "умирать",
+                    "вечный",
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
+                    "душа",
                     "конец",
-                    "умирать",
-                    "спасение",
-                    "вечный"
+                    "вечный",
+                    "спасение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Корнуолла</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Корнуолла</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["желать", "честолюбие", "стремиться", "жадность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["честолюбие", "стремиться", "жадность", "желать"], "correct_index": 2}, {"question": "Что означает немецкое слово «streben»?", "choices": ["стремиться", "жадность", "жадный", "честолюбие"], "correct_index": 0}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["желать", "стремиться", "властолюбие", "вожделеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["захватывать", "жадность", "вожделеть", "жадный"], "correct_index": 2}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["стремиться", "честолюбие", "вожделеть", "жадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["вожделеть", "желать", "властолюбие", "жадность"], "correct_index": 2}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["честолюбие", "вожделеть", "стремиться", "захватывать"], "correct_index": 3}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["одобрять", "злоба", "жестокость", "поддерживать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["злоба", "одобрять", "жестокость", "поддерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["одобрять", "подстрекать", "суровость", "поощрять"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["злоба", "жестокость", "поддерживать", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["поддерживать", "подстрекать", "одобрять", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["подстрекать", "жестокость", "поощрять", "одобрять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["злоба", "поддерживать", "поощрять", "суровость"], "correct_index": 3}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["подавлять", "страх", "угнетение", "тирания"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["угнетение", "страх", "подавлять", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "тирания", "страх", "принуждать"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["подавлять", "произвол", "брутальный", "тирания"], "correct_index": 0}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "подавлять", "брутальный", "произвол"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["брутальный", "принуждать", "угнетение", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["принуждать", "порабощать", "страх", "произвол"], "correct_index": 3}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["произвол", "брутальный", "подавлять", "угнетение"], "correct_index": 1}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["гнев", "наказание", "наказывать", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказание", "гнев", "наказывать", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["карать", "наказывать", "унижать", "наказание"], "correct_index": 0}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["карать", "унижать", "наказание", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["гнев", "унижать", "наказывать", "карать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["наказывать", "унижать", "гнев", "наказание"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["карать", "мучить", "унижать", "наказывать"], "correct_index": 1}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытать", "пытка", "садизм", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытать", "пытка", "садизм", "кровь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["ослеплять", "калечить", "выкалывать", "кровь"], "correct_index": 3}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "пытать", "калечить", "мука"], "correct_index": 1}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["ослеплять", "кровь", "садизм", "калечить"], "correct_index": 3}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "садизм", "пытка", "калечить"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["мука", "калечить", "выкалывать", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["выкалывать", "пытка", "пытать", "мука"], "correct_index": 3}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["рана", "боль", "удивление", "кровоточить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["рана", "удивление", "боль", "кровоточить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["раненый", "удивление", "боль", "рана"], "correct_index": 1}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["кровоточить", "раненый", "боль", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["страдать", "боль", "удивление", "раненый"], "correct_index": 3}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["боль", "раненый", "удивление", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["ослаблять", "страдать", "рана", "удивление"], "correct_index": 1}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["возмездие", "умирать", "смерть", "конец"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["умирать", "возмездие", "конец", "смерть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "проклинать", "конец", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "конец", "издыхать", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["издыхать", "кара", "проклинать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["смерть", "проклинать", "умирать", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["проклинать", "хрипеть", "умирать", "конец"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["проклинать", "конец", "кара", "издыхать"], "correct_index": 2}]}'>
+                    <div class="quiz-section" data-quiz-map='{"ambitious_duke": [{"question": "Что означает немецкое слово «der Ehrgeiz»?", "choices": ["честолюбие", "стремиться", "жадность", "желать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["жадность", "стремиться", "желать", "честолюбие"], "correct_index": 0}, {"question": "Что означает немецкое слово «streben»?", "choices": ["честолюбие", "желать", "стремиться", "захватывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlangen»?", "choices": ["жадный", "захватывать", "желать", "властолюбие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделеть", "стремиться", "жадный", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «gierig»?", "choices": ["жадный", "честолюбие", "стремиться", "жадность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Herrschsucht»?", "choices": ["властолюбие", "вожделеть", "желать", "захватывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergreifen»?", "choices": ["жадный", "желать", "захватывать", "честолюбие"], "correct_index": 2}], "cruel_husband": [{"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["одобрять", "жестокость", "поддерживать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["одобрять", "поддерживать", "злоба", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «billigen»?", "choices": ["жестокость", "одобрять", "поддерживать", "суровость"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterstützen»?", "choices": ["поддерживать", "поощрять", "одобрять", "подстрекать"], "correct_index": 0}, {"question": "Что означает немецкое слово «anstacheln»?", "choices": ["одобрять", "поощрять", "подстрекать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «ermutigen»?", "choices": ["суровость", "поощрять", "жестокость", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["поддерживать", "суровость", "жестокость", "поощрять"], "correct_index": 1}], "tyrant": [{"question": "Что означает немецкое слово «die Tyrannei»?", "choices": ["тирания", "подавлять", "угнетение", "страх"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Unterdrückung»?", "choices": ["страх", "угнетение", "подавлять", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Furcht»?", "choices": ["порабощать", "брутальный", "тирания", "страх"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterdrücken»?", "choices": ["страх", "порабощать", "подавлять", "брутальный"], "correct_index": 2}, {"question": "Что означает немецкое слово «knechten»?", "choices": ["порабощать", "угнетение", "принуждать", "брутальный"], "correct_index": 0}, {"question": "Что означает немецкое слово «zwingen»?", "choices": ["угнетение", "страх", "принуждать", "произвол"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Willkür»?", "choices": ["подавлять", "произвол", "брутальный", "тирания"], "correct_index": 1}, {"question": "Что означает немецкое слово «brutal»?", "choices": ["произвол", "брутальный", "принуждать", "угнетение"], "correct_index": 1}], "punishment": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["карать", "наказывать", "гнев", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["наказывать", "карать", "наказание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «bestrafen»?", "choices": ["карать", "унижать", "наказывать", "унижать"], "correct_index": 0}, {"question": "Что означает немецкое слово «züchtigen»?", "choices": ["унижать", "гнев", "унижать", "наказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «demütigen»?", "choices": ["мучить", "наказывать", "унижать", "гнев"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["карать", "унижать", "наказывать", "гнев"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "мучить", "гнев", "карать"], "correct_index": 1}], "torturer": [{"question": "Что означает немецкое слово «die Folter»?", "choices": ["кровь", "пытка", "садизм", "пытать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["пытка", "садизм", "пытать", "кровь"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Blut»?", "choices": ["пытка", "калечить", "кровь", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «foltern»?", "choices": ["ослеплять", "выкалывать", "мука", "пытать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstümmeln»?", "choices": ["пытка", "кровь", "калечить", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["ослеплять", "пытать", "кровь", "пытка"], "correct_index": 0}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["выкалывать", "садизм", "калечить", "мука"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мука", "кровь", "калечить", "выкалывать"], "correct_index": 0}], "wounded": [{"question": "Что означает немецкое слово «die Wunde»?", "choices": ["удивление", "рана", "боль", "кровоточить"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["кровоточить", "удивление", "рана", "боль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Überraschung»?", "choices": ["рана", "страдать", "кровоточить", "удивление"], "correct_index": 3}, {"question": "Что означает немецкое слово «bluten»?", "choices": ["кровоточить", "боль", "рана", "ослаблять"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwundet»?", "choices": ["раненый", "страдать", "рана", "удивление"], "correct_index": 0}, {"question": "Что означает немецкое слово «schwächen»?", "choices": ["кровоточить", "рана", "раненый", "ослаблять"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["удивление", "боль", "кровоточить", "страдать"], "correct_index": 3}], "death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["конец", "смерть", "возмездие", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergeltung»?", "choices": ["возмездие", "смерть", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["умирать", "издыхать", "возмездие", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["возмездие", "умирать", "хрипеть", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["умирать", "кара", "смерть", "издыхать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["умирать", "конец", "кара", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «röcheln»?", "choices": ["умирать", "проклинать", "издыхать", "хрипеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возмездие", "издыхать", "хрипеть", "кара"], "correct_index": 3}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Амбициозный герцог</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,24 +433,8 @@
                         <div class="quiz-phase-container active" data-phase="ambitious_duke">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Ehrgeiz»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
@@ -461,15 +449,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «streben»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                                         
@@ -477,63 +465,47 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «streben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verlangen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">захватывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">властолюбие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">захватывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жадность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">стремиться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жадный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стремиться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">властолюбие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жадный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
                                         
@@ -541,17 +513,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «gierig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">честолюбие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честолюбие</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">стремиться</button>
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Herrschsucht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">властолюбие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="3">захватывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «ergreifen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">захватывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">честолюбие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,79 +568,31 @@
                         <div class="quiz-phase-container" data-phase="cruel_husband">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поддерживать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">суровость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подстрекать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                                         
@@ -644,33 +600,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «billigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подстрекать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">одобрять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поддерживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">одобрять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «unterstützen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подстрекать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «anstacheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одобрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подстрекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «ermutigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">суровость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поощрять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поддерживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поддерживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">суровость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">поощрять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">суровость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поощрять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -683,29 +687,29 @@
                         <div class="quiz-phase-container" data-phase="tyrant">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Tyrannei»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">тирания</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Unterdrückung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
                                         
@@ -715,24 +719,72 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Furcht»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">тирания</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тирания</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">принуждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страх</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «unterdrücken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угнетение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брутальный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">угнетение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страх</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">подавлять</button>
@@ -747,54 +799,6 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «knechten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">порабощать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подавлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">брутальный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «zwingen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">брутальный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">принуждать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">угнетение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">тирания</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Willkür»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">принуждать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">порабощать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страх</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">произвол</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
                                 <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «brutal»?</div>
                                     <div class="quiz-choices">
@@ -803,7 +807,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">брутальный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">подавлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">принуждать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">угнетение</button>
                                         
@@ -818,33 +822,33 @@
                         <div class="quiz-phase-container" data-phase="punishment">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">карать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -856,11 +860,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -870,11 +874,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «züchtigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
                                         
@@ -882,17 +886,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -902,13 +906,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -918,13 +922,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">карать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">карать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -941,27 +945,27 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
                                         
@@ -969,49 +973,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «das Blut»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">кровь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «foltern»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выкалывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мука</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verstümmeln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">садизм</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1023,25 +1027,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">калечить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">калечить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                                         
@@ -1049,17 +1037,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">мука</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мука</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">кровь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">калечить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1072,15 +1076,15 @@
                         <div class="quiz-phase-container" data-phase="wounded">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Wunde»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
                                         
@@ -1088,33 +1092,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Schmerz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">кровоточить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Überraschung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">рана</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1126,27 +1130,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «verwundet»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раненый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">раненый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1156,11 +1160,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «schwächen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">кровоточить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раненый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рана</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раненый</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">ослаблять</button>
                                         
@@ -1168,17 +1172,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослаблять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">удивление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">рана</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кровоточить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">удивление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1191,15 +1195,47 @@
                         <div class="quiz-phase-container" data-phase="death">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возмездие</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
                                         
@@ -1207,31 +1243,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Vergeltung»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">возмездие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                                         
@@ -1239,15 +1259,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                                         
@@ -1255,65 +1291,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">кара</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «röcheln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хрипеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хрипеть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возмездие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">кара</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хрипеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кара</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1985,82 +1989,82 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "желать",
-                    "честолюбие",
-                    "стремиться",
-                    "жадность"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
                     "честолюбие",
                     "стремиться",
                     "жадность",
                     "желать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «streben»?",
+                "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
-                    "стремиться",
                     "жадность",
-                    "жадный",
+                    "стремиться",
+                    "желать",
                     "честолюбие"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verlangen»?",
+                "question": "Что означает немецкое слово «streben»?",
                 "choices": [
+                    "честолюбие",
                     "желать",
                     "стремиться",
-                    "властолюбие",
-                    "вожделеть"
+                    "захватывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verlangen»?",
+                "choices": [
+                    "жадный",
+                    "захватывать",
+                    "желать",
+                    "властолюбие"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "захватывать",
-                    "жадность",
                     "вожделеть",
-                    "жадный"
+                    "стремиться",
+                    "жадный",
+                    "жадность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
-                    "стремиться",
+                    "жадный",
                     "честолюбие",
-                    "вожделеть",
-                    "жадный"
+                    "стремиться",
+                    "жадность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
+                    "властолюбие",
                     "вожделеть",
                     "желать",
-                    "властолюбие",
-                    "жадность"
+                    "захватывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
-                    "честолюбие",
-                    "вожделеть",
-                    "стремиться",
-                    "захватывать"
+                    "жадный",
+                    "желать",
+                    "захватывать",
+                    "честолюбие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2519,71 +2523,71 @@
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
                     "одобрять",
-                    "злоба",
-                    "жестокость",
-                    "поддерживать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Bosheit»?",
-                "choices": [
-                    "злоба",
-                    "одобрять",
-                    "жестокость",
-                    "поддерживать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «billigen»?",
-                "choices": [
-                    "одобрять",
-                    "подстрекать",
-                    "суровость",
-                    "поощрять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «unterstützen»?",
-                "choices": [
-                    "злоба",
                     "жестокость",
                     "поддерживать",
-                    "одобрять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «anstacheln»?",
-                "choices": [
-                    "поддерживать",
-                    "подстрекать",
-                    "одобрять",
-                    "жестокость"
+                    "злоба"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «ermutigen»?",
+                "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "подстрекать",
-                    "жестокость",
-                    "поощрять",
-                    "одобрять"
+                    "одобрять",
+                    "поддерживать",
+                    "злоба",
+                    "жестокость"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Härte»?",
+                "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
-                    "злоба",
+                    "жестокость",
+                    "одобрять",
                     "поддерживать",
-                    "поощрять",
                     "суровость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «unterstützen»?",
+                "choices": [
+                    "поддерживать",
+                    "поощрять",
+                    "одобрять",
+                    "подстрекать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «anstacheln»?",
+                "choices": [
+                    "одобрять",
+                    "поощрять",
+                    "подстрекать",
+                    "злоба"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «ermutigen»?",
+                "choices": [
+                    "суровость",
+                    "поощрять",
+                    "жестокость",
+                    "злоба"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Härte»?",
+                "choices": [
+                    "поддерживать",
+                    "суровость",
+                    "жестокость",
+                    "поощрять"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3043,79 +3047,79 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
+                    "тирания",
                     "подавлять",
-                    "страх",
                     "угнетение",
-                    "тирания"
+                    "страх"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
                 "choices": [
-                    "угнетение",
                     "страх",
+                    "угнетение",
                     "подавлять",
                     "тирания"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
                     "порабощать",
+                    "брутальный",
                     "тирания",
-                    "страх",
-                    "принуждать"
+                    "страх"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unterdrücken»?",
                 "choices": [
+                    "страх",
+                    "порабощать",
                     "подавлять",
-                    "произвол",
-                    "брутальный",
-                    "тирания"
+                    "брутальный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
                     "порабощать",
-                    "подавлять",
-                    "брутальный",
-                    "произвол"
+                    "угнетение",
+                    "принуждать",
+                    "брутальный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
-                    "брутальный",
-                    "принуждать",
                     "угнетение",
-                    "тирания"
+                    "страх",
+                    "принуждать",
+                    "произвол"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "принуждать",
-                    "порабощать",
-                    "страх",
-                    "произвол"
+                    "подавлять",
+                    "произвол",
+                    "брутальный",
+                    "тирания"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
                     "произвол",
                     "брутальный",
-                    "подавлять",
+                    "принуждать",
                     "угнетение"
                 ],
                 "correctIndex": 1
@@ -3566,39 +3570,39 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "гнев",
-                    "наказание",
+                    "карать",
                     "наказывать",
-                    "карать"
+                    "гнев",
+                    "наказание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "наказание",
-                    "гнев",
                     "наказывать",
-                    "карать"
+                    "карать",
+                    "наказание",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
                     "карать",
-                    "наказывать",
                     "унижать",
-                    "наказание"
+                    "наказывать",
+                    "унижать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
-                    "карать",
                     "унижать",
-                    "наказание",
+                    "гнев",
+                    "унижать",
                     "наказывать"
                 ],
                 "correctIndex": 3
@@ -3606,30 +3610,30 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "гнев",
-                    "унижать",
+                    "мучить",
                     "наказывать",
-                    "карать"
+                    "унижать",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "наказывать",
+                    "карать",
                     "унижать",
-                    "гнев",
-                    "наказание"
+                    "наказывать",
+                    "гнев"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "карать",
-                    "мучить",
                     "унижать",
-                    "наказывать"
+                    "мучить",
+                    "гнев",
+                    "карать"
                 ],
                 "correctIndex": 1
             }
@@ -4130,82 +4134,82 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытать",
+                    "кровь",
                     "пытка",
                     "садизм",
-                    "кровь"
+                    "пытать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "пытать",
                     "пытка",
                     "садизм",
+                    "пытать",
                     "кровь"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Blut»?",
                 "choices": [
-                    "ослеплять",
+                    "пытка",
                     "калечить",
-                    "выкалывать",
-                    "кровь"
+                    "кровь",
+                    "пытать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
                     "ослеплять",
-                    "пытать",
-                    "калечить",
-                    "мука"
+                    "выкалывать",
+                    "мука",
+                    "пытать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verstümmeln»?",
                 "choices": [
-                    "ослеплять",
+                    "пытка",
                     "кровь",
-                    "садизм",
-                    "калечить"
+                    "калечить",
+                    "садизм"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
                     "ослеплять",
-                    "садизм",
-                    "пытка",
-                    "калечить"
+                    "пытать",
+                    "кровь",
+                    "пытка"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "мука",
-                    "калечить",
                     "выкалывать",
-                    "пытка"
+                    "садизм",
+                    "калечить",
+                    "мука"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "выкалывать",
-                    "пытка",
-                    "пытать",
-                    "мука"
+                    "мука",
+                    "кровь",
+                    "калечить",
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4631,59 +4635,59 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
+                    "удивление",
                     "рана",
                     "боль",
-                    "удивление",
                     "кровоточить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "рана",
+                    "кровоточить",
                     "удивление",
-                    "боль",
-                    "кровоточить"
+                    "рана",
+                    "боль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
-                    "раненый",
-                    "удивление",
-                    "боль",
-                    "рана"
+                    "рана",
+                    "страдать",
+                    "кровоточить",
+                    "удивление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
                     "кровоточить",
-                    "раненый",
                     "боль",
-                    "удивление"
+                    "рана",
+                    "ослаблять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
+                    "раненый",
                     "страдать",
-                    "боль",
-                    "удивление",
-                    "раненый"
+                    "рана",
+                    "удивление"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
-                    "боль",
+                    "кровоточить",
+                    "рана",
                     "раненый",
-                    "удивление",
                     "ослаблять"
                 ],
                 "correctIndex": 3
@@ -4691,12 +4695,12 @@
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "ослаблять",
-                    "страдать",
-                    "рана",
-                    "удивление"
+                    "удивление",
+                    "боль",
+                    "кровоточить",
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5173,82 +5177,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "возмездие",
-                    "умирать",
+                    "конец",
                     "смерть",
-                    "конец"
+                    "возмездие",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Vergeltung»?",
                 "choices": [
-                    "умирать",
                     "возмездие",
+                    "смерть",
                     "конец",
-                    "смерть"
+                    "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "умирать",
-                    "проклинать",
-                    "конец",
-                    "издыхать"
+                    "издыхать",
+                    "возмездие",
+                    "конец"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
+                    "возмездие",
                     "умирать",
-                    "конец",
-                    "издыхать",
-                    "проклинать"
+                    "хрипеть",
+                    "издыхать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "издыхать",
+                    "умирать",
                     "кара",
-                    "проклинать",
-                    "смерть"
+                    "смерть",
+                    "издыхать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "смерть",
-                    "проклинать",
                     "умирать",
-                    "издыхать"
+                    "конец",
+                    "кара",
+                    "проклинать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
-                    "проклинать",
-                    "хрипеть",
                     "умирать",
-                    "конец"
+                    "проклинать",
+                    "издыхать",
+                    "хрипеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "проклинать",
-                    "конец",
-                    "кара",
-                    "издыхать"
+                    "возмездие",
+                    "издыхать",
+                    "хрипеть",
+                    "кара"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Превращение Эдгара</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Превращение Эдгара</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "знать", "королевство", "наследник"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["наследник", "знать", "королевство", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["наследник", "законный", "королевство", "ничего не подозревающий"], "correct_index": 2}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["законный", "королевство", "доверять", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["наследник", "честь", "доверять", "законный"], "correct_index": 1}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["законный", "королевство", "ничего не подозревающий", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["честь", "ничего не подозревающий", "граф", "наследник"], "correct_index": 2}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["ничего не подозревающий", "наследник", "знать", "честь"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["преследовать", "предательство", "бежать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["бежать", "опасность", "преследовать", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["прятаться", "обман", "опасность", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["опасность", "интрига", "предательство", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["изгнать", "интрига", "прятаться", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["прятаться", "интрига", "опасность", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["опасность", "обман", "прятаться", "предательство"], "correct_index": 1}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["интрига", "предательство", "изгнать", "бежать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "маскировка", "безумие", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["голый", "нищий", "безумие", "маскировка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["маскировка", "нищий", "дрожать", "голый"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["бормотать", "голый", "дрожать", "нищета"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["дрожать", "безумный", "голый", "бормотать"], "correct_index": 3}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["нищий", "дрожать", "безумие", "маскировка"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["безумный", "нищий", "маскировка", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["безумие", "голый", "нищий", "безумный"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["хижина", "буря", "мёрзнуть", "страдать"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "страдать", "буря", "хижина"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "гром", "сопровождать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["хижина", "страдать", "сопровождать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["страдать", "мёрзнуть", "буря", "защищать"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["гром", "молния", "хижина", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["гром", "буря", "защищать", "страдать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["страдать", "молния", "защищать", "буря"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["вести", "обманывать", "слепой", "утёс"], "correct_index": 2}, {"question": "Что означает немецкое слово «führen»?", "choices": ["вести", "утёс", "слепой", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["утёс", "слепой", "утешать", "хитрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "хитрость", "утешать", "спасать"], "correct_index": 0}, {"question": "Что означает немецкое слово «retten»?", "choices": ["слепой", "хитрость", "вести", "спасать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["спасать", "хитрость", "отчаяние", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "обманывать", "спасать", "вести"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["слепой", "утешать", "отчаяние", "спасать"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["бой", "дуэль", "месть", "разоблачать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "дуэль", "бой", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["бой", "разоблачать", "меч", "месть"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["бой", "разоблачать", "справедливость", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["брат", "меч", "побеждать", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["брат", "побеждать", "дуэль", "справедливость"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["дуэль", "меч", "бой", "разоблачать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["побеждать", "брат", "месть", "дуэль"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["выживать", "наследовать", "будущее", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["выживать", "будущее", "править", "наследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["новый", "будущее", "наследовать", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["наследовать", "выживать", "править", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["новый", "мудрость", "править", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["выживать", "ответственность", "править", "порядок"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["порядок", "мудрость", "наследовать", "ответственность"], "correct_index": 3}, {"question": "Что означает немецкое слово «neu»?", "choices": ["ответственность", "новый", "мудрость", "порядок"], "correct_index": 1}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["знать", "королевство", "наследник", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erbe»?", "choices": ["знать", "наследник", "доверять", "королевство"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["ничего не подозревающий", "королевство", "наследник", "доверять"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["доверять", "ничего не подозревающий", "законный", "честь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["доверять", "наследник", "королевство", "честь"], "correct_index": 3}, {"question": "Что означает немецкое слово «legitim»?", "choices": ["доверять", "честь", "законный", "граф"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["честь", "граф", "доверять", "ничего не подозревающий"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnungslos»?", "choices": ["знать", "граф", "наследник", "ничего не подозревающий"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «fliehen»?", "choices": ["предательство", "преследовать", "бежать", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["предательство", "преследовать", "бежать", "опасность"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["предательство", "бежать", "прятаться", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["прятаться", "обман", "опасность", "преследовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstecken»?", "choices": ["предательство", "обман", "прятаться", "бежать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "предательство", "опасность", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["предательство", "интрига", "обман", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannen»?", "choices": ["изгнать", "обман", "преследовать", "бежать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["голый", "маскировка", "нищий", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["голый", "безумие", "маскировка", "нищий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["нищий", "маскировка", "голый", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["нищета", "голый", "нищий", "бормотать"], "correct_index": 1}, {"question": "Что означает немецкое слово «murmeln»?", "choices": ["голый", "дрожать", "бормотать", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["дрожать", "маскировка", "голый", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Elend»?", "choices": ["безумие", "нищета", "нищий", "бормотать"], "correct_index": 1}, {"question": "Что означает немецкое слово «wahnsinnig»?", "choices": ["дрожать", "голый", "бормотать", "безумный"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["хижина", "страдать", "мёрзнуть", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "страдать", "хижина", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["хижина", "буря", "страдать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["буря", "хижина", "мёрзнуть", "гром"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschützen»?", "choices": ["хижина", "буря", "защищать", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["буря", "страдать", "сопровождать", "молния"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["буря", "гром", "мёрзнуть", "защищать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["сопровождать", "гром", "молния", "защищать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blind»?", "choices": ["утёс", "вести", "обманывать", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «führen»?", "choices": ["обманывать", "вести", "слепой", "утёс"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Klippe»?", "choices": ["вести", "отчаяние", "утёс", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["спасать", "вести", "обманывать", "слепой"], "correct_index": 2}, {"question": "Что означает немецкое слово «retten»?", "choices": ["утёс", "спасать", "отчаяние", "вести"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["хитрость", "утешать", "спасать", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["вести", "обманывать", "утешать", "хитрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["утёс", "спасать", "обманывать", "отчаяние"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «der Kampf»?", "choices": ["разоблачать", "месть", "дуэль", "бой"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Duell»?", "choices": ["разоблачать", "месть", "бой", "дуэль"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["дуэль", "разоблачать", "месть", "справедливость"], "correct_index": 2}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["меч", "разоблачать", "справедливость", "дуэль"], "correct_index": 1}, {"question": "Что означает немецкое слово «siegen»?", "choices": ["бой", "брат", "меч", "побеждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gerechtigkeit»?", "choices": ["брат", "месть", "справедливость", "разоблачать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schwert»?", "choices": ["брат", "меч", "дуэль", "побеждать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bruder»?", "choices": ["брат", "дуэль", "месть", "разоблачать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «überleben»?", "choices": ["выживать", "наследовать", "будущее", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "выживать", "править", "будущее"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zukunft»?", "choices": ["выживать", "порядок", "будущее", "мудрость"], "correct_index": 2}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["выживать", "наследовать", "править", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["порядок", "мудрость", "ответственность", "выживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ordnung»?", "choices": ["ответственность", "выживать", "порядок", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verantwortung»?", "choices": ["мудрость", "будущее", "ответственность", "новый"], "correct_index": 2}, {"question": "Что означает немецкое слово «neu»?", "choices": ["будущее", "мудрость", "выживать", "новый"], "correct_index": 3}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный сын</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,31 +433,15 @@
                         <div class="quiz-phase-container active" data-phase="throne">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
                                         
@@ -461,15 +449,95 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Erbe»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">законный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">законный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                                         
@@ -477,81 +545,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наследник</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">законный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «legitim»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">законный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ничего не подозревающий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ничего не подозревающий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследник</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «ahnungslos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ничего не подозревающий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наследник</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследник</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ничего не подозревающий</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -568,9 +572,9 @@
                                     <div class="quiz-question">Что означает немецкое слово «fliehen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                                         
@@ -580,33 +584,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бежать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бежать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бежать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -616,11 +620,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
                                         
@@ -632,59 +636,59 @@
                                     <div class="quiz-question">Что означает немецкое слово «verstecken»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прятаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">прятаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verbannen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">бежать</button>
                                         
@@ -699,7 +703,7 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                                     <div class="quiz-choices">
                                         
@@ -707,7 +711,23 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                                         
@@ -715,33 +735,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Verkleidung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">маскировка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -751,27 +755,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бормотать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дрожать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">безумный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
                                         
@@ -779,33 +767,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «murmeln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">маскировка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">маскировка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">безумный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">маскировка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бормотать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -815,11 +819,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «wahnsinnig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бормотать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">безумный</button>
                                         
@@ -834,17 +838,17 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -858,23 +862,23 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">хижина</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                                         
@@ -882,31 +886,63 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                                     <div class="quiz-choices">
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                                    <div class="quiz-choices">
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «beschützen»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                                         
@@ -914,49 +950,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защищать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -969,13 +973,29 @@
                         <div class="quiz-phase-container" data-phase="hut">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «blind»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «führen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
                                         
@@ -985,15 +1005,63 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «führen»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">утёс</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">слепой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вести</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «retten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die List»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                                         
@@ -1001,13 +1069,13 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Klippe»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вести</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слепой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                                         
@@ -1017,81 +1085,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «retten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вести</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die List»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">спасать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спасать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вести</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утёс</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">утешать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">спасать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">спасать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1104,49 +1108,49 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Kampf»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бой</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">разоблачать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1156,7 +1160,7 @@
                                     <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">меч</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">разоблачать</button>
                                         
@@ -1168,33 +1172,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «siegen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бой</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">меч</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Gerechtigkeit»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1204,29 +1208,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Schwert»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">меч</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">бой</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">побеждать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Bruder»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">побеждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">брат</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">брат</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разоблачать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1255,31 +1259,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «erben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">будущее</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Zukunft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">порядок</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">будущее</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                                         
@@ -1291,9 +1295,9 @@
                                     <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                                         
@@ -1307,61 +1311,61 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">новый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">выживать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ответственность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
-                                    <div class="quiz-choices">
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="0">порядок</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ответственность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выживать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ordnung»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">ответственность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">новый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">порядок</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">порядок</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verantwortung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">будущее</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ответственность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «neu»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">будущее</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">новый</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2029,82 +2033,82 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "доверять",
                     "знать",
                     "королевство",
-                    "наследник"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Erbe»?",
-                "choices": [
                     "наследник",
-                    "знать",
-                    "королевство",
                     "доверять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «das Königreich»?",
+                "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
+                    "знать",
                     "наследник",
-                    "законный",
-                    "королевство",
-                    "ничего не подозревающий"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vertrauen»?",
-                "choices": [
-                    "законный",
-                    "королевство",
                     "доверять",
-                    "наследник"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Ehre»?",
-                "choices": [
-                    "наследник",
-                    "честь",
-                    "доверять",
-                    "законный"
+                    "королевство"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «legitim»?",
+                "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "законный",
-                    "королевство",
                     "ничего не подозревающий",
+                    "королевство",
+                    "наследник",
+                    "доверять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «vertrauen»?",
+                "choices": [
+                    "доверять",
+                    "ничего не подозревающий",
+                    "законный",
                     "честь"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Ehre»?",
+                "choices": [
+                    "доверять",
+                    "наследник",
+                    "королевство",
+                    "честь"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «legitim»?",
+                "choices": [
+                    "доверять",
+                    "честь",
+                    "законный",
+                    "граф"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
                     "честь",
-                    "ничего не подозревающий",
                     "граф",
-                    "наследник"
+                    "доверять",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
-                    "ничего не подозревающий",
-                    "наследник",
                     "знать",
-                    "честь"
+                    "граф",
+                    "наследник",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2570,8 +2574,8 @@
             {
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
-                    "преследовать",
                     "предательство",
+                    "преследовать",
                     "бежать",
                     "опасность"
                 ],
@@ -2580,29 +2584,29 @@
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "бежать",
-                    "опасность",
+                    "предательство",
                     "преследовать",
-                    "предательство"
+                    "бежать",
+                    "опасность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
+                    "предательство",
+                    "бежать",
                     "прятаться",
-                    "обман",
-                    "опасность",
-                    "преследовать"
+                    "опасность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
+                    "прятаться",
+                    "обман",
                     "опасность",
-                    "интрига",
-                    "предательство",
                     "преследовать"
                 ],
                 "correctIndex": 3
@@ -2610,42 +2614,42 @@
             {
                 "question": "Что означает немецкое слово «verstecken»?",
                 "choices": [
-                    "изгнать",
-                    "интрига",
+                    "предательство",
+                    "обман",
                     "прятаться",
-                    "преследовать"
+                    "бежать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "прятаться",
                     "интрига",
+                    "предательство",
                     "опасность",
-                    "предательство"
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "опасность",
+                    "предательство",
+                    "интрига",
                     "обман",
-                    "прятаться",
-                    "предательство"
+                    "опасность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
-                    "интрига",
-                    "предательство",
                     "изгнать",
+                    "обман",
+                    "преследовать",
                     "бежать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3138,77 +3142,77 @@
                 "choices": [
                     "голый",
                     "маскировка",
-                    "безумие",
-                    "нищий"
+                    "нищий",
+                    "безумие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
                     "голый",
-                    "нищий",
                     "безумие",
-                    "маскировка"
+                    "маскировка",
+                    "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "маскировка",
                     "нищий",
-                    "дрожать",
-                    "голый"
+                    "маскировка",
+                    "голый",
+                    "безумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "бормотать",
+                    "нищета",
                     "голый",
-                    "дрожать",
-                    "нищета"
+                    "нищий",
+                    "бормотать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «murmeln»?",
                 "choices": [
-                    "дрожать",
-                    "безумный",
                     "голый",
-                    "бормотать"
+                    "дрожать",
+                    "бормотать",
+                    "безумие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "нищий",
                     "дрожать",
-                    "безумие",
-                    "маскировка"
+                    "маскировка",
+                    "голый",
+                    "нищий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "безумный",
+                    "безумие",
+                    "нищета",
                     "нищий",
-                    "маскировка",
-                    "нищета"
+                    "бормотать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
-                    "безумие",
+                    "дрожать",
                     "голый",
-                    "нищий",
+                    "бормотать",
                     "безумный"
                 ],
                 "correctIndex": 3
@@ -3714,81 +3718,81 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "хижина",
-                    "буря",
+                    "страдать",
                     "мёрзнуть",
-                    "страдать"
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
                     "мёрзнуть",
                     "страдать",
-                    "буря",
-                    "хижина"
+                    "хижина",
+                    "буря"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "хижина",
+                    "буря",
                     "страдать",
-                    "гром",
-                    "сопровождать",
                     "мёрзнуть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
+                    "буря",
                     "хижина",
-                    "страдать",
-                    "сопровождать",
-                    "мёрзнуть"
+                    "мёрзнуть",
+                    "гром"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
-                    "страдать",
-                    "мёрзнуть",
+                    "хижина",
                     "буря",
-                    "защищать"
+                    "защищать",
+                    "мёрзнуть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "гром",
-                    "молния",
-                    "хижина",
-                    "сопровождать"
+                    "буря",
+                    "страдать",
+                    "сопровождать",
+                    "молния"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Donner»?",
                 "choices": [
-                    "гром",
                     "буря",
-                    "защищать",
-                    "страдать"
+                    "гром",
+                    "мёрзнуть",
+                    "защищать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "страдать",
+                    "сопровождать",
+                    "гром",
                     "молния",
-                    "защищать",
-                    "буря"
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4279,82 +4283,82 @@
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
+                    "утёс",
                     "вести",
                     "обманывать",
-                    "слепой",
-                    "утёс"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «führen»?",
-                "choices": [
-                    "вести",
-                    "утёс",
-                    "слепой",
-                    "обманывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Klippe»?",
-                "choices": [
-                    "утёс",
-                    "слепой",
-                    "утешать",
-                    "хитрость"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "обманывать",
-                    "хитрость",
-                    "утешать",
-                    "спасать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «retten»?",
-                "choices": [
-                    "слепой",
-                    "хитрость",
-                    "вести",
-                    "спасать"
+                    "слепой"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die List»?",
+                "question": "Что означает немецкое слово «führen»?",
                 "choices": [
-                    "спасать",
-                    "хитрость",
-                    "отчаяние",
-                    "обманывать"
+                    "обманывать",
+                    "вести",
+                    "слепой",
+                    "утёс"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «trösten»?",
+                "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
-                    "утешать",
-                    "обманывать",
+                    "вести",
+                    "отчаяние",
+                    "утёс",
+                    "хитрость"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
                     "спасать",
+                    "вести",
+                    "обманывать",
+                    "слепой"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «retten»?",
+                "choices": [
+                    "утёс",
+                    "спасать",
+                    "отчаяние",
                     "вести"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die List»?",
+                "choices": [
+                    "хитрость",
+                    "утешать",
+                    "спасать",
+                    "обманывать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "слепой",
+                    "вести",
+                    "обманывать",
                     "утешать",
-                    "отчаяние",
-                    "спасать"
+                    "хитрость"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "утёс",
+                    "спасать",
+                    "обманывать",
+                    "отчаяние"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4825,37 +4829,37 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "бой",
-                    "дуэль",
+                    "разоблачать",
                     "месть",
-                    "разоблачать"
+                    "дуэль",
+                    "бой"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
                     "разоблачать",
-                    "дуэль",
+                    "месть",
                     "бой",
-                    "месть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "бой",
-                    "разоблачать",
-                    "меч",
-                    "месть"
+                    "дуэль"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "дуэль",
+                    "разоблачать",
+                    "месть",
+                    "справедливость"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
-                    "бой",
+                    "меч",
                     "разоблачать",
                     "справедливость",
                     "дуэль"
@@ -4865,42 +4869,42 @@
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
+                    "бой",
                     "брат",
                     "меч",
-                    "побеждать",
-                    "дуэль"
+                    "побеждать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
                     "брат",
-                    "побеждать",
-                    "дуэль",
-                    "справедливость"
+                    "месть",
+                    "справедливость",
+                    "разоблачать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
-                    "дуэль",
+                    "брат",
                     "меч",
-                    "бой",
-                    "разоблачать"
+                    "дуэль",
+                    "побеждать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "побеждать",
                     "брат",
+                    "дуэль",
                     "месть",
-                    "дуэль"
+                    "разоблачать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5394,28 +5398,28 @@
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
+                    "наследовать",
                     "выживать",
-                    "будущее",
                     "править",
-                    "наследовать"
+                    "будущее"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Zukunft»?",
                 "choices": [
-                    "новый",
+                    "выживать",
+                    "порядок",
                     "будущее",
-                    "наследовать",
                     "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "наследовать",
                     "выживать",
+                    "наследовать",
                     "править",
                     "новый"
                 ],
@@ -5424,42 +5428,42 @@
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "новый",
+                    "порядок",
                     "мудрость",
-                    "править",
-                    "наследовать"
+                    "ответственность",
+                    "выживать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ordnung»?",
                 "choices": [
-                    "выживать",
                     "ответственность",
-                    "править",
-                    "порядок"
+                    "выживать",
+                    "порядок",
+                    "новый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
-                    "порядок",
                     "мудрость",
-                    "наследовать",
-                    "ответственность"
+                    "будущее",
+                    "ответственность",
+                    "новый"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «neu»?",
                 "choices": [
-                    "ответственность",
-                    "новый",
+                    "будущее",
                     "мудрость",
-                    "порядок"
+                    "выживать",
+                    "новый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Эдмунда</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Эдмунда</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["обделённый", "зависть", "бастард", "амбиция"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["обделённый", "зависть", "амбиция", "бастард"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["природа", "зависть", "амбиция", "обделённый"], "correct_index": 2}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["зависть", "обделённый", "бастард", "внебрачный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["природа", "возвышаться", "месть", "внебрачный"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["зависть", "обделённый", "возвышаться", "амбиция"], "correct_index": 2}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["возвышаться", "природа", "обделённый", "внебрачный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "возвышаться"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["подделывать", "план", "интриговать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["обвинять", "подделывать", "интриговать", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обман", "обвинять", "план", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["план", "обман", "интриговать", "лгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["письмо", "манипулировать", "интриговать", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["письмо", "манипулировать", "лгать", "обман"], "correct_index": 0}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["подделывать", "лгать", "обвинять", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["интриговать", "план", "обман", "лгать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["торжествовать", "изгонять", "успех", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["изгонять", "торжествовать", "успех", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "изгонять", "успех", "вытеснять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["изгонять", "успех", "торжествовать", "награда"], "correct_index": 1}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["награда", "выигрывать", "торжествовать", "наследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["наследовать", "награда", "выигрывать", "победа"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["победа", "торжествовать", "наследовать", "вытеснять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["победа", "наследовать", "выигрывать", "награда"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "завоёвывать", "объединяться", "союз"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["объединяться", "власть", "союз", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["завоёвывать", "альянс", "власть", "завоевание"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["соблазнять", "завоёвывать", "объединяться", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "господствовать", "завоевание", "завоёвывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["союз", "завоевание", "завоёвывать", "альянс"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["завоевание", "соблазнять", "союз", "господствовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["альянс", "объединяться", "союз", "завоёвывать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["доносить", "ослеплять", "предавать", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["жестокость", "предавать", "доносить", "ослеплять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["беспощадный", "пытка", "жестокость", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["жестокость", "выдавать", "доносить", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["пытка", "жертвовать", "выдавать", "доносить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["жертвовать", "выдавать", "доносить", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["жертвовать", "доносить", "выдавать", "предавать"], "correct_index": 0}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["ослеплять", "жертвовать", "беспощадный", "доносить"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["играть", "любовная связь", "соперничество", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["любовная связь", "соперничество", "играть", "завлекать"], "correct_index": 1}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["завлекать", "играть", "соперничество", "похоть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["использовать", "соперничество", "любовная связь", "завлекать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["любовная связь", "похоть", "играть", "использовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["завлекать", "играть", "любовная связь", "использовать"], "correct_index": 3}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["играть", "жонглировать", "использовать", "соперничество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["интрига", "похоть", "соперничество", "использовать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["сожалеть", "дуэль", "падать", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["сожалеть", "падать", "дуэль", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["признаваться", "дуэль", "сожалеть", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["падать", "проигрывать", "дуэль", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["проигрывать", "поражение", "сожалеть", "дуэль"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["дуэль", "сожалеть", "признаваться", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["дуэль", "падать", "признаваться", "падение"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["дуэль", "падение", "проигрывать", "конец"], "correct_index": 3}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Bastard»?", "choices": ["зависть", "бастард", "амбиция", "обделённый"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Neid»?", "choices": ["зависть", "обделённый", "амбиция", "бастард"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ambition»?", "choices": ["зависть", "возвышаться", "амбиция", "природа"], "correct_index": 2}, {"question": "Что означает немецкое слово «benachteiligt»?", "choices": ["зависть", "возвышаться", "обделённый", "месть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "природа", "обделённый", "внебрачный"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufsteigen»?", "choices": ["природа", "возвышаться", "месть", "внебрачный"], "correct_index": 1}, {"question": "Что означает немецкое слово «unehelich»?", "choices": ["природа", "бастард", "зависть", "внебрачный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Natur»?", "choices": ["амбиция", "зависть", "природа", "внебрачный"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «fälschen»?", "choices": ["план", "подделывать", "интриговать", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «intrigieren»?", "choices": ["план", "интриговать", "подделывать", "обвинять"], "correct_index": 1}, {"question": "Что означает немецкое слово «beschuldigen»?", "choices": ["обман", "обвинять", "план", "манипулировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["интриговать", "подделывать", "манипулировать", "план"], "correct_index": 3}, {"question": "Что означает немецкое слово «manipulieren»?", "choices": ["манипулировать", "письмо", "подделывать", "обвинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Brief»?", "choices": ["манипулировать", "обман", "интриговать", "письмо"], "correct_index": 3}, {"question": "Что означает немецкое слово «lügen»?", "choices": ["обман", "подделывать", "письмо", "лгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["лгать", "план", "обман", "подделывать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "торжествовать", "наследовать", "успех"], "correct_index": 0}, {"question": "Что означает немецкое слово «triumphieren»?", "choices": ["наследовать", "изгонять", "торжествовать", "успех"], "correct_index": 2}, {"question": "Что означает немецкое слово «erben»?", "choices": ["наследовать", "награда", "торжествовать", "победа"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Erfolg»?", "choices": ["изгонять", "успех", "наследовать", "победа"], "correct_index": 1}, {"question": "Что означает немецкое слово «gewinnen»?", "choices": ["изгонять", "выигрывать", "торжествовать", "успех"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Belohnung»?", "choices": ["торжествовать", "выигрывать", "награда", "наследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verdrängen»?", "choices": ["наследовать", "вытеснять", "изгонять", "победа"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sieg»?", "choices": ["успех", "победа", "вытеснять", "наследовать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «verbünden»?", "choices": ["власть", "завоёвывать", "союз", "объединяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["союз", "власть", "объединяться", "завоёвывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["альянс", "объединяться", "завоёвывать", "завоевание"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["завоевание", "союз", "соблазнять", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["власть", "господствовать", "соблазнять", "альянс"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Eroberung»?", "choices": ["союз", "завоевание", "власть", "господствовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «beherrschen»?", "choices": ["альянс", "господствовать", "соблазнять", "объединяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Allianz»?", "choices": ["альянс", "завоёвывать", "соблазнять", "господствовать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «verraten»?", "choices": ["предавать", "жестокость", "доносить", "ослеплять"], "correct_index": 0}, {"question": "Что означает немецкое слово «blenden»?", "choices": ["доносить", "жестокость", "ослеплять", "предавать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["доносить", "жестокость", "выдавать", "жертвовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «denunzieren»?", "choices": ["пытка", "доносить", "выдавать", "предавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausliefern»?", "choices": ["беспощадный", "жертвовать", "жестокость", "выдавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["жестокость", "пытка", "беспощадный", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «opfern»?", "choices": ["пытка", "жертвовать", "предавать", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["жертвовать", "беспощадный", "жестокость", "ослеплять"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Liebschaft»?", "choices": ["завлекать", "соперничество", "играть", "любовная связь"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["играть", "завлекать", "любовная связь", "соперничество"], "correct_index": 3}, {"question": "Что означает немецкое слово «spielen»?", "choices": ["использовать", "играть", "любовная связь", "жонглировать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verlocken»?", "choices": ["соперничество", "похоть", "завлекать", "жонглировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["любовная связь", "завлекать", "похоть", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausnutzen»?", "choices": ["использовать", "жонглировать", "интрига", "играть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jonglieren»?", "choices": ["использовать", "похоть", "жонглировать", "интрига"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Affäre»?", "choices": ["соперничество", "интрига", "завлекать", "играть"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «das Duell»?", "choices": ["поражение", "дуэль", "сожалеть", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["сожалеть", "поражение", "падать", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["падение", "конец", "сожалеть", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["конец", "проигрывать", "поражение", "дуэль"], "correct_index": 2}, {"question": "Что означает немецкое слово «verlieren»?", "choices": ["падать", "признаваться", "конец", "проигрывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Untergang»?", "choices": ["проигрывать", "дуэль", "падать", "падение"], "correct_index": 3}, {"question": "Что означает немецкое слово «gestehen»?", "choices": ["дуэль", "падать", "признаваться", "проигрывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["конец", "падение", "поражение", "признаваться"], "correct_index": 0}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Незаконнорождённый</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,29 +433,29 @@
                         <div class="quiz-phase-container active" data-phase="throne">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Bastard»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Neid»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обделённый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                                         
@@ -465,27 +469,43 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Ambition»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">зависть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">амбиция</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обделённый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">природа</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «benachteiligt»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возвышаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">бастард</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                                         
@@ -493,8 +513,8 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
@@ -509,31 +529,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «aufsteigen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">зависть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обделённый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">возвышаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">амбиция</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
                                 <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «unehelich»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">возвышаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">природа</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">природа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бастард</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обделённый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">зависть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                                         
@@ -551,7 +555,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">природа</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">возвышаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">внебрачный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,13 +568,13 @@
                         <div class="quiz-phase-container" data-phase="goneril">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «fälschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                                         
@@ -580,17 +584,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «intrigieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обвинять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интриговать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -612,31 +616,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">манипулировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «manipulieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подделывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">обвинять</button>
                                         
@@ -644,33 +648,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">манипулировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">манипулировать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">лгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">интриговать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «lügen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подделывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">лгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подделывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обвинять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -680,13 +684,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">интриговать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">лгать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">лгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подделывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -699,33 +703,33 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «triumphieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -737,11 +741,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">успех</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -755,9 +759,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">успех</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -767,11 +771,27 @@
                                     <div class="quiz-question">Что означает немецкое слово «gewinnen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">награда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">успех</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">торжествовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">награда</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                                         
@@ -779,15 +799,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Belohnung»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">наследовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">награда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вытеснять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">победа</button>
                                         
@@ -795,33 +815,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «verdrängen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">торжествовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наследовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вытеснять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Sieg»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">победа</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">успех</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">победа</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вытеснять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">награда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследовать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -834,7 +838,7 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «verbünden»?</div>
                                     <div class="quiz-choices">
                                         
@@ -842,9 +846,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,11 +858,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">объединяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                                         
@@ -866,15 +870,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">альянс</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">завоевание</button>
                                         
@@ -882,33 +886,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">объединяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">завоевание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -922,25 +926,25 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">завоевание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">альянс</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «beherrschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">завоевание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">господствовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">объединяться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -952,11 +956,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">альянс</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">объединяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">господствовать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -969,107 +973,59 @@
                         <div class="quiz-phase-container" data-phase="hut">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доносить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жертвовать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «denunzieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выдавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">доносить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">доносить</button>
                                         
@@ -1081,17 +1037,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «ausliefern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выдавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">доносить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «opfern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жертвовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жертвовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1104,33 +1108,33 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Liebschaft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">любовная связь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">любовная связь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,93 +1144,93 @@
                                     <div class="quiz-question">Что означает немецкое слово «spielen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verlocken»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завлекать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жонглировать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">любовная связь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">завлекать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">играть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «ausnutzen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">завлекать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">играть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">любовная связь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">играть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">жонглировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">использовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «jonglieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">использовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жонглировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">использовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Affäre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завлекать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">играть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1243,29 +1247,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Duell»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1275,45 +1279,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">признаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">признаваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «verlieren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1323,11 +1327,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Untergang»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дуэль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
                                         
@@ -1345,23 +1349,23 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">признаваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">падение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проигрывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дуэль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">падение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">признаваться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2028,30 +2032,30 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "обделённый",
                     "зависть",
                     "бастард",
-                    "амбиция"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Neid»?",
-                "choices": [
-                    "обделённый",
-                    "зависть",
                     "амбиция",
-                    "бастард"
+                    "обделённый"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Neid»?",
+                "choices": [
+                    "зависть",
+                    "обделённый",
+                    "амбиция",
+                    "бастард"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "природа",
                     "зависть",
+                    "возвышаться",
                     "амбиция",
-                    "обделённый"
+                    "природа"
                 ],
                 "correctIndex": 2
             },
@@ -2059,38 +2063,38 @@
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
                     "зависть",
+                    "возвышаться",
                     "обделённый",
-                    "бастард",
-                    "внебрачный"
+                    "месть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "месть",
+                    "природа",
+                    "обделённый",
+                    "внебрачный"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
                     "природа",
                     "возвышаться",
                     "месть",
                     "внебрачный"
                 ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «aufsteigen»?",
-                "choices": [
-                    "зависть",
-                    "обделённый",
-                    "возвышаться",
-                    "амбиция"
-                ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
-                    "возвышаться",
                     "природа",
-                    "обделённый",
+                    "бастард",
+                    "зависть",
                     "внебрачный"
                 ],
                 "correctIndex": 3
@@ -2101,7 +2105,7 @@
                     "амбиция",
                     "зависть",
                     "природа",
-                    "возвышаться"
+                    "внебрачный"
                 ],
                 "correctIndex": 2
             }
@@ -2592,22 +2596,22 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
-                    "подделывать",
                     "план",
+                    "подделывать",
                     "интриговать",
                     "обвинять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «intrigieren»?",
                 "choices": [
-                    "обвинять",
-                    "подделывать",
+                    "план",
                     "интриговать",
-                    "план"
+                    "подделывать",
+                    "обвинять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beschuldigen»?",
@@ -2622,50 +2626,50 @@
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "план",
-                    "обман",
                     "интриговать",
-                    "лгать"
+                    "подделывать",
+                    "манипулировать",
+                    "план"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «manipulieren»?",
                 "choices": [
-                    "письмо",
                     "манипулировать",
-                    "интриговать",
+                    "письмо",
+                    "подделывать",
                     "обвинять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Brief»?",
-                "choices": [
-                    "письмо",
-                    "манипулировать",
-                    "лгать",
-                    "обман"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «der Brief»?",
+                "choices": [
+                    "манипулировать",
+                    "обман",
+                    "интриговать",
+                    "письмо"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
+                    "обман",
                     "подделывать",
-                    "лгать",
-                    "обвинять",
-                    "план"
+                    "письмо",
+                    "лгать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "интриговать",
+                    "лгать",
                     "план",
                     "обман",
-                    "лгать"
+                    "подделывать"
                 ],
                 "correctIndex": 2
             }
@@ -3139,30 +3143,30 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "торжествовать",
                     "изгонять",
-                    "успех",
-                    "наследовать"
+                    "торжествовать",
+                    "наследовать",
+                    "успех"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
+                    "наследовать",
                     "изгонять",
                     "торжествовать",
-                    "успех",
-                    "наследовать"
+                    "успех"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
                     "наследовать",
-                    "изгонять",
-                    "успех",
-                    "вытеснять"
+                    "награда",
+                    "торжествовать",
+                    "победа"
                 ],
                 "correctIndex": 0
             },
@@ -3171,50 +3175,50 @@
                 "choices": [
                     "изгонять",
                     "успех",
-                    "торжествовать",
-                    "награда"
+                    "наследовать",
+                    "победа"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "награда",
+                    "изгонять",
                     "выигрывать",
                     "торжествовать",
-                    "наследовать"
+                    "успех"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
-                    "наследовать",
-                    "награда",
+                    "торжествовать",
                     "выигрывать",
+                    "награда",
+                    "наследовать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «verdrängen»?",
+                "choices": [
+                    "наследовать",
+                    "вытеснять",
+                    "изгонять",
                     "победа"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verdrängen»?",
-                "choices": [
-                    "победа",
-                    "торжествовать",
-                    "наследовать",
-                    "вытеснять"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
+                    "успех",
                     "победа",
-                    "наследовать",
-                    "выигрывать",
-                    "награда"
+                    "вытеснять",
+                    "наследовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3703,17 +3707,17 @@
                 "choices": [
                     "власть",
                     "завоёвывать",
-                    "объединяться",
-                    "союз"
+                    "союз",
+                    "объединяться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "объединяться",
-                    "власть",
                     "союз",
+                    "власть",
+                    "объединяться",
                     "завоёвывать"
                 ],
                 "correctIndex": 1
@@ -3721,60 +3725,60 @@
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "завоёвывать",
                     "альянс",
-                    "власть",
+                    "объединяться",
+                    "завоёвывать",
                     "завоевание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
+                    "завоевание",
+                    "союз",
                     "соблазнять",
-                    "завоёвывать",
-                    "объединяться",
-                    "союз"
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "соблазнять",
+                    "власть",
                     "господствовать",
-                    "завоевание",
-                    "завоёвывать"
+                    "соблазнять",
+                    "альянс"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
                     "союз",
                     "завоевание",
-                    "завоёвывать",
-                    "альянс"
+                    "власть",
+                    "господствовать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
-                    "завоевание",
+                    "альянс",
+                    "господствовать",
                     "соблазнять",
-                    "союз",
-                    "господствовать"
+                    "объединяться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
                     "альянс",
-                    "объединяться",
-                    "союз",
-                    "завоёвывать"
+                    "завоёвывать",
+                    "соблазнять",
+                    "господствовать"
                 ],
                 "correctIndex": 0
             }
@@ -4299,82 +4303,82 @@
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "доносить",
-                    "ослеплять",
                     "предавать",
-                    "жестокость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «blenden»?",
-                "choices": [
                     "жестокость",
-                    "предавать",
                     "доносить",
                     "ослеплять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Grausamkeit»?",
-                "choices": [
-                    "беспощадный",
-                    "пытка",
-                    "жестокость",
-                    "ослеплять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «denunzieren»?",
-                "choices": [
-                    "жестокость",
-                    "выдавать",
-                    "доносить",
-                    "ослеплять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "пытка",
-                    "жертвовать",
-                    "выдавать",
-                    "доносить"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Folter»?",
-                "choices": [
-                    "жертвовать",
-                    "выдавать",
-                    "доносить",
-                    "пытка"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «opfern»?",
-                "choices": [
-                    "жертвовать",
-                    "доносить",
-                    "выдавать",
-                    "предавать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
+                    "доносить",
+                    "жестокость",
                     "ослеплять",
-                    "жертвовать",
-                    "беспощадный",
-                    "доносить"
+                    "предавать"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Grausamkeit»?",
+                "choices": [
+                    "доносить",
+                    "жестокость",
+                    "выдавать",
+                    "жертвовать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «denunzieren»?",
+                "choices": [
+                    "пытка",
+                    "доносить",
+                    "выдавать",
+                    "предавать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "беспощадный",
+                    "жертвовать",
+                    "жестокость",
+                    "выдавать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Folter»?",
+                "choices": [
+                    "жестокость",
+                    "пытка",
+                    "беспощадный",
+                    "ослеплять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «opfern»?",
+                "choices": [
+                    "пытка",
+                    "жертвовать",
+                    "предавать",
+                    "жестокость"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "жертвовать",
+                    "беспощадный",
+                    "жестокость",
+                    "ослеплять"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4863,82 +4867,82 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "играть",
-                    "любовная связь",
+                    "завлекать",
                     "соперничество",
-                    "завлекать"
+                    "играть",
+                    "любовная связь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "любовная связь",
-                    "соперничество",
                     "играть",
-                    "завлекать"
+                    "завлекать",
+                    "любовная связь",
+                    "соперничество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
-                    "завлекать",
+                    "использовать",
                     "играть",
-                    "соперничество",
-                    "похоть"
+                    "любовная связь",
+                    "жонглировать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
-                    "использовать",
                     "соперничество",
-                    "любовная связь",
-                    "завлекать"
+                    "похоть",
+                    "завлекать",
+                    "жонглировать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
                     "любовная связь",
+                    "завлекать",
                     "похоть",
-                    "играть",
-                    "использовать"
+                    "интрига"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "завлекать",
-                    "играть",
-                    "любовная связь",
-                    "использовать"
+                    "использовать",
+                    "жонглировать",
+                    "интрига",
+                    "играть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
-                    "играть",
-                    "жонглировать",
                     "использовать",
-                    "соперничество"
+                    "похоть",
+                    "жонглировать",
+                    "интрига"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
-                    "интрига",
-                    "похоть",
                     "соперничество",
-                    "использовать"
+                    "интрига",
+                    "завлекать",
+                    "играть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5413,10 +5417,10 @@
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "сожалеть",
+                    "поражение",
                     "дуэль",
-                    "падать",
-                    "поражение"
+                    "сожалеть",
+                    "падать"
                 ],
                 "correctIndex": 1
             },
@@ -5424,48 +5428,48 @@
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
                     "сожалеть",
+                    "поражение",
                     "падать",
-                    "дуэль",
-                    "поражение"
+                    "дуэль"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "признаваться",
-                    "дуэль",
+                    "падение",
+                    "конец",
                     "сожалеть",
-                    "падение"
+                    "проигрывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "падать",
+                    "конец",
                     "проигрывать",
-                    "дуэль",
-                    "поражение"
+                    "поражение",
+                    "дуэль"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "проигрывать",
-                    "поражение",
-                    "сожалеть",
-                    "дуэль"
+                    "падать",
+                    "признаваться",
+                    "конец",
+                    "проигрывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
+                    "проигрывать",
                     "дуэль",
-                    "сожалеть",
-                    "признаваться",
+                    "падать",
                     "падение"
                 ],
                 "correctIndex": 3
@@ -5476,19 +5480,19 @@
                     "дуэль",
                     "падать",
                     "признаваться",
-                    "падение"
+                    "проигрывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "дуэль",
+                    "конец",
                     "падение",
-                    "проигрывать",
-                    "конец"
+                    "поражение",
+                    "признаваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Шута</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Шута</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "шутить", "печаль", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["печаль", "шут", "шутить", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["шут", "печаль", "умный", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["шут", "скучать", "умный", "шутить"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["шут", "мудрость", "шутить", "забава"], "correct_index": 3}, {"question": "Что означает немецкое слово «klug»?", "choices": ["умный", "печаль", "шутить", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["скучать", "шут", "печаль", "шутить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["остроумие", "умный", "шутить", "скучать"], "correct_index": 0}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["горький", "правда", "предупреждение", "шутка"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["предупреждение", "горький", "шутка", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "предупреждение", "правда", "дразнить"], "correct_index": 1}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["горький", "правда", "дразнить", "раскрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["дразнить", "раскрывать", "насмехаться", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «necken»?", "choices": ["правда", "горький", "шутка", "дразнить"], "correct_index": 3}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["шутка", "раскрывать", "предупреждение", "насмехаться"], "correct_index": 1}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["пророчество", "загадка", "предсказывать", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["предсказывать", "загадка", "предчувствие", "пророчество"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["знамение", "загадка", "предчувствие", "предчувствовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["пророчество", "толковать", "загадка", "предсказывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["толковать", "предчувствовать", "знамение", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["толковать", "пророчество", "предчувствовать", "предчувствие"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["пророчество", "предчувствовать", "загадочный", "знамение"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "предчувствие", "пророчество", "загадка"], "correct_index": 0}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["безумие", "дружба", "сопровождать", "мёрзнуть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["мёрзнуть", "сопровождать", "безумие", "дружба"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["петь", "безумие", "дружба", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "верный", "безумие", "дрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «singen»?", "choices": ["безумие", "дрожать", "петь", "дружба"], "correct_index": 2}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["мёрзнуть", "верный", "дружба", "дрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["сопровождать", "петь", "дружба", "верный"], "correct_index": 3}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["песня", "ирония", "напевать", "утешение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["утешение", "напевать", "ирония", "песня"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["утешение", "рифма", "ирония", "мелодия"], "correct_index": 2}, {"question": "Что означает немецкое слово «summen»?", "choices": ["ирония", "напевать", "утешение", "звучать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["напевать", "мелодия", "свистеть", "звучать"], "correct_index": 1}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["напевать", "песня", "утешение", "свистеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["рифма", "ирония", "песня", "звучать"], "correct_index": 0}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["свистеть", "утешение", "ирония", "звучать"], "correct_index": 3}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["бренность", "философия", "размышлять", "судьба"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["бренность", "судьба", "философия", "размышлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["преходящий", "размышлять", "философия", "бренность"], "correct_index": 3}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["познавать", "бренность", "судьба", "размышлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["познавать", "судьба", "бренность", "философия"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["бренность", "судьба", "смысл", "размышлять"], "correct_index": 2}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["бренность", "размышлять", "преходящий", "судьба"], "correct_index": 2}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "тайна", "пустота", "растворяться"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "тайна", "исчезать", "пустота"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["туман", "бесследно", "пустота", "растворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["загадочный", "растворяться", "бесследно", "уходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["бесследно", "пустота", "загадочный", "туман"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["пустота", "бесследно", "уходить", "туман"], "correct_index": 3}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["загадочный", "уходить", "растворяться", "бесследно"], "correct_index": 0}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["пустота", "уходить", "тайна", "исчезать"], "correct_index": 1}]}'>
+                    <div class="quiz-section" data-quiz-map='{"jester": [{"question": "Что означает немецкое слово «der Narr»?", "choices": ["печаль", "шутить", "мудрость", "шут"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["печаль", "шут", "шутить", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["шутить", "умный", "забава", "печаль"], "correct_index": 3}, {"question": "Что означает немецкое слово «scherzen»?", "choices": ["мудрость", "скучать", "шутить", "забава"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Spaß»?", "choices": ["шутить", "скучать", "мудрость", "забава"], "correct_index": 3}, {"question": "Что означает немецкое слово «klug»?", "choices": ["скучать", "умный", "остроумие", "забава"], "correct_index": 1}, {"question": "Что означает немецкое слово «vermissen»?", "choices": ["умный", "скучать", "забава", "остроумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Witz»?", "choices": ["скучать", "мудрость", "шутить", "остроумие"], "correct_index": 3}], "bitter_truths": [{"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "горький", "шутка", "предупреждение"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Scherz»?", "choices": ["горький", "предупреждение", "правда", "шутка"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Warnung»?", "choices": ["горький", "насмехаться", "предупреждение", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «bitter»?", "choices": ["шутка", "раскрывать", "правда", "горький"], "correct_index": 3}, {"question": "Что означает немецкое слово «spotten»?", "choices": ["насмехаться", "шутка", "горький", "раскрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «necken»?", "choices": ["насмехаться", "дразнить", "раскрывать", "шутка"], "correct_index": 1}, {"question": "Что означает немецкое слово «enthüllen»?", "choices": ["горький", "предупреждение", "насмехаться", "раскрывать"], "correct_index": 3}], "prophecies": [{"question": "Что означает немецкое слово «die Prophezeiung»?", "choices": ["предсказывать", "предчувствие", "загадка", "пророчество"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Rätsel»?", "choices": ["пророчество", "загадка", "предчувствие", "предсказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vorahnung»?", "choices": ["толковать", "знамение", "пророчество", "предчувствие"], "correct_index": 3}, {"question": "Что означает немецкое слово «vorhersagen»?", "choices": ["предсказывать", "загадка", "предчувствовать", "предчувствие"], "correct_index": 0}, {"question": "Что означает немецкое слово «deuten»?", "choices": ["предсказывать", "толковать", "предчувствовать", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ahnen»?", "choices": ["предчувствовать", "знамение", "предсказывать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Omen»?", "choices": ["знамение", "предсказывать", "пророчество", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["толковать", "загадка", "загадочный", "предчувствовать"], "correct_index": 2}], "mad_companion": [{"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["дружба", "сопровождать", "безумие", "мёрзнуть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Freundschaft»?", "choices": ["сопровождать", "мёрзнуть", "дружба", "безумие"], "correct_index": 2}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["дрожать", "сопровождать", "дружба", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["дружба", "мёрзнуть", "петь", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «singen»?", "choices": ["сопровождать", "петь", "мёрзнуть", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «zittern»?", "choices": ["сопровождать", "петь", "верный", "дрожать"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["безумие", "верный", "мёрзнуть", "дружба"], "correct_index": 1}], "songs": [{"question": "Что означает немецкое слово «das Lied»?", "choices": ["напевать", "песня", "утешение", "ирония"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Trost»?", "choices": ["ирония", "утешение", "песня", "напевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ironie»?", "choices": ["рифма", "мелодия", "ирония", "звучать"], "correct_index": 2}, {"question": "Что означает немецкое слово «summen»?", "choices": ["рифма", "напевать", "мелодия", "свистеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Melodie»?", "choices": ["утешение", "звучать", "мелодия", "рифма"], "correct_index": 2}, {"question": "Что означает немецкое слово «pfeifen»?", "choices": ["свистеть", "утешение", "песня", "напевать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Reim»?", "choices": ["напевать", "свистеть", "рифма", "ирония"], "correct_index": 2}, {"question": "Что означает немецкое слово «klingen»?", "choices": ["утешение", "мелодия", "звучать", "песня"], "correct_index": 2}], "wisdom": [{"question": "Что означает немецкое слово «die Philosophie»?", "choices": ["размышлять", "бренность", "философия", "судьба"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Schicksal»?", "choices": ["размышлять", "судьба", "бренность", "философия"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Vergänglichkeit»?", "choices": ["философия", "бренность", "размышлять", "познавать"], "correct_index": 1}, {"question": "Что означает немецкое слово «nachdenken»?", "choices": ["размышлять", "судьба", "познавать", "смысл"], "correct_index": 0}, {"question": "Что означает немецкое слово «erkennen»?", "choices": ["бренность", "судьба", "философия", "познавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Sinn»?", "choices": ["судьба", "смысл", "познавать", "философия"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergänglich»?", "choices": ["преходящий", "судьба", "бренность", "размышлять"], "correct_index": 0}], "vanishing": [{"question": "Что означает немецкое слово «verschwinden»?", "choices": ["исчезать", "пустота", "растворяться", "тайна"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Geheimnis»?", "choices": ["растворяться", "исчезать", "пустота", "тайна"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leere»?", "choices": ["исчезать", "уходить", "бесследно", "пустота"], "correct_index": 3}, {"question": "Что означает немецкое слово «sich auflösen»?", "choices": ["бесследно", "пустота", "туман", "растворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «spurlos»?", "choices": ["туман", "бесследно", "уходить", "загадочный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Nebel»?", "choices": ["туман", "растворяться", "исчезать", "загадочный"], "correct_index": 0}, {"question": "Что означает немецкое слово «rätselhaft»?", "choices": ["растворяться", "пустота", "уходить", "загадочный"], "correct_index": 3}, {"question": "Что означает немецкое слово «fortgehen»?", "choices": ["уходить", "бесследно", "тайна", "растворяться"], "correct_index": 0}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Королевский шут</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,17 +433,17 @@
                         <div class="quiz-phase-container active" data-phase="jester">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">печаль</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">шутить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -461,45 +465,29 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">печаль</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «scherzen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                                         
@@ -509,49 +497,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «klug»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Spaß»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шутить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">печаль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «klug»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">печаль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">остроумие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шутить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">забава</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «vermissen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">забава</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Witz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">остроумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">скучать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">умный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">шутить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">скучать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">остроумие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,88 +568,8 @@
                         <div class="quiz-phase-container" data-phase="bitter_truths">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">предупреждение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">горький</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дразнить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дразнить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «necken»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
@@ -654,23 +578,103 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">шутка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дразнить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предупреждение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Scherz»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Warnung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «bitter»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">шутка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">раскрывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">горький</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «spotten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шутка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «necken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">дразнить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раскрывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шутка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «enthüllen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">горький</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раскрывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -683,17 +687,17 @@
                         <div class="quiz-phase-container" data-phase="prophecies">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Prophezeiung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -703,43 +707,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Rätsel»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пророчество</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
-                                    <div class="quiz-choices">
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">загадка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствие</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">предсказывать</button>
                                         
@@ -747,29 +719,29 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vorahnung»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">знамение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vorhersagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пророчество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                                         
@@ -779,33 +751,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «deuten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пророчество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предсказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">толковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предчувствовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">знамение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ahnen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предчувствовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предчувствие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">знамение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предсказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «das Omen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">знамение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предсказывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">пророчество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">загадка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">толковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">загадка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предчувствовать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -818,15 +822,15 @@
                         <div class="quiz-phase-container" data-phase="mad_companion">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дружба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                                         
@@ -834,31 +838,47 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Freundschaft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">петь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дрожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">дружба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                                         
@@ -866,33 +886,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «singen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">петь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -902,11 +906,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «zittern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">дрожать</button>
                                         
@@ -914,17 +918,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">петь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">дружба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">дружба</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -937,33 +941,33 @@
                         <div class="quiz-phase-container" data-phase="songs">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Lied»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">песня</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">напевать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">утешение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Trost»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -973,13 +977,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Ironie»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">рифма</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мелодия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -989,43 +993,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «summen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ирония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">напевать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">свистеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">песня</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">свистеть</button>
                                         
@@ -1033,33 +1005,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Melodie»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">рифма</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ирония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">звучать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мелодия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">рифма</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «pfeifen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">свистеть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">утешение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ирония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">песня</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">звучать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">напевать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Reim»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">напевать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">свистеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рифма</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ирония</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «klingen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мелодия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">звучать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">песня</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1072,15 +1076,15 @@
                         <div class="quiz-phase-container" data-phase="wisdom">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Philosophie»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">философия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
                                         
@@ -1092,55 +1096,7 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Schicksal»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бренность</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">судьба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">познавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                                         
@@ -1152,33 +1108,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Vergänglichkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">философия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бренность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «nachdenken»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">размышлять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смысл</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смысл</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">философия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">познавать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Sinn»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">судьба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смысл</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">познавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">философия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «vergänglich»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бренность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">преходящий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">размышлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">судьба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">преходящий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бренность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">судьба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">размышлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1197,25 +1201,41 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «das Geheimnis»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">тайна</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">исчезать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайна</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пустота</button>
                                         
@@ -1223,15 +1243,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Leere»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пустота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">туман</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                                         
@@ -1239,81 +1259,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «sich auflösen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">бесследно</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">уходить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «spurlos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бесследно</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">загадочный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">туман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Nebel»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">туман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">растворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исчезать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «rätselhaft»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">загадочный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">растворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пустота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">растворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">уходить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бесследно</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">загадочный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «fortgehen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пустота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">уходить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">уходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бесследно</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">тайна</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">исчезать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">растворяться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2002,12 +2006,12 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "шут",
-                    "шутить",
                     "печаль",
-                    "мудрость"
+                    "шутить",
+                    "мудрость",
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
@@ -2022,29 +2026,29 @@
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "шут",
-                    "печаль",
+                    "шутить",
                     "умный",
-                    "мудрость"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «scherzen»?",
-                "choices": [
-                    "шут",
-                    "скучать",
-                    "умный",
-                    "шутить"
+                    "забава",
+                    "печаль"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «scherzen»?",
+                "choices": [
+                    "мудрость",
+                    "скучать",
+                    "шутить",
+                    "забава"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "шут",
-                    "мудрость",
                     "шутить",
+                    "скучать",
+                    "мудрость",
                     "забава"
                 ],
                 "correctIndex": 3
@@ -2052,32 +2056,32 @@
             {
                 "question": "Что означает немецкое слово «klug»?",
                 "choices": [
+                    "скучать",
                     "умный",
-                    "печаль",
-                    "шутить",
-                    "мудрость"
+                    "остроумие",
+                    "забава"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
+                    "умный",
                     "скучать",
-                    "шут",
-                    "печаль",
-                    "шутить"
+                    "забава",
+                    "остроумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Witz»?",
                 "choices": [
-                    "остроумие",
-                    "умный",
+                    "скучать",
+                    "мудрость",
                     "шутить",
-                    "скучать"
+                    "остроумие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2513,72 +2517,72 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "горький",
                     "правда",
-                    "предупреждение",
-                    "шутка"
+                    "горький",
+                    "шутка",
+                    "предупреждение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
-                    "предупреждение",
                     "горький",
-                    "шутка",
-                    "правда"
+                    "предупреждение",
+                    "правда",
+                    "шутка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Warnung»?",
                 "choices": [
                     "горький",
-                    "предупреждение",
-                    "правда",
-                    "дразнить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «bitter»?",
-                "choices": [
-                    "горький",
-                    "правда",
-                    "дразнить",
-                    "раскрывать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «spotten»?",
-                "choices": [
-                    "дразнить",
-                    "раскрывать",
                     "насмехаться",
+                    "предупреждение",
                     "правда"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «necken»?",
+                "question": "Что означает немецкое слово «bitter»?",
                 "choices": [
-                    "правда",
-                    "горький",
                     "шутка",
-                    "дразнить"
+                    "раскрывать",
+                    "правда",
+                    "горький"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «enthüllen»?",
+                "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
+                    "насмехаться",
                     "шутка",
+                    "горький",
+                    "раскрывать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «necken»?",
+                "choices": [
+                    "насмехаться",
+                    "дразнить",
                     "раскрывать",
-                    "предупреждение",
-                    "насмехаться"
+                    "шутка"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "горький",
+                    "предупреждение",
+                    "насмехаться",
+                    "раскрывать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3050,82 +3054,82 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "пророчество",
-                    "загадка",
                     "предсказывать",
-                    "предчувствие"
+                    "предчувствие",
+                    "загадка",
+                    "пророчество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Rätsel»?",
                 "choices": [
-                    "предсказывать",
+                    "пророчество",
                     "загадка",
                     "предчувствие",
-                    "пророчество"
+                    "предсказывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "знамение",
-                    "загадка",
-                    "предчувствие",
-                    "предчувствовать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «vorhersagen»?",
-                "choices": [
-                    "пророчество",
                     "толковать",
-                    "загадка",
-                    "предсказывать"
+                    "знамение",
+                    "пророчество",
+                    "предчувствие"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «vorhersagen»?",
+                "choices": [
+                    "предсказывать",
+                    "загадка",
+                    "предчувствовать",
+                    "предчувствие"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «deuten»?",
                 "choices": [
+                    "предсказывать",
                     "толковать",
                     "предчувствовать",
+                    "загадочный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ahnen»?",
+                "choices": [
+                    "предчувствовать",
                     "знамение",
+                    "предсказывать",
                     "загадочный"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «ahnen»?",
-                "choices": [
-                    "толковать",
-                    "пророчество",
-                    "предчувствовать",
-                    "предчувствие"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «das Omen»?",
                 "choices": [
+                    "знамение",
+                    "предсказывать",
                     "пророчество",
-                    "предчувствовать",
-                    "загадочный",
-                    "знамение"
+                    "загадочный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
+                    "толковать",
+                    "загадка",
                     "загадочный",
-                    "предчувствие",
-                    "пророчество",
-                    "загадка"
+                    "предчувствовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3575,59 +3579,59 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "безумие",
                     "дружба",
                     "сопровождать",
+                    "безумие",
                     "мёрзнуть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Freundschaft»?",
-                "choices": [
-                    "мёрзнуть",
-                    "сопровождать",
-                    "безумие",
-                    "дружба"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «begleiten»?",
-                "choices": [
-                    "петь",
-                    "безумие",
-                    "дружба",
-                    "сопровождать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «frieren»?",
-                "choices": [
-                    "мёрзнуть",
-                    "верный",
-                    "безумие",
-                    "дрожать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «singen»?",
-                "choices": [
-                    "безумие",
-                    "дрожать",
-                    "петь",
-                    "дружба"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Freundschaft»?",
+                "choices": [
+                    "сопровождать",
+                    "мёрзнуть",
+                    "дружба",
+                    "безумие"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «begleiten»?",
+                "choices": [
+                    "дрожать",
+                    "сопровождать",
+                    "дружба",
+                    "верный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «frieren»?",
+                "choices": [
+                    "дружба",
+                    "мёрзнуть",
+                    "петь",
+                    "сопровождать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «singen»?",
+                "choices": [
+                    "сопровождать",
+                    "петь",
+                    "мёрзнуть",
+                    "безумие"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "мёрзнуть",
+                    "сопровождать",
+                    "петь",
                     "верный",
-                    "дружба",
                     "дрожать"
                 ],
                 "correctIndex": 3
@@ -3635,12 +3639,12 @@
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "сопровождать",
-                    "петь",
-                    "дружба",
-                    "верный"
+                    "безумие",
+                    "верный",
+                    "мёрзнуть",
+                    "дружба"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4104,82 +4108,82 @@
             {
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
-                    "песня",
-                    "ирония",
                     "напевать",
-                    "утешение"
+                    "песня",
+                    "утешение",
+                    "ирония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
-                    "утешение",
-                    "напевать",
                     "ирония",
-                    "песня"
+                    "утешение",
+                    "песня",
+                    "напевать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
-                    "утешение",
                     "рифма",
+                    "мелодия",
                     "ирония",
-                    "мелодия"
+                    "звучать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
-                    "ирония",
+                    "рифма",
                     "напевать",
-                    "утешение",
-                    "звучать"
+                    "мелодия",
+                    "свистеть"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
-                    "напевать",
+                    "утешение",
+                    "звучать",
                     "мелодия",
-                    "свистеть",
-                    "звучать"
+                    "рифма"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «pfeifen»?",
                 "choices": [
-                    "напевать",
-                    "песня",
+                    "свистеть",
                     "утешение",
-                    "свистеть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Reim»?",
-                "choices": [
-                    "рифма",
-                    "ирония",
                     "песня",
-                    "звучать"
+                    "напевать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «der Reim»?",
+                "choices": [
+                    "напевать",
+                    "свистеть",
+                    "рифма",
+                    "ирония"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «klingen»?",
                 "choices": [
-                    "свистеть",
                     "утешение",
-                    "ирония",
-                    "звучать"
+                    "мелодия",
+                    "звучать",
+                    "песня"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4609,72 +4613,72 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
+                    "размышлять",
                     "бренность",
                     "философия",
-                    "размышлять",
                     "судьба"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
-                    "бренность",
+                    "размышлять",
                     "судьба",
-                    "философия",
-                    "размышлять"
+                    "бренность",
+                    "философия"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Vergänglichkeit»?",
                 "choices": [
-                    "преходящий",
-                    "размышлять",
                     "философия",
-                    "бренность"
+                    "бренность",
+                    "размышлять",
+                    "познавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "познавать",
-                    "бренность",
+                    "размышлять",
                     "судьба",
-                    "размышлять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
                     "познавать",
-                    "судьба",
-                    "бренность",
-                    "философия"
+                    "смысл"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «der Sinn»?",
+                "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
                     "бренность",
                     "судьба",
-                    "смысл",
-                    "размышлять"
+                    "философия",
+                    "познавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Sinn»?",
+                "choices": [
+                    "судьба",
+                    "смысл",
+                    "познавать",
+                    "философия"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
-                    "бренность",
-                    "размышлять",
                     "преходящий",
-                    "судьба"
+                    "судьба",
+                    "бренность",
+                    "размышлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5142,9 +5146,9 @@
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
                     "исчезать",
-                    "тайна",
                     "пустота",
-                    "растворяться"
+                    "растворяться",
+                    "тайна"
                 ],
                 "correctIndex": 0
             },
@@ -5152,71 +5156,71 @@
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
                     "растворяться",
-                    "тайна",
                     "исчезать",
-                    "пустота"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Leere»?",
-                "choices": [
-                    "туман",
-                    "бесследно",
                     "пустота",
-                    "растворяться"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «sich auflösen»?",
-                "choices": [
-                    "загадочный",
-                    "растворяться",
-                    "бесследно",
-                    "уходить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «spurlos»?",
-                "choices": [
-                    "бесследно",
-                    "пустота",
-                    "загадочный",
-                    "туман"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Nebel»?",
-                "choices": [
-                    "пустота",
-                    "бесследно",
-                    "уходить",
-                    "туман"
+                    "тайна"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «rätselhaft»?",
+                "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
-                    "загадочный",
+                    "исчезать",
                     "уходить",
+                    "бесследно",
+                    "пустота"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «sich auflösen»?",
+                "choices": [
+                    "бесследно",
+                    "пустота",
+                    "туман",
+                    "растворяться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «spurlos»?",
+                "choices": [
+                    "туман",
+                    "бесследно",
+                    "уходить",
+                    "загадочный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Nebel»?",
+                "choices": [
+                    "туман",
                     "растворяться",
-                    "бесследно"
+                    "исчезать",
+                    "загадочный"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «fortgehen»?",
+                "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
+                    "растворяться",
                     "пустота",
                     "уходить",
-                    "тайна",
-                    "исчезать"
+                    "загадочный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «fortgehen»?",
+                "choices": [
+                    "уходить",
+                    "бесследно",
+                    "тайна",
+                    "растворяться"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Глостера</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Глостера</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["доверять", "знать", "граф", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "доверять", "знать", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["знать", "честь", "долг", "доверять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["граф", "честь", "знать", "уважать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["уважать", "праведный", "честь", "доверять"], "correct_index": 2}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["праведный", "долг", "честь", "доверять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["граф", "долг", "уважать", "честь"], "correct_index": 1}, {"question": "Что означает немецкое слово «achten»?", "choices": ["доверять", "уважать", "служить", "долг"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обманывать", "письмо", "верить", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["обман", "верить", "письмо", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "верить", "простодушный", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["простодушный", "ловушка", "письмо", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["письмо", "простодушный", "верить", "ловушка"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["простодушный", "подозревать", "обман", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["письмо", "обманывать", "верить", "легковерный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["верить", "обман", "ловушка", "обманывать"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["проклинать", "заблуждение", "изгонять", "сожалеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "изгонять", "заблуждение", "проклинать"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["слепой", "изгонять", "сожалеть", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["сожалеть", "заблуждение", "гнать", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «blind»?", "choices": ["проклинать", "заблуждение", "гнать", "слепой"], "correct_index": 3}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["сожалеть", "несправедливость", "гнать", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["изгонять", "проклинать", "сожалеть", "несправедливость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["сострадание", "помогать", "рисковать", "опасность"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "сострадание", "опасность", "рисковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["опасность", "сострадание", "рисковать", "измена"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["рисковать", "защищать", "сострадание", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["защищать", "рисковать", "тайно", "сострадание"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["защищать", "сострадание", "помогать", "тайно"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["измена", "помогать", "сострадание", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["опасность", "тайно", "осмеливаться", "помогать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["темнота", "ослеплять", "пытка", "боль"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["пытка", "ослеплять", "боль", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "ослеплять", "кричать", "темнота"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["слепнуть", "боль", "темнота", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["боль", "слепнуть", "кричать", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["темнота", "слепнуть", "ослеплять", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["ослеплять", "слепнуть", "темнота", "месть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "обман", "пропасть", "прыгать"], "correct_index": 0}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "пропасть", "прыгать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["отчаяние", "обман", "избавлять", "прыгать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["избавлять", "отчаяние", "прыгать", "пропасть"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "прыгать", "пропасть", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["сдаваться", "обман", "прыгать", "безнадёжность"], "correct_index": 3}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["обман", "безнадёжность", "избавлять", "падать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["избавлять", "сдаваться", "безнадёжность", "обман"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "прощать", "умирать", "осознание"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["осознание", "прощать", "узнавать", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "прощать", "раскаяние", "обнимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["раскаяние", "осознание", "примирение", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["осознание", "сердце", "раскаяние", "примирение"], "correct_index": 2}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["прощать", "обнимать", "умирать", "примирение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["примирение", "сердце", "обнимать", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["обнимать", "раскаяние", "сердце", "прощать"], "correct_index": 2}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Adel»?", "choices": ["служить", "знать", "доверять", "граф"], "correct_index": 1}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["граф", "знать", "доверять", "служить"], "correct_index": 3}, {"question": "Что означает немецкое слово «vertrauen»?", "choices": ["знать", "доверять", "служить", "долг"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Graf»?", "choices": ["доверять", "граф", "служить", "праведный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ehre»?", "choices": ["праведный", "честь", "доверять", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «rechtschaffen»?", "choices": ["граф", "служить", "праведный", "долг"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Pflicht»?", "choices": ["долг", "уважать", "праведный", "знать"], "correct_index": 0}, {"question": "Что означает немецкое слово «achten»?", "choices": ["долг", "служить", "честь", "уважать"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «der Brief»?", "choices": ["обманывать", "обман", "письмо", "верить"], "correct_index": 2}, {"question": "Что означает немецкое слово «glauben»?", "choices": ["верить", "обман", "обманывать", "письмо"], "correct_index": 0}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["обманывать", "подозревать", "письмо", "ловушка"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Betrug»?", "choices": ["обман", "легковерный", "подозревать", "обманывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «arglos»?", "choices": ["обманывать", "простодушный", "легковерный", "обман"], "correct_index": 1}, {"question": "Что означает немецкое слово «verdächtigen»?", "choices": ["подозревать", "обман", "ловушка", "легковерный"], "correct_index": 0}, {"question": "Что означает немецкое слово «leichtgläubig»?", "choices": ["письмо", "легковерный", "обман", "верить"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["легковерный", "ловушка", "обманывать", "верить"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["сожалеть", "проклинать", "заблуждение", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "изгонять", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["сожалеть", "гнать", "несправедливость", "проклинать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Irrtum»?", "choices": ["проклинать", "сожалеть", "заблуждение", "изгонять"], "correct_index": 2}, {"question": "Что означает немецкое слово «blind»?", "choices": ["слепой", "гнать", "изгонять", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["несправедливость", "гнать", "проклинать", "заблуждение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["проклинать", "сожалеть", "несправедливость", "гнать"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «helfen»?", "choices": ["рисковать", "опасность", "сострадание", "помогать"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Mitleid»?", "choices": ["помогать", "рисковать", "сострадание", "опасность"], "correct_index": 2}, {"question": "Что означает немецкое слово «riskieren»?", "choices": ["рисковать", "опасность", "сострадание", "тайно"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["осмеливаться", "рисковать", "опасность", "тайно"], "correct_index": 2}, {"question": "Что означает немецкое слово «heimlich»?", "choices": ["рисковать", "защищать", "тайно", "осмеливаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «schützen»?", "choices": ["опасность", "тайно", "защищать", "сострадание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["измена", "тайно", "рисковать", "осмеливаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «wagen»?", "choices": ["измена", "тайно", "осмеливаться", "помогать"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["боль", "темнота", "ослеплять", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["боль", "темнота", "ослеплять", "пытка"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Schmerz»?", "choices": ["боль", "месть", "темнота", "кричать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Dunkelheit»?", "choices": ["темнота", "слепнуть", "пытка", "месть"], "correct_index": 0}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["месть", "пытка", "кричать", "темнота"], "correct_index": 2}, {"question": "Что означает немецкое слово «erblinden»?", "choices": ["слепнуть", "темнота", "ослеплять", "боль"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["темнота", "боль", "ослеплять", "месть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["пропасть", "прыгать", "обман", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «springen»?", "choices": ["обман", "пропасть", "отчаяние", "прыгать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Täuschung»?", "choices": ["отчаяние", "прыгать", "сдаваться", "обман"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abgrund»?", "choices": ["прыгать", "пропасть", "падать", "сдаваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["отчаяние", "сдаваться", "безнадёжность", "пропасть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hoffnungslosigkeit»?", "choices": ["избавлять", "обман", "безнадёжность", "пропасть"], "correct_index": 2}, {"question": "Что означает немецкое слово «stürzen»?", "choices": ["отчаяние", "прыгать", "падать", "безнадёжность"], "correct_index": 2}, {"question": "Что означает немецкое слово «erlösen»?", "choices": ["отчаяние", "обман", "пропасть", "избавлять"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["прощать", "узнавать", "умирать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["прощать", "узнавать", "осознание", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["раскаяние", "умирать", "узнавать", "осознание"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["узнавать", "примирение", "осознание", "сердце"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["обнимать", "осознание", "прощать", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «umarmen»?", "choices": ["примирение", "осознание", "узнавать", "обнимать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Versöhnung»?", "choices": ["умирать", "примирение", "раскаяние", "обнимать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "сердце", "умирать", "узнавать"], "correct_index": 1}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Благородный граф</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -433,13 +437,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Adel»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">граф</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">граф</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -451,9 +455,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">знать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                                         
@@ -461,97 +465,97 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «vertrauen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">знать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">долг</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">знать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">уважать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">праведный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">доверять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">долг</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">уважать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">честь</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «achten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">доверять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Graf»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">праведный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ehre»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">доверять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «rechtschaffen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">граф</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">долг</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Pflicht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уважать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">праведный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">знать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «achten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">долг</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">честь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уважать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,33 +568,33 @@
                         <div class="quiz-phase-container" data-phase="goneril">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Brief»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «glauben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">письмо</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -602,9 +606,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">простодушный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
                                         
@@ -612,17 +616,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Betrug»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -632,43 +636,27 @@
                                     <div class="quiz-question">Что означает немецкое слово «arglos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">простодушный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">легковерный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ловушка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «verdächtigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">простодушный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подозревать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">легковерный</button>
                                         
@@ -676,17 +664,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «leichtgläubig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">письмо</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">легковерный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">верить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">легковерный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -699,13 +703,77 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                                         
@@ -715,97 +783,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">заблуждение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">заблуждение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слепой</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «der Irrtum»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «blind»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">заблуждение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">слепой</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Ungerechtigkeit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">несправедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -818,61 +822,29 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «helfen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сострадание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">помогать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «das Mitleid»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">помогать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">рисковать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">измена</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                                         
@@ -882,33 +854,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «riskieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">осмеливаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рисковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «heimlich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">рисковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">тайно</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «schützen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сострадание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">помогать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">тайно</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сострадание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -920,9 +924,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">помогать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сострадание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">рисковать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">осмеливаться</button>
                                         
@@ -934,7 +938,7 @@
                                     <div class="quiz-question">Что означает немецкое слово «wagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">измена</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">тайно</button>
                                         
@@ -953,33 +957,33 @@
                         <div class="quiz-phase-container" data-phase="hut">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -991,27 +995,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Dunkelheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1021,29 +1025,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «schreien»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">боль</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пытка</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">кричать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">темнота</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «erblinden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слепнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">темнота</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">боль</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1053,11 +1057,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">темнота</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слепнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">боль</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">темнота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                                         
@@ -1072,31 +1076,15 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пропасть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «springen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">обман</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
                                         
@@ -1104,15 +1092,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «springen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">прыгать</button>
                                         
@@ -1120,15 +1108,47 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Täuschung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Abgrund»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прыгать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пропасть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сдаваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                                         
@@ -1136,31 +1156,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пропасть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Hoffnungslosigkeit»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прыгать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прыгать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">падать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">безнадёжность</button>
                                         
@@ -1168,33 +1188,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «stürzen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обман</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">безнадёжность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">избавлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «erlösen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">избавлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обман</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безнадёжность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пропасть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обман</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">избавлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1207,13 +1211,13 @@
                         <div class="quiz-phase-container" data-phase="prison">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
@@ -1223,15 +1227,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «vergeben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                                         
@@ -1239,13 +1243,77 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">осознание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обнимать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">примирение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                                         
@@ -1255,81 +1323,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">осознание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">примирение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">осознание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «umarmen»?</div>
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обнимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">примирение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Versöhnung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">примирение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сердце</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обнимать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обнимать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2002,10 +2006,10 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
-                    "доверять",
+                    "служить",
                     "знать",
-                    "граф",
-                    "служить"
+                    "доверять",
+                    "граф"
                 ],
                 "correctIndex": 1
             },
@@ -2013,8 +2017,8 @@
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
                     "граф",
-                    "доверять",
                     "знать",
+                    "доверять",
                     "служить"
                 ],
                 "correctIndex": 3
@@ -2023,61 +2027,61 @@
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
                     "знать",
-                    "честь",
-                    "долг",
-                    "доверять"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Graf»?",
-                "choices": [
-                    "граф",
-                    "честь",
-                    "знать",
-                    "уважать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Ehre»?",
-                "choices": [
-                    "уважать",
-                    "праведный",
-                    "честь",
-                    "доверять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «rechtschaffen»?",
-                "choices": [
-                    "праведный",
-                    "долг",
-                    "честь",
-                    "доверять"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Pflicht»?",
-                "choices": [
-                    "граф",
-                    "долг",
-                    "уважать",
-                    "честь"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «achten»?",
-                "choices": [
                     "доверять",
-                    "уважать",
                     "служить",
                     "долг"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Graf»?",
+                "choices": [
+                    "доверять",
+                    "граф",
+                    "служить",
+                    "праведный"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Ehre»?",
+                "choices": [
+                    "праведный",
+                    "честь",
+                    "доверять",
+                    "служить"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «rechtschaffen»?",
+                "choices": [
+                    "граф",
+                    "служить",
+                    "праведный",
+                    "долг"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Pflicht»?",
+                "choices": [
+                    "долг",
+                    "уважать",
+                    "праведный",
+                    "знать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «achten»?",
+                "choices": [
+                    "долг",
+                    "служить",
+                    "честь",
+                    "уважать"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2554,28 +2558,28 @@
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
                     "обманывать",
+                    "обман",
                     "письмо",
-                    "верить",
-                    "обман"
+                    "верить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «glauben»?",
                 "choices": [
-                    "обман",
                     "верить",
-                    "письмо",
-                    "обманывать"
+                    "обман",
+                    "обманывать",
+                    "письмо"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
                     "обманывать",
-                    "верить",
-                    "простодушный",
+                    "подозревать",
+                    "письмо",
                     "ловушка"
                 ],
                 "correctIndex": 0
@@ -2583,52 +2587,52 @@
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
-                    "простодушный",
-                    "ловушка",
-                    "письмо",
-                    "обман"
+                    "обман",
+                    "легковерный",
+                    "подозревать",
+                    "обманывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «arglos»?",
                 "choices": [
-                    "письмо",
+                    "обманывать",
                     "простодушный",
-                    "верить",
-                    "ловушка"
+                    "легковерный",
+                    "обман"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
-                    "простодушный",
                     "подозревать",
                     "обман",
-                    "обманывать"
+                    "ловушка",
+                    "легковерный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leichtgläubig»?",
                 "choices": [
                     "письмо",
-                    "обманывать",
-                    "верить",
-                    "легковерный"
+                    "легковерный",
+                    "обман",
+                    "верить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "верить",
-                    "обман",
+                    "легковерный",
                     "ловушка",
-                    "обманывать"
+                    "обманывать",
+                    "верить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3081,72 +3085,72 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
+                    "сожалеть",
                     "проклинать",
                     "заблуждение",
-                    "изгонять",
-                    "сожалеть"
+                    "изгонять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
                     "сожалеть",
+                    "проклинать",
                     "изгонять",
-                    "заблуждение",
-                    "проклинать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
-                    "слепой",
-                    "изгонять",
-                    "сожалеть",
-                    "проклинать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Irrtum»?",
-                "choices": [
-                    "сожалеть",
-                    "заблуждение",
-                    "гнать",
-                    "изгонять"
+                    "заблуждение"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «blind»?",
-                "choices": [
-                    "проклинать",
-                    "заблуждение",
-                    "гнать",
-                    "слепой"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «jagen»?",
+                "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "сожалеть",
-                    "несправедливость",
                     "гнать",
+                    "несправедливость",
                     "проклинать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «der Irrtum»?",
+                "choices": [
+                    "проклинать",
+                    "сожалеть",
+                    "заблуждение",
+                    "изгонять"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «blind»?",
+                "choices": [
+                    "слепой",
+                    "гнать",
+                    "изгонять",
+                    "сожалеть"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «jagen»?",
+                "choices": [
+                    "несправедливость",
+                    "гнать",
+                    "проклинать",
+                    "заблуждение"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "изгонять",
                     "проклинать",
                     "сожалеть",
-                    "несправедливость"
+                    "несправедливость",
+                    "гнать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3602,69 +3606,69 @@
             {
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
-                    "сострадание",
-                    "помогать",
                     "рисковать",
-                    "опасность"
+                    "опасность",
+                    "сострадание",
+                    "помогать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Mitleid»?",
                 "choices": [
                     "помогать",
-                    "сострадание",
-                    "опасность",
-                    "рисковать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «riskieren»?",
-                "choices": [
-                    "опасность",
-                    "сострадание",
                     "рисковать",
-                    "измена"
+                    "сострадание",
+                    "опасность"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Gefahr»?",
+                "question": "Что означает немецкое слово «riskieren»?",
                 "choices": [
                     "рисковать",
-                    "защищать",
+                    "опасность",
                     "сострадание",
-                    "опасность"
+                    "тайно"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "осмеливаться",
+                    "рисковать",
+                    "опасность",
+                    "тайно"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
-                    "защищать",
                     "рисковать",
+                    "защищать",
                     "тайно",
-                    "сострадание"
+                    "осмеливаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
+                    "опасность",
+                    "тайно",
                     "защищать",
-                    "сострадание",
-                    "помогать",
-                    "тайно"
+                    "сострадание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
                     "измена",
-                    "помогать",
-                    "сострадание",
+                    "тайно",
+                    "рисковать",
                     "осмеливаться"
                 ],
                 "correctIndex": 0
@@ -3672,7 +3676,7 @@
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "опасность",
+                    "измена",
                     "тайно",
                     "осмеливаться",
                     "помогать"
@@ -4120,69 +4124,69 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
+                    "боль",
                     "темнота",
                     "ослеплять",
-                    "пытка",
-                    "боль"
+                    "пытка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "пытка",
-                    "ослеплять",
                     "боль",
-                    "темнота"
+                    "темнота",
+                    "ослеплять",
+                    "пытка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
                     "боль",
-                    "ослеплять",
-                    "кричать",
-                    "темнота"
+                    "месть",
+                    "темнота",
+                    "кричать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
-                    "слепнуть",
-                    "боль",
                     "темнота",
-                    "ослеплять"
+                    "слепнуть",
+                    "пытка",
+                    "месть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
-                    "боль",
-                    "слепнуть",
+                    "месть",
+                    "пытка",
                     "кричать",
-                    "ослеплять"
+                    "темнота"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
-                    "темнота",
                     "слепнуть",
+                    "темнота",
                     "ослеплять",
-                    "месть"
+                    "боль"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "ослеплять",
-                    "слепнуть",
                     "темнота",
+                    "боль",
+                    "ослеплять",
                     "месть"
                 ],
                 "correctIndex": 3
@@ -4661,82 +4665,82 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "отчаяние",
-                    "обман",
                     "пропасть",
-                    "прыгать"
+                    "прыгать",
+                    "обман",
+                    "отчаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «springen»?",
                 "choices": [
                     "обман",
                     "пропасть",
-                    "прыгать",
-                    "отчаяние"
+                    "отчаяние",
+                    "прыгать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
                     "отчаяние",
-                    "обман",
-                    "избавлять",
-                    "прыгать"
+                    "прыгать",
+                    "сдаваться",
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "избавлять",
-                    "отчаяние",
                     "прыгать",
-                    "пропасть"
+                    "пропасть",
+                    "падать",
+                    "сдаваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
+                    "отчаяние",
                     "сдаваться",
-                    "прыгать",
-                    "пропасть",
-                    "падать"
+                    "безнадёжность",
+                    "пропасть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
                 "choices": [
-                    "сдаваться",
+                    "избавлять",
                     "обман",
-                    "прыгать",
-                    "безнадёжность"
+                    "безнадёжность",
+                    "пропасть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "обман",
-                    "безнадёжность",
-                    "избавлять",
-                    "падать"
+                    "отчаяние",
+                    "прыгать",
+                    "падать",
+                    "безнадёжность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
-                    "избавлять",
-                    "сдаваться",
-                    "безнадёжность",
-                    "обман"
+                    "отчаяние",
+                    "обман",
+                    "пропасть",
+                    "избавлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5214,82 +5218,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
                     "прощать",
+                    "узнавать",
                     "умирать",
                     "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
-                    "осознание",
                     "прощать",
                     "узнавать",
+                    "осознание",
                     "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "умирать",
-                    "прощать",
                     "раскаяние",
-                    "обнимать"
+                    "умирать",
+                    "узнавать",
+                    "осознание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "раскаяние",
-                    "осознание",
+                    "узнавать",
                     "примирение",
-                    "умирать"
+                    "осознание",
+                    "сердце"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
+                    "обнимать",
                     "осознание",
-                    "сердце",
-                    "раскаяние",
-                    "примирение"
+                    "прощать",
+                    "раскаяние"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "прощать",
-                    "обнимать",
-                    "умирать",
-                    "примирение"
+                    "примирение",
+                    "осознание",
+                    "узнавать",
+                    "обнимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
+                    "умирать",
                     "примирение",
-                    "сердце",
-                    "обнимать",
-                    "умирать"
+                    "раскаяние",
+                    "обнимать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "обнимать",
-                    "раскаяние",
+                    "прощать",
                     "сердце",
-                    "прощать"
+                    "умирать",
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Гонерильи</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Гонерильи</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["клясться", "лицемерить", "ложь", "наследство"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["ложь", "клясться", "наследство", "лицемерить"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["льстить", "обманывать", "клясться", "наследство"], "correct_index": 3}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["обманывать", "лицемерить", "ложь", "наследство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["состояние", "льстить", "жадность", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["ложь", "состояние", "обманывать", "лицемерить"], "correct_index": 2}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["клясться", "наследство", "обманывать", "льстить"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["клясться", "обманывать", "жадность", "состояние"], "correct_index": 3}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["трон", "власть", "приказывать", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["приказывать", "трон", "править", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["власть", "господство", "приказывать", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["править", "господство", "трон", "завоёвывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["управлять", "завоёвывать", "власть", "господство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["господство", "управлять", "завоёвывать", "править"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["приказывать", "трон", "управлять", "господство"], "correct_index": 2}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["управлять", "подчинять", "власть", "трон"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["унижать", "жестокий", "месть", "изгонять"], "correct_index": 0}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "изгонять", "месть", "жестокий"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["изгонять", "месть", "презирать", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "мучить", "унижать", "ограничивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["отказывать", "презирать", "унижать", "ограничивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["изгонять", "месть", "отказывать", "мучить"], "correct_index": 2}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["месть", "унижать", "мучить", "ограничивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["ограничивать", "отказывать", "унижать", "месть"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "отвергать", "запирать", "безжалостный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["отвергать", "безжалостный", "запирать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["буря", "безжалостный", "холод", "отвергать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["ожесточаться", "беспощадный", "запирать", "холод"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["отвергать", "холод", "ожесточаться", "запирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["отвергать", "холод", "беспощадный", "безжалостный"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["ожесточаться", "буря", "холод", "безжалостный"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["ссориться", "раздор", "предавать", "ненавидеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["ненавидеть", "ссориться", "раздор", "предавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["ссориться", "раздор", "презрение", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ссориться", "ненавидеть", "разрушать", "презрение"], "correct_index": 1}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["изменять", "раздор", "разрушать", "страсть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["разрушать", "презрение", "страсть", "изменять"], "correct_index": 1}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["предавать", "разрушать", "изменять", "раздор"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["раздор", "страсть", "ненавидеть", "презрение"], "correct_index": 1}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["желать", "бороться", "ревность", "соперничать"], "correct_index": 2}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["бороться", "желать", "ревность", "соперничать"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["убивать", "бороться", "яд", "интрига"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["желать", "ревность", "соперничать", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["желать", "ревность", "интрига", "устранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["соперничать", "интрига", "яд", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["соперничать", "убивать", "интрига", "ревность"], "correct_index": 2}, {"question": "Что означает немецкое слово «morden»?", "choices": ["убивать", "бороться", "яд", "ревность"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["отравлять", "отчаяние", "вина", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "отравлять", "вина", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "вина", "сожалеть", "отравлять"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["вина", "погибель", "отчаяние", "сожалеть"], "correct_index": 0}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["отчаяние", "уничтожать", "отравлять", "сожалеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["погибель", "отчаяние", "сожалеть", "ад"], "correct_index": 0}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["вина", "сожалеть", "уничтожать", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["умирать", "ад", "отчаяние", "отравлять"], "correct_index": 1}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «die Lüge»?", "choices": ["клясться", "наследство", "ложь", "лицемерить"], "correct_index": 2}, {"question": "Что означает немецкое слово «schwören»?", "choices": ["наследство", "лицемерить", "клясться", "ложь"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Erbe»?", "choices": ["льстить", "наследство", "ложь", "обманывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «heucheln»?", "choices": ["жадность", "клясться", "лицемерить", "обманывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Gier»?", "choices": ["состояние", "лицемерить", "наследство", "жадность"], "correct_index": 3}, {"question": "Что означает немецкое слово «täuschen»?", "choices": ["льстить", "наследство", "ложь", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmeicheln»?", "choices": ["льстить", "ложь", "состояние", "наследство"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Vermögen»?", "choices": ["лицемерить", "состояние", "клясться", "льстить"], "correct_index": 1}], "goneril": [{"question": "Что означает немецкое слово «die Macht»?", "choices": ["приказывать", "трон", "власть", "править"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["трон", "власть", "приказывать", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «befehlen»?", "choices": ["подчинять", "приказывать", "власть", "господство"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Thron»?", "choices": ["приказывать", "править", "завоёвывать", "трон"], "correct_index": 3}, {"question": "Что означает немецкое слово «erobern»?", "choices": ["подчинять", "завоёвывать", "власть", "править"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Herrschaft»?", "choices": ["господство", "приказывать", "править", "подчинять"], "correct_index": 0}, {"question": "Что означает немецкое слово «regieren»?", "choices": ["приказывать", "подчинять", "править", "управлять"], "correct_index": 3}, {"question": "Что означает немецкое слово «unterwerfen»?", "choices": ["господство", "приказывать", "подчинять", "править"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["месть", "изгонять", "жестокий", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «grausam»?", "choices": ["унижать", "жестокий", "месть", "изгонять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Rache»?", "choices": ["месть", "изгонять", "жестокий", "отказывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["презирать", "месть", "ограничивать", "изгонять"], "correct_index": 3}, {"question": "Что означает немецкое слово «verachten»?", "choices": ["жестокий", "презирать", "унижать", "отказывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verweigern»?", "choices": ["жестокий", "отказывать", "унижать", "месть"], "correct_index": 1}, {"question": "Что означает немецкое слово «quälen»?", "choices": ["унижать", "месть", "изгонять", "мучить"], "correct_index": 3}, {"question": "Что означает немецкое слово «beschränken»?", "choices": ["ограничивать", "презирать", "мучить", "изгонять"], "correct_index": 0}], "storm": [{"question": "Что означает немецкое слово «verstoßen»?", "choices": ["буря", "безжалостный", "отвергать", "запирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sturm»?", "choices": ["безжалостный", "запирать", "отвергать", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «gnadenlos»?", "choices": ["ожесточаться", "холод", "безжалостный", "запирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschließen»?", "choices": ["буря", "запирать", "холод", "беспощадный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["беспощадный", "буря", "запирать", "холод"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["безжалостный", "беспощадный", "отвергать", "запирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhärten»?", "choices": ["беспощадный", "ожесточаться", "отвергать", "холод"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «streiten»?", "choices": ["предавать", "раздор", "ссориться", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["раздор", "предавать", "ссориться", "ненавидеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Zwietracht»?", "choices": ["страсть", "изменять", "предавать", "раздор"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["раздор", "ссориться", "ненавидеть", "изменять"], "correct_index": 2}, {"question": "Что означает немецкое слово «betrügen»?", "choices": ["предавать", "презрение", "изменять", "ссориться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verachtung»?", "choices": ["изменять", "предавать", "презрение", "разрушать"], "correct_index": 2}, {"question": "Что означает немецкое слово «zerstören»?", "choices": ["предавать", "ссориться", "презрение", "разрушать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Leidenschaft»?", "choices": ["предавать", "ненавидеть", "раздор", "страсть"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «die Eifersucht»?", "choices": ["ревность", "бороться", "желать", "соперничать"], "correct_index": 0}, {"question": "Что означает немецкое слово «rivalisieren»?", "choices": ["ревность", "соперничать", "бороться", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["желать", "бороться", "ревность", "яд"], "correct_index": 1}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соперничать", "ревность", "желать", "устранять"], "correct_index": 2}, {"question": "Что означает немецкое слово «beseitigen»?", "choices": ["устранять", "интрига", "убивать", "соперничать"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Gift»?", "choices": ["устранять", "яд", "убивать", "желать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "устранять", "ревность", "убивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «morden»?", "choices": ["ревность", "убивать", "желать", "интрига"], "correct_index": 1}], "prison": [{"question": "Что означает немецкое слово «vergiften»?", "choices": ["умирать", "отчаяние", "отравлять", "вина"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["отчаяние", "отравлять", "вина", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["сожалеть", "умирать", "вина", "отравлять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schuld»?", "choices": ["умирать", "отчаяние", "уничтожать", "вина"], "correct_index": 3}, {"question": "Что означает немецкое слово «vernichten»?", "choices": ["отравлять", "уничтожать", "отчаяние", "ад"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Verderben»?", "choices": ["ад", "погибель", "вина", "отчаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["вина", "уничтожать", "сожалеть", "умирать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Hölle»?", "choices": ["ад", "вина", "отравлять", "уничтожать"], "correct_index": 0}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Лесть и обман</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -435,25 +439,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
                                         
@@ -461,47 +449,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «schwören»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наследство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ложь</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Erbe»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">льстить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                                         
@@ -509,49 +481,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «heucheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жадность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">клясться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gier»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">состояние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">лицемерить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наследство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жадность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «täuschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ложь</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">лицемерить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">наследство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ложь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «schmeicheln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">льстить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ложь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">состояние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">наследство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Vermögen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">клясться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">лицемерить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">состояние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жадность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">клясться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">состояние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">льстить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,8 +568,24 @@
                         <div class="quiz-phase-container" data-phase="goneril">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
@@ -580,49 +600,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «befehlen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">приказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">господство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">завоёвывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -632,13 +636,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «erobern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">подчинять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">завоёвывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -650,43 +654,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">управлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">завоёвывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подчинять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «regieren»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">приказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">управлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">господство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">управлять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «unterwerfen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">управлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">господство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">подчинять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">приказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подчинять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -699,8 +703,24 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
@@ -715,49 +735,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «grausam»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">месть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокий</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Rache»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">презирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">презирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мучить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ограничивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -767,45 +771,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «verachten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отказывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «verweigern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «quälen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">месть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ограничивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мучить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -817,11 +821,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">ограничивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отказывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">презирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">мучить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">месть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгонять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -834,17 +838,17 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -854,11 +858,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                                         
@@ -866,29 +870,45 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «gnadenlos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">безжалостный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безжалостный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «verschließen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">запирать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">запирать</button>
                                         
@@ -898,15 +918,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">безжалостный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ожесточаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">запирать</button>
                                         
@@ -914,33 +934,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «verhärten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ожесточаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ожесточаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">безжалостный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">холод</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -953,111 +957,47 @@
                         <div class="quiz-phase-container" data-phase="hut">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «streiten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предавать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ссориться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">разрушать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">разрушать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страсть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">разрушать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раздор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zwietracht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страсть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предавать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">раздор</button>
                                         
@@ -1065,17 +1005,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «hassen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">раздор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страсть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">презрение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «betrügen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">презрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ссориться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Verachtung»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «zerstören»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ссориться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">презрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разрушать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Leidenschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">раздор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страсть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1088,15 +1092,15 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Eifersucht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
                                         
@@ -1104,17 +1108,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «rivalisieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">желать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1124,43 +1128,27 @@
                                     <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">яд</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">желать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ревность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">устранять</button>
                                         
@@ -1168,49 +1156,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «beseitigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Gift»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">устранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">яд</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">убивать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">желать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соперничать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">устранять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ревность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">убивать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «morden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">убивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ревность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">убивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">яд</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">желать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ревность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1223,17 +1227,17 @@
                         <div class="quiz-phase-container" data-phase="prison">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «vergiften»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1255,15 +1259,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
                                         
@@ -1271,17 +1275,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Schuld»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вина</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1291,27 +1295,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «vernichten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отравлять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">уничтожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">погибель</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
                                         
@@ -1319,33 +1307,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «das Verderben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">погибель</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">вина</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">уничтожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">уничтожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ад</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Hölle»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ад</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ад</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вина</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отравлять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отравлять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">уничтожать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2051,81 +2055,81 @@
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
                     "клясться",
-                    "лицемерить",
+                    "наследство",
                     "ложь",
-                    "наследство"
+                    "лицемерить"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
-                    "ложь",
-                    "клясться",
                     "наследство",
-                    "лицемерить"
+                    "лицемерить",
+                    "клясться",
+                    "ложь"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
                     "льстить",
-                    "обманывать",
-                    "клясться",
-                    "наследство"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «heucheln»?",
-                "choices": [
-                    "обманывать",
-                    "лицемерить",
+                    "наследство",
                     "ложь",
-                    "наследство"
+                    "обманывать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Gier»?",
+                "question": "Что означает немецкое слово «heucheln»?",
                 "choices": [
-                    "состояние",
-                    "льстить",
                     "жадность",
+                    "клясться",
+                    "лицемерить",
                     "обманывать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "состояние",
+                    "лицемерить",
+                    "наследство",
+                    "жадность"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «täuschen»?",
                 "choices": [
+                    "льстить",
+                    "наследство",
                     "ложь",
-                    "состояние",
-                    "обманывать",
-                    "лицемерить"
+                    "обманывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schmeicheln»?",
                 "choices": [
-                    "клясться",
-                    "наследство",
-                    "обманывать",
-                    "льстить"
+                    "льстить",
+                    "ложь",
+                    "состояние",
+                    "наследство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Vermögen»?",
                 "choices": [
+                    "лицемерить",
+                    "состояние",
                     "клясться",
-                    "обманывать",
-                    "жадность",
-                    "состояние"
+                    "льстить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2656,50 +2660,50 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
+                    "приказывать",
+                    "трон",
+                    "власть",
+                    "править"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «herrschen»?",
+                "choices": [
                     "трон",
                     "власть",
                     "приказывать",
                     "править"
                 ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «herrschen»?",
-                "choices": [
-                    "приказывать",
-                    "трон",
-                    "править",
-                    "власть"
-                ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
-                    "власть",
-                    "господство",
+                    "подчинять",
                     "приказывать",
-                    "трон"
+                    "власть",
+                    "господство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
+                    "приказывать",
                     "править",
-                    "господство",
-                    "трон",
-                    "завоёвывать"
+                    "завоёвывать",
+                    "трон"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "управлять",
+                    "подчинять",
                     "завоёвывать",
                     "власть",
-                    "господство"
+                    "править"
                 ],
                 "correctIndex": 1
             },
@@ -2707,9 +2711,9 @@
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
                     "господство",
-                    "управлять",
-                    "завоёвывать",
-                    "править"
+                    "приказывать",
+                    "править",
+                    "подчинять"
                 ],
                 "correctIndex": 0
             },
@@ -2717,21 +2721,21 @@
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
                     "приказывать",
-                    "трон",
-                    "управлять",
-                    "господство"
+                    "подчинять",
+                    "править",
+                    "управлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «unterwerfen»?",
                 "choices": [
-                    "управлять",
+                    "господство",
+                    "приказывать",
                     "подчинять",
-                    "власть",
-                    "трон"
+                    "править"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3276,80 +3280,80 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
-                    "жестокий",
                     "месть",
-                    "изгонять"
+                    "изгонять",
+                    "жестокий",
+                    "унижать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
                     "унижать",
-                    "изгонять",
+                    "жестокий",
                     "месть",
-                    "жестокий"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "изгонять",
-                    "месть",
-                    "презирать",
-                    "унижать"
+                    "изгонять"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «vertreiben»?",
+                "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
+                    "месть",
                     "изгонять",
-                    "мучить",
-                    "унижать",
-                    "ограничивать"
+                    "жестокий",
+                    "отказывать"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «vertreiben»?",
+                "choices": [
+                    "презирать",
+                    "месть",
+                    "ограничивать",
+                    "изгонять"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verachten»?",
                 "choices": [
-                    "отказывать",
+                    "жестокий",
                     "презирать",
                     "унижать",
-                    "ограничивать"
+                    "отказывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verweigern»?",
                 "choices": [
-                    "изгонять",
-                    "месть",
+                    "жестокий",
                     "отказывать",
-                    "мучить"
+                    "унижать",
+                    "месть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "месть",
                     "унижать",
-                    "мучить",
-                    "ограничивать"
+                    "месть",
+                    "изгонять",
+                    "мучить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
                     "ограничивать",
-                    "отказывать",
-                    "унижать",
-                    "месть"
+                    "презирать",
+                    "мучить",
+                    "изгонять"
                 ],
                 "correctIndex": 0
             }
@@ -3851,18 +3855,18 @@
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "буря",
+                    "безжалостный",
                     "отвергать",
-                    "запирать",
-                    "безжалостный"
+                    "запирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "отвергать",
                     "безжалостный",
                     "запирать",
+                    "отвергать",
                     "буря"
                 ],
                 "correctIndex": 3
@@ -3870,52 +3874,52 @@
             {
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
-                    "буря",
-                    "безжалостный",
-                    "холод",
-                    "отвергать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verschließen»?",
-                "choices": [
                     "ожесточаться",
-                    "беспощадный",
-                    "запирать",
-                    "холод"
+                    "холод",
+                    "безжалостный",
+                    "запирать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «verschließen»?",
+                "choices": [
+                    "буря",
+                    "запирать",
+                    "холод",
+                    "беспощадный"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
+                    "беспощадный",
+                    "буря",
+                    "запирать",
+                    "холод"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «erbarmungslos»?",
+                "choices": [
+                    "безжалостный",
+                    "беспощадный",
                     "отвергать",
-                    "холод",
-                    "ожесточаться",
                     "запирать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
-                "choices": [
-                    "отвергать",
-                    "холод",
-                    "беспощадный",
-                    "безжалостный"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
+                    "беспощадный",
                     "ожесточаться",
-                    "буря",
-                    "холод",
-                    "безжалостный"
+                    "отвергать",
+                    "холод"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4426,82 +4430,82 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
-                    "ссориться",
-                    "раздор",
                     "предавать",
+                    "раздор",
+                    "ссориться",
                     "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "ненавидеть",
-                    "ссориться",
                     "раздор",
-                    "предавать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Zwietracht»?",
-                "choices": [
+                    "предавать",
                     "ссориться",
-                    "раздор",
-                    "презрение",
                     "ненавидеть"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «die Zwietracht»?",
+                "choices": [
+                    "страсть",
+                    "изменять",
+                    "предавать",
+                    "раздор"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
+                    "раздор",
                     "ссориться",
                     "ненавидеть",
-                    "разрушать",
-                    "презрение"
+                    "изменять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
+                    "предавать",
+                    "презрение",
                     "изменять",
-                    "раздор",
-                    "разрушать",
-                    "страсть"
+                    "ссориться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
-                    "разрушать",
+                    "изменять",
+                    "предавать",
                     "презрение",
-                    "страсть",
-                    "изменять"
+                    "разрушать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zerstören»?",
                 "choices": [
                     "предавать",
-                    "разрушать",
-                    "изменять",
-                    "раздор"
+                    "ссориться",
+                    "презрение",
+                    "разрушать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "раздор",
-                    "страсть",
+                    "предавать",
                     "ненавидеть",
-                    "презрение"
+                    "раздор",
+                    "страсть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5029,82 +5033,82 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "желать",
-                    "бороться",
                     "ревность",
+                    "бороться",
+                    "желать",
                     "соперничать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
-                    "бороться",
-                    "желать",
                     "ревность",
-                    "соперничать"
+                    "соперничать",
+                    "бороться",
+                    "желать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "убивать",
+                    "желать",
                     "бороться",
-                    "яд",
-                    "интрига"
+                    "ревность",
+                    "яд"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "желать",
-                    "ревность",
                     "соперничать",
-                    "интрига"
+                    "ревность",
+                    "желать",
+                    "устранять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
-                    "желать",
-                    "ревность",
+                    "устранять",
                     "интрига",
-                    "устранять"
+                    "убивать",
+                    "соперничать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
-                    "соперничать",
-                    "интрига",
+                    "устранять",
                     "яд",
-                    "ревность"
+                    "убивать",
+                    "желать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "соперничать",
-                    "убивать",
                     "интрига",
-                    "ревность"
+                    "устранять",
+                    "ревность",
+                    "убивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
+                    "ревность",
                     "убивать",
-                    "бороться",
-                    "яд",
-                    "ревность"
+                    "желать",
+                    "интрига"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5631,12 +5635,12 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
-                    "отравлять",
+                    "умирать",
                     "отчаяние",
-                    "вина",
-                    "умирать"
+                    "отравлять",
+                    "вина"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
@@ -5651,62 +5655,62 @@
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
+                    "сожалеть",
                     "умирать",
                     "вина",
-                    "сожалеть",
                     "отравлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "вина",
-                    "погибель",
+                    "умирать",
                     "отчаяние",
-                    "сожалеть"
+                    "уничтожать",
+                    "вина"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
-                    "отчаяние",
-                    "уничтожать",
                     "отравлять",
-                    "сожалеть"
+                    "уничтожать",
+                    "отчаяние",
+                    "ад"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Verderben»?",
                 "choices": [
+                    "ад",
                     "погибель",
-                    "отчаяние",
-                    "сожалеть",
-                    "ад"
+                    "вина",
+                    "отчаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "вина",
-                    "сожалеть",
                     "уничтожать",
-                    "ад"
+                    "сожалеть",
+                    "умирать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "умирать",
                     "ад",
-                    "отчаяние",
-                    "отравлять"
+                    "вина",
+                    "отравлять",
+                    "уничтожать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Кента</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Кента</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "мужество", "верность", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["защищать", "верность", "мужество", "возражать"], "correct_index": 2}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["защищать", "возражать", "справедливый", "верность"], "correct_index": 1}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["справедливый", "защищать", "предупреждать", "искренний"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["слуга", "возражать", "искренний", "верность"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["защищать", "мужество", "слуга", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["верность", "мужество", "предупреждать", "справедливый"], "correct_index": 2}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["слуга", "верность", "справедливый", "мужество"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["несправедливость", "гнев", "изгнание", "изгнанный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "гнев", "изгнание", "изгнанный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["изгнание", "наказание", "гнев", "возвращаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["изгнанный", "наказание", "прощание", "возвращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["возвращаться", "прощание", "несправедливость", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "прощание", "несправедливость", "наказание"], "correct_index": 3}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["наказание", "изгнание", "возвращаться", "гнев"], "correct_index": 2}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["неузнанный", "хитрость", "притворяться", "переодевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["переодевание", "хитрость", "неузнанный", "притворяться"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["неузнанный", "притворяться", "переодевание", "наниматься"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["хитрость", "борода", "наниматься", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["наниматься", "изменять", "притворяться", "верный"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["верный", "переодевание", "хитрость", "борода"], "correct_index": 3}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["хитрость", "верный", "переодевание", "наниматься"], "correct_index": 3}, {"question": "Что означает немецкое слово «treu»?", "choices": ["хитрость", "верный", "борода", "неузнанный"], "correct_index": 1}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["служба", "опасность", "охранять", "защита"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["опасность", "защита", "охранять", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["опасность", "защита", "стража", "служба"], "correct_index": 0}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["защита", "стража", "охранять", "сражаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["опасность", "советовать", "сражаться", "защита"], "correct_index": 2}, {"question": "Что означает немецкое слово «raten»?", "choices": ["защита", "советовать", "стража", "служба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["защита", "стража", "советовать", "служба"], "correct_index": 1}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["стойкость", "наказание", "сковывать", "унижение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["сковывать", "унижение", "наказание", "стойкость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["наказание", "стойкость", "колодка", "позор"], "correct_index": 1}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["унижение", "позор", "наказание", "сковывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["терпеть", "стойкость", "наказание", "выдерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["позор", "сковывать", "наказание", "колодка"], "correct_index": 3}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["терпеть", "выдерживать", "позор", "сковывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["позор", "выдерживать", "терпеть", "стойкость"], "correct_index": 0}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "поддержка", "утешать", "сопровождать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["сопровождать", "буря", "утешать", "поддержка"], "correct_index": 3}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["сопровождать", "поддержка", "утешать", "буря"], "correct_index": 0}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["холод", "убежище", "поддержка", "утешать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["утешать", "убежище", "поддержка", "сопровождать"], "correct_index": 1}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["убежище", "выдерживать", "утешать", "поддержка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["убежище", "холод", "буря", "поддержка"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["плакать", "вечный", "смерть", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["смерть", "прощание", "плакать", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["плакать", "сдаваться", "следовать", "вечный"], "correct_index": 3}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["истощение", "плакать", "смерть", "вечный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["сдаваться", "вечный", "истощение", "плакать"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["сдаваться", "истощение", "прощание", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["истощение", "скорбь", "сдаваться", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["сдаваться", "следовать", "истощение", "плакать"], "correct_index": 1}]}'>
+                    <div class="quiz-section" data-quiz-map='{"loyalty": [{"question": "Что означает немецкое слово «die Treue»?", "choices": ["возражать", "мужество", "верность", "защищать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Mut»?", "choices": ["мужество", "возражать", "защищать", "верность"], "correct_index": 0}, {"question": "Что означает немецкое слово «widersprechen»?", "choices": ["предупреждать", "мужество", "искренний", "возражать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verteidigen»?", "choices": ["защищать", "возражать", "верность", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «aufrichtig»?", "choices": ["искренний", "предупреждать", "возражать", "мужество"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Diener»?", "choices": ["защищать", "верность", "слуга", "искренний"], "correct_index": 2}, {"question": "Что означает немецкое слово «warnen»?", "choices": ["возражать", "мужество", "слуга", "предупреждать"], "correct_index": 3}, {"question": "Что означает немецкое слово «gerecht»?", "choices": ["возражать", "защищать", "справедливый", "мужество"], "correct_index": 2}], "banishment": [{"question": "Что означает немецкое слово «die Verbannung»?", "choices": ["гнев", "изгнанный", "несправедливость", "изгнание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Ungerechtigkeit»?", "choices": ["несправедливость", "изгнание", "изгнанный", "гнев"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["возвращаться", "несправедливость", "наказание", "гнев"], "correct_index": 3}, {"question": "Что означает немецкое слово «verbannt»?", "choices": ["возвращаться", "изгнанный", "наказание", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["изгнание", "прощание", "возвращаться", "изгнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Strafe»?", "choices": ["возвращаться", "гнев", "наказание", "изгнание"], "correct_index": 2}, {"question": "Что означает немецкое слово «zurückkehren»?", "choices": ["прощание", "изгнанный", "изгнание", "возвращаться"], "correct_index": 3}], "disguise": [{"question": "Что означает немецкое слово «die Verkleidung»?", "choices": ["неузнанный", "притворяться", "хитрость", "переодевание"], "correct_index": 3}, {"question": "Что означает немецкое слово «die List»?", "choices": ["неузнанный", "хитрость", "притворяться", "переодевание"], "correct_index": 1}, {"question": "Что означает немецкое слово «unerkannt»?", "choices": ["хитрость", "верный", "неузнанный", "притворяться"], "correct_index": 2}, {"question": "Что означает немецкое слово «vorgeben»?", "choices": ["притворяться", "неузнанный", "верный", "переодевание"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstellen»?", "choices": ["наниматься", "переодевание", "верный", "изменять"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bart»?", "choices": ["борода", "притворяться", "переодевание", "изменять"], "correct_index": 0}, {"question": "Что означает немецкое слово «anheuern»?", "choices": ["изменять", "наниматься", "борода", "неузнанный"], "correct_index": 1}, {"question": "Что означает немецкое слово «treu»?", "choices": ["хитрость", "изменять", "притворяться", "верный"], "correct_index": 3}], "service": [{"question": "Что означает немецкое слово «der Dienst»?", "choices": ["опасность", "служба", "защита", "охранять"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Schutz»?", "choices": ["охранять", "опасность", "служба", "защита"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Gefahr»?", "choices": ["стража", "сражаться", "защита", "опасность"], "correct_index": 3}, {"question": "Что означает немецкое слово «bewachen»?", "choices": ["стража", "служба", "защита", "охранять"], "correct_index": 3}, {"question": "Что означает немецкое слово «kämpfen»?", "choices": ["сражаться", "охранять", "опасность", "стража"], "correct_index": 0}, {"question": "Что означает немецкое слово «raten»?", "choices": ["сражаться", "охранять", "советовать", "защита"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Wache»?", "choices": ["стража", "охранять", "служба", "опасность"], "correct_index": 0}], "stocks": [{"question": "Что означает немецкое слово «die Strafe»?", "choices": ["сковывать", "стойкость", "наказание", "унижение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Demütigung»?", "choices": ["унижение", "сковывать", "наказание", "стойкость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Standhaftigkeit»?", "choices": ["колодка", "выдерживать", "унижение", "стойкость"], "correct_index": 3}, {"question": "Что означает немецкое слово «fesseln»?", "choices": ["унижение", "сковывать", "выдерживать", "позор"], "correct_index": 1}, {"question": "Что означает немецкое слово «erdulden»?", "choices": ["сковывать", "терпеть", "наказание", "выдерживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Stock»?", "choices": ["стойкость", "колодка", "позор", "терпеть"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausharren»?", "choices": ["наказание", "терпеть", "выдерживать", "позор"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Schande»?", "choices": ["наказание", "стойкость", "позор", "сковывать"], "correct_index": 2}], "storm_companion": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["буря", "сопровождать", "поддержка", "утешать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Beistand»?", "choices": ["утешать", "поддержка", "сопровождать", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «begleiten»?", "choices": ["убежище", "буря", "выдерживать", "сопровождать"], "correct_index": 3}, {"question": "Что означает немецкое слово «trösten»?", "choices": ["утешать", "выдерживать", "буря", "поддержка"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zuflucht»?", "choices": ["убежище", "буря", "холод", "выдерживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «durchhalten»?", "choices": ["сопровождать", "холод", "выдерживать", "убежище"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Kälte»?", "choices": ["буря", "холод", "утешать", "поддержка"], "correct_index": 1}], "final_loyalty": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["вечный", "смерть", "плакать", "прощание"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["вечный", "плакать", "прощание", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "истощение", "скорбь", "плакать"], "correct_index": 0}, {"question": "Что означает немецкое слово «weinen»?", "choices": ["сдаваться", "скорбь", "прощание", "плакать"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Erschöpfung»?", "choices": ["сдаваться", "прощание", "истощение", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «aufgeben»?", "choices": ["плакать", "смерть", "сдаваться", "вечный"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощание", "следовать", "скорбь", "плакать"], "correct_index": 2}, {"question": "Что означает немецкое слово «folgen»?", "choices": ["вечный", "скорбь", "следовать", "смерть"], "correct_index": 2}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Верность королю</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -445,15 +449,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Mut»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мужество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мужество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защищать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">предупреждать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">возражать</button>
                                         
@@ -461,49 +481,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «widersprechen»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verteidigen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">справедливый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «aufrichtig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">искренний</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">возражать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предупреждать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">искренний</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возражать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мужество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -515,27 +519,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">защищать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">искренний</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «warnen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">мужество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">предупреждать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">справедливый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">предупреждать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -545,9 +549,9 @@
                                     <div class="quiz-question">Что означает немецкое слово «gerecht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возражать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">защищать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">справедливый</button>
                                         
@@ -564,17 +568,17 @@
                         <div class="quiz-phase-container" data-phase="banishment">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Verbannung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -586,43 +590,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">несправедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнанный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">несправедливость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «verbannt»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнанный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -632,11 +636,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгнание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">изгнанный</button>
                                         
@@ -644,33 +648,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">возвращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">несправедливость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изгнание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «zurückkehren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">изгнанный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">возвращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">изгнание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">возвращаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -689,9 +693,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
                                         
@@ -703,9 +707,25 @@
                                     <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">переодевание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">неузнанный</button>
                                         
@@ -715,97 +735,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «unerkannt»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">неузнанный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">неузнанный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">переодевание</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">верный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">борода</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">изменять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «vorgeben»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изменять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наниматься</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «treu»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">борода</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наниматься</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verstellen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наниматься</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">изменять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">верный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «der Bart»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">верный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">переодевание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">борода</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «anheuern»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">переодевание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">наниматься</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «treu»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">верный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">борода</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">неузнанный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -818,79 +822,31 @@
                         <div class="quiz-phase-container" data-phase="service">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Dienst»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">служба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Schutz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">охранять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">опасность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">защита</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">охранять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сражаться</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">опасность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сражаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
                                         
@@ -898,33 +854,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «raten»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Gefahr»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">советовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сражаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">стража</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «bewachen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">защита</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">стража</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">служба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">защита</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охранять</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «kämpfen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">опасность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стража</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «raten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сражаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">советовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">служба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">защита</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стража</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">охранять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">опасность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -937,15 +941,15 @@
                         <div class="quiz-phase-container" data-phase="stocks">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Strafe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сковывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">унижение</button>
                                         
@@ -953,13 +957,13 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Demütigung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
@@ -969,15 +973,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Standhaftigkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">колодка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">колодка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
                                         
@@ -985,29 +1005,13 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «fesseln»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">унижение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">позор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «erdulden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сковывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
                                         
@@ -1017,49 +1021,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Stock»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">стойкость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сковывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">колодка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наказание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">колодка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">терпеть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «ausharren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">терпеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">терпеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">позор</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">наказание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">стойкость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">позор</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">сковывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Schande»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">позор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">терпеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">стойкость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1078,55 +1082,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">холод</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сопровождать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
                                         
@@ -1136,15 +1092,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Beistand»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">убежище</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поддержка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">поддержка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «begleiten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">сопровождать</button>
                                         
@@ -1152,17 +1124,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «trösten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">утешать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zuflucht»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выдерживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">холод</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выдерживать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «durchhalten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сопровождать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдерживать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">убежище</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1172,11 +1176,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Kälte»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">убежище</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">холод</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">утешать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">поддержка</button>
                                         
@@ -1191,15 +1195,15 @@
                         <div class="quiz-phase-container" data-phase="final_loyalty">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                                         
@@ -1207,49 +1211,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">плакать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сдаваться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">плакать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «ewig»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «weinen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1261,59 +1265,59 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «aufgeben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">плакать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">истощение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">истощение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">сдаваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вечный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сдаваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">следовать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">истощение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">скорбь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">плакать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «folgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">следовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1986,68 +1990,68 @@
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "защищать",
-                    "верность",
                     "мужество",
-                    "возражать"
+                    "возражать",
+                    "защищать",
+                    "верность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
-                    "защищать",
-                    "возражать",
-                    "справедливый",
-                    "верность"
+                    "предупреждать",
+                    "мужество",
+                    "искренний",
+                    "возражать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "справедливый",
                     "защищать",
-                    "предупреждать",
-                    "искренний"
+                    "возражать",
+                    "верность",
+                    "слуга"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "слуга",
-                    "возражать",
                     "искренний",
-                    "верность"
+                    "предупреждать",
+                    "возражать",
+                    "мужество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
                     "защищать",
-                    "мужество",
+                    "верность",
                     "слуга",
-                    "справедливый"
+                    "искренний"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «warnen»?",
                 "choices": [
-                    "верность",
+                    "возражать",
                     "мужество",
-                    "предупреждать",
-                    "справедливый"
+                    "слуга",
+                    "предупреждать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
-                    "слуга",
-                    "верность",
+                    "возражать",
+                    "защищать",
                     "справедливый",
                     "мужество"
                 ],
@@ -2509,49 +2513,49 @@
             {
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
-                    "несправедливость",
                     "гнев",
-                    "изгнание",
-                    "изгнанный"
+                    "изгнанный",
+                    "несправедливость",
+                    "изгнание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
                     "несправедливость",
-                    "гнев",
                     "изгнание",
-                    "изгнанный"
+                    "изгнанный",
+                    "гнев"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "изгнание",
+                    "возвращаться",
+                    "несправедливость",
                     "наказание",
-                    "гнев",
-                    "возвращаться"
+                    "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
+                    "возвращаться",
                     "изгнанный",
                     "наказание",
-                    "прощание",
-                    "возвращаться"
+                    "прощание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "возвращаться",
+                    "изгнание",
                     "прощание",
-                    "несправедливость",
+                    "возвращаться",
                     "изгнанный"
                 ],
                 "correctIndex": 1
@@ -2560,21 +2564,21 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "возвращаться",
-                    "прощание",
-                    "несправедливость",
-                    "наказание"
+                    "гнев",
+                    "наказание",
+                    "изгнание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "наказание",
+                    "прощание",
+                    "изгнанный",
                     "изгнание",
-                    "возвращаться",
-                    "гнев"
+                    "возвращаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3071,8 +3075,8 @@
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
                     "неузнанный",
-                    "хитрость",
                     "притворяться",
+                    "хитрость",
                     "переодевание"
                 ],
                 "correctIndex": 3
@@ -3080,72 +3084,72 @@
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "переодевание",
-                    "хитрость",
                     "неузнанный",
-                    "притворяться"
+                    "хитрость",
+                    "притворяться",
+                    "переодевание"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
+                    "хитрость",
+                    "верный",
                     "неузнанный",
-                    "притворяться",
-                    "переодевание",
-                    "наниматься"
+                    "притворяться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
-                    "хитрость",
-                    "борода",
-                    "наниматься",
-                    "притворяться"
+                    "притворяться",
+                    "неузнанный",
+                    "верный",
+                    "переодевание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstellen»?",
                 "choices": [
                     "наниматься",
-                    "изменять",
-                    "притворяться",
-                    "верный"
+                    "переодевание",
+                    "верный",
+                    "изменять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Bart»?",
                 "choices": [
-                    "верный",
+                    "борода",
+                    "притворяться",
                     "переодевание",
-                    "хитрость",
-                    "борода"
+                    "изменять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
-                    "хитрость",
-                    "верный",
-                    "переодевание",
-                    "наниматься"
+                    "изменять",
+                    "наниматься",
+                    "борода",
+                    "неузнанный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
                     "хитрость",
-                    "верный",
-                    "борода",
-                    "неузнанный"
+                    "изменять",
+                    "притворяться",
+                    "верный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3571,72 +3575,72 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
-                    "служба",
                     "опасность",
-                    "охранять",
-                    "защита"
+                    "служба",
+                    "защита",
+                    "охранять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
-                    "опасность",
-                    "защита",
                     "охранять",
-                    "служба"
+                    "опасность",
+                    "служба",
+                    "защита"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "опасность",
-                    "защита",
                     "стража",
-                    "служба"
+                    "сражаться",
+                    "защита",
+                    "опасность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «bewachen»?",
                 "choices": [
-                    "защита",
                     "стража",
-                    "охранять",
-                    "сражаться"
+                    "служба",
+                    "защита",
+                    "охранять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "опасность",
-                    "советовать",
                     "сражаться",
+                    "охранять",
+                    "опасность",
+                    "стража"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «raten»?",
+                "choices": [
+                    "сражаться",
+                    "охранять",
+                    "советовать",
                     "защита"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «raten»?",
-                "choices": [
-                    "защита",
-                    "советовать",
-                    "стража",
-                    "служба"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
-                    "защита",
                     "стража",
-                    "советовать",
-                    "служба"
+                    "охранять",
+                    "служба",
+                    "опасность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4105,82 +4109,82 @@
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
+                    "сковывать",
                     "стойкость",
                     "наказание",
-                    "сковывать",
                     "унижение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
-                    "сковывать",
                     "унижение",
+                    "сковывать",
                     "наказание",
                     "стойкость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
-                    "наказание",
-                    "стойкость",
                     "колодка",
-                    "позор"
+                    "выдерживать",
+                    "унижение",
+                    "стойкость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
                     "унижение",
-                    "позор",
-                    "наказание",
-                    "сковывать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erdulden»?",
-                "choices": [
-                    "терпеть",
-                    "стойкость",
-                    "наказание",
-                    "выдерживать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Stock»?",
-                "choices": [
-                    "позор",
                     "сковывать",
-                    "наказание",
-                    "колодка"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausharren»?",
-                "choices": [
-                    "терпеть",
                     "выдерживать",
-                    "позор",
-                    "сковывать"
+                    "позор"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «erdulden»?",
+                "choices": [
+                    "сковывать",
+                    "терпеть",
+                    "наказание",
+                    "выдерживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Stock»?",
+                "choices": [
+                    "стойкость",
+                    "колодка",
+                    "позор",
+                    "терпеть"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ausharren»?",
+                "choices": [
+                    "наказание",
+                    "терпеть",
+                    "выдерживать",
+                    "позор"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
+                    "наказание",
+                    "стойкость",
                     "позор",
-                    "выдерживать",
-                    "терпеть",
-                    "стойкость"
+                    "сковывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4627,68 +4631,68 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "буря",
+                    "сопровождать",
                     "поддержка",
-                    "утешать",
-                    "сопровождать"
+                    "утешать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
-                    "сопровождать",
-                    "буря",
                     "утешать",
-                    "поддержка"
+                    "поддержка",
+                    "сопровождать",
+                    "буря"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "сопровождать",
-                    "поддержка",
-                    "утешать",
-                    "буря"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «trösten»?",
-                "choices": [
-                    "холод",
                     "убежище",
-                    "поддержка",
-                    "утешать"
+                    "буря",
+                    "выдерживать",
+                    "сопровождать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Zuflucht»?",
+                "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
                     "утешать",
-                    "убежище",
-                    "поддержка",
-                    "сопровождать"
+                    "выдерживать",
+                    "буря",
+                    "поддержка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Zuflucht»?",
+                "choices": [
+                    "убежище",
+                    "буря",
+                    "холод",
+                    "выдерживать"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "убежище",
+                    "сопровождать",
+                    "холод",
                     "выдерживать",
-                    "утешать",
-                    "поддержка"
+                    "убежище"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "убежище",
-                    "холод",
                     "буря",
+                    "холод",
+                    "утешать",
                     "поддержка"
                 ],
                 "correctIndex": 1
@@ -5190,82 +5194,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "плакать",
                     "вечный",
                     "смерть",
+                    "плакать",
                     "прощание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "смерть",
-                    "прощание",
+                    "вечный",
                     "плакать",
-                    "вечный"
+                    "прощание",
+                    "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "плакать",
-                    "сдаваться",
-                    "следовать",
-                    "вечный"
+                    "вечный",
+                    "истощение",
+                    "скорбь",
+                    "плакать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
-                    "истощение",
-                    "плакать",
-                    "смерть",
-                    "вечный"
+                    "сдаваться",
+                    "скорбь",
+                    "прощание",
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
                     "сдаваться",
-                    "вечный",
+                    "прощание",
                     "истощение",
-                    "плакать"
+                    "вечный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
+                    "плакать",
+                    "смерть",
                     "сдаваться",
-                    "истощение",
-                    "прощание",
-                    "смерть"
+                    "вечный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "истощение",
+                    "прощание",
+                    "следовать",
                     "скорбь",
-                    "сдаваться",
-                    "прощание"
+                    "плакать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
-                    "сдаваться",
+                    "вечный",
+                    "скорбь",
                     "следовать",
-                    "истощение",
-                    "плакать"
+                    "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путешествие Короля Лира</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путешествие Короля Лира</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["править", "трон", "королевство", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["править", "трон", "власть", "королевство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["великолепный", "власть", "королевство", "корона"], "correct_index": 1}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["церемония", "трон", "провозглашать", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["великолепный", "провозглашать", "церемония", "корона"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["корона", "великолепный", "провозглашать", "трон"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["великолепный", "церемония", "править", "власть"], "correct_index": 1}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["великолепный", "корона", "трон", "церемония"], "correct_index": 0}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["неблагодарность", "гнев", "проклинать", "унижать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["унижать", "гнев", "проклинать", "неблагодарность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["неблагодарность", "проклятие", "изгонять", "обида"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["сожалеть", "проклинать", "изгонять", "обида"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["проклятие", "изгонять", "неблагодарность", "унижать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["проклинать", "сожалеть", "изгонять", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["изгонять", "обида", "унижать", "сожалеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["гнев", "проклятие", "неблагодарность", "унижать"], "correct_index": 1}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["отвергать", "жестокость", "покидать", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "отвергать", "жестокость", "покидать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["слеза", "отвергать", "жестокость", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["покидать", "слеза", "просить", "отчаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["просить", "слеза", "жестокость", "отчаяние"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["покидать", "просить", "нужда", "одиночество"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["жестокость", "покидать", "слеза", "отчаяние"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["покидать", "слеза", "нужда", "одиночество"], "correct_index": 2}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "буря", "гром", "безумие"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["буря", "бушевать", "гром", "безумие"], "correct_index": 3}, {"question": "Что означает немецкое слово «toben»?", "choices": ["бушевать", "молния", "гром", "кричать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["кричать", "гром", "безумие", "голый"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["кричать", "хаос", "буря", "молния"], "correct_index": 3}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "молния", "хаос", "гром"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["гром", "голый", "молния", "кричать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["безумие", "гром", "хаос", "молния"], "correct_index": 2}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищета", "нищий", "мёрзнуть", "бедный"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["мёрзнуть", "нищета", "нищий", "бедный"], "correct_index": 2}, {"question": "Что означает немецкое слово «arm»?", "choices": ["мёрзнуть", "шут", "нищета", "бедный"], "correct_index": 3}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["мёрзнуть", "познание", "страдать", "бедный"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["бедный", "мёрзнуть", "хижина", "шут"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "бедный", "мёрзнуть", "нищета"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["нищета", "шут", "мёрзнуть", "нищий"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["хижина", "нищий", "мёрзнуть", "познание"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["узнавать", "понимать", "раскаяние", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["узнавать", "понимать", "правда", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["узнавать", "правда", "раскаяние", "прозрение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["узнавать", "виновный", "правда", "раскаяние"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["виновный", "прозрение", "правда", "мудрость"], "correct_index": 3}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["правда", "прощать", "прозрение", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["узнавать", "прозрение", "мудрость", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["виновный", "мудрость", "правда", "узнавать"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["прощать", "конец", "умирать", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "прощать", "конец", "умирать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["умирать", "конец", "прощание", "сердце"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["скорбь", "прощать", "вечный", "конец"], "correct_index": 3}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["прощать", "прощание", "сердце", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["скорбь", "конец", "сердце", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["умирать", "вечный", "прощание", "скорбь"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "умирать", "сердце", "скорбь"], "correct_index": 0}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «der Thron»?", "choices": ["власть", "править", "трон", "королевство"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Königreich»?", "choices": ["власть", "править", "королевство", "трон"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Macht»?", "choices": ["править", "трон", "власть", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «herrschen»?", "choices": ["великолепный", "трон", "королевство", "править"], "correct_index": 3}, {"question": "Что означает немецкое слово «verkünden»?", "choices": ["великолепный", "королевство", "провозглашать", "власть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Krone»?", "choices": ["трон", "власть", "корона", "церемония"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Zeremonie»?", "choices": ["церемония", "трон", "королевство", "власть"], "correct_index": 0}, {"question": "Что означает немецкое слово «prächtig»?", "choices": ["править", "церемония", "великолепный", "королевство"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «demütigen»?", "choices": ["гнев", "унижать", "неблагодарность", "проклинать"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Zorn»?", "choices": ["неблагодарность", "проклинать", "гнев", "унижать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Undankbarkeit»?", "choices": ["неблагодарность", "сожалеть", "гнев", "проклятие"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfluchen»?", "choices": ["обида", "проклинать", "изгонять", "проклятие"], "correct_index": 1}, {"question": "Что означает немецкое слово «vertreiben»?", "choices": ["изгонять", "обида", "проклинать", "проклятие"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Kränkung»?", "choices": ["изгонять", "проклинать", "проклятие", "обида"], "correct_index": 3}, {"question": "Что означает немецкое слово «bereuen»?", "choices": ["проклятие", "сожалеть", "проклинать", "обида"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Fluch»?", "choices": ["проклятие", "гнев", "неблагодарность", "унижать"], "correct_index": 0}], "regan": [{"question": "Что означает немецкое слово «verlassen»?", "choices": ["покидать", "отчаяние", "жестокость", "отвергать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verstoßen»?", "choices": ["отчаяние", "жестокость", "отвергать", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["нужда", "слеза", "жестокость", "покидать"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Verzweiflung»?", "choices": ["нужда", "жестокость", "отчаяние", "слеза"], "correct_index": 2}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["отчаяние", "нужда", "одиночество", "просить"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Einsamkeit»?", "choices": ["одиночество", "слеза", "просить", "покидать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Träne»?", "choices": ["просить", "покидать", "слеза", "жестокость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Not»?", "choices": ["одиночество", "жестокость", "отчаяние", "нужда"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «der Sturm»?", "choices": ["бушевать", "гром", "безумие", "буря"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Wahnsinn»?", "choices": ["бушевать", "безумие", "гром", "буря"], "correct_index": 1}, {"question": "Что означает немецкое слово «toben»?", "choices": ["голый", "хаос", "молния", "бушевать"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Donner»?", "choices": ["хаос", "буря", "гром", "кричать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Blitz»?", "choices": ["голый", "молния", "буря", "бушевать"], "correct_index": 1}, {"question": "Что означает немецкое слово «schreien»?", "choices": ["кричать", "хаос", "голый", "молния"], "correct_index": 0}, {"question": "Что означает немецкое слово «nackt»?", "choices": ["хаос", "гром", "голый", "бушевать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Chaos»?", "choices": ["хаос", "голый", "гром", "бушевать"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «das Elend»?", "choices": ["нищий", "мёрзнуть", "бедный", "нищета"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Bettler»?", "choices": ["нищета", "нищий", "бедный", "мёрзнуть"], "correct_index": 1}, {"question": "Что означает немецкое слово «arm»?", "choices": ["бедный", "мёрзнуть", "познание", "нищий"], "correct_index": 0}, {"question": "Что означает немецкое слово «frieren»?", "choices": ["нищета", "бедный", "шут", "мёрзнуть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Hütte»?", "choices": ["мёрзнуть", "нищета", "хижина", "нищий"], "correct_index": 2}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["познание", "нищета", "страдать", "шут"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Narr»?", "choices": ["шут", "нищета", "страдать", "познание"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Erkenntnis»?", "choices": ["мёрзнуть", "бедный", "нищета", "познание"], "correct_index": 3}], "dover": [{"question": "Что означает немецкое слово «erkennen»?", "choices": ["раскаяние", "понимать", "правда", "узнавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verstehen»?", "choices": ["понимать", "раскаяние", "узнавать", "правда"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Wahrheit»?", "choices": ["правда", "узнавать", "прозрение", "мудрость"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Reue»?", "choices": ["понимать", "раскаяние", "узнавать", "мудрость"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Weisheit»?", "choices": ["мудрость", "правда", "раскаяние", "понимать"], "correct_index": 0}, {"question": "Что означает немецкое слово «vergeben»?", "choices": ["правда", "прощать", "понимать", "раскаяние"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Einsicht»?", "choices": ["мудрость", "узнавать", "прозрение", "правда"], "correct_index": 2}, {"question": "Что означает немецкое слово «schuldig»?", "choices": ["прозрение", "мудрость", "правда", "виновный"], "correct_index": 3}], "prison": [{"question": "Что означает немецкое слово «verzeihen»?", "choices": ["умирать", "конец", "прощать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Tod»?", "choices": ["смерть", "умирать", "конец", "прощать"], "correct_index": 0}, {"question": "Что означает немецкое слово «sterben»?", "choices": ["прощать", "вечный", "умирать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Ende»?", "choices": ["смерть", "конец", "вечный", "умирать"], "correct_index": 1}, {"question": "Что означает немецкое слово «das Herz»?", "choices": ["умирать", "скорбь", "сердце", "прощание"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Trauer»?", "choices": ["прощание", "вечный", "умирать", "скорбь"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Abschied»?", "choices": ["конец", "вечный", "прощание", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «ewig»?", "choices": ["вечный", "скорбь", "конец", "смерть"], "correct_index": 0}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Тронный зал</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,24 +433,40 @@
                         <div class="quiz-phase-container active" data-phase="throne">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Thron»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «das Königreich»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">править</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">править</button>
@@ -455,23 +475,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">власть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Macht»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -481,11 +485,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «herrschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">править</button>
                                         
@@ -493,47 +497,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verkünden»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">провозглашать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">церемония</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">корона</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">корона</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">великолепный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">королевство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">провозглашать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">трон</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">править</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
                                         
@@ -541,17 +513,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Krone»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">власть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">корона</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Zeremonie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">церемония</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трон</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">королевство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">власть</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «prächtig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">великолепный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">править</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">корона</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">церемония</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">трон</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">великолепный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">церемония</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">королевство</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,33 +568,33 @@
                         <div class="quiz-phase-container" data-phase="goneril">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «demütigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Zorn»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">неблагодарность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -602,11 +606,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">неблагодарность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гнев</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -616,29 +620,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «verfluchen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">обида</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «vertreiben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклятие</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -648,11 +652,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Kränkung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклятие</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
                                         
@@ -660,29 +664,29 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «bereuen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">изгонять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обида</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сожалеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сожалеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обида</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Fluch»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гнев</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проклятие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклятие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнев</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">неблагодарность</button>
                                         
@@ -699,31 +703,31 @@
                         <div class="quiz-phase-container" data-phase="regan">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «verlassen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verstoßen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                                         
@@ -735,9 +739,9 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">слеза</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                                         
@@ -747,49 +751,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Verzweiflung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">слеза</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отчаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нужда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">одиночество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">просить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">просить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Einsamkeit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">просить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">покидать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -799,29 +803,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Träne»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">просить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">покидать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">слеза</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">отчаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Not»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">покидать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">одиночество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">слеза</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">нужда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">отчаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">одиночество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нужда</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -834,45 +838,61 @@
                         <div class="quiz-phase-container" data-phase="storm">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Sturm»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Wahnsinn»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">буря</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">бушевать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">безумие</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «toben»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">бушевать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">безумие</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">буря</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «toben»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">буря</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                                         
@@ -882,33 +902,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «der Donner»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">безумие</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">голый</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Blitz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">буря</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -920,43 +924,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">кричать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хаос</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гром</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «nackt»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гром</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">кричать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «das Chaos»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">безумие</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хаос</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">гром</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">голый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хаос</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гром</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">молния</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бушевать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -969,65 +973,65 @@
                         <div class="quiz-phase-container" data-phase="hut">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «das Elend»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">бедный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «der Bettler»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">нищий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «arm»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">познание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «frieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">познание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шут</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бедный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мёрзнуть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1037,11 +1041,27 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Hütte»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">бедный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">хижина</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">познание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">шут</button>
                                         
@@ -1049,33 +1069,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">нищета</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Narr»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">нищета</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шут</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шут</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">нищета</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1085,11 +1089,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Erkenntnis»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">хижина</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мёрзнуть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">нищий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">бедный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мёрзнуть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">нищета</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">познание</button>
                                         
@@ -1104,15 +1108,31 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «erkennen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раскаяние</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
                                         
@@ -1120,65 +1140,49 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verstehen»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">понимать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Wahrheit»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">понимать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раскаяние</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">правда</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">раскаяние</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прозрение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Reue»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">виновный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Weisheit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">понимать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1192,23 +1196,7 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мудрость</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">узнавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прозрение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">мудрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">понимать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">раскаяние</button>
                                         
@@ -1216,17 +1204,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Einsicht»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мудрость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">узнавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прозрение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">правда</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «schuldig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">виновный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прозрение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">мудрость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">правда</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">узнавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">виновный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1239,15 +1243,15 @@
                         <div class="quiz-phase-container" data-phase="prison">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verzeihen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">прощать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
@@ -1261,43 +1265,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «sterben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сердце</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «das Ende»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">умирать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1307,29 +1311,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «das Herz»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">прощание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">прощание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Trauer»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">скорбь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">конец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умирать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">прощать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1339,13 +1343,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Abschied»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">конец</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">вечный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">прощание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1357,11 +1361,11 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">вечный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">умирать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скорбь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сердце</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">конец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">скорбь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2086,39 +2090,39 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
+                    "власть",
                     "править",
                     "трон",
-                    "королевство",
-                    "власть"
+                    "королевство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "править",
-                    "трон",
                     "власть",
-                    "королевство"
+                    "править",
+                    "королевство",
+                    "трон"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "великолепный",
+                    "править",
+                    "трон",
                     "власть",
-                    "королевство",
-                    "корона"
+                    "церемония"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "церемония",
+                    "великолепный",
                     "трон",
-                    "провозглашать",
+                    "королевство",
                     "править"
                 ],
                 "correctIndex": 3
@@ -2127,41 +2131,41 @@
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
                     "великолепный",
+                    "королевство",
                     "провозглашать",
-                    "церемония",
-                    "корона"
+                    "власть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
+                    "трон",
+                    "власть",
                     "корона",
-                    "великолепный",
-                    "провозглашать",
-                    "трон"
+                    "церемония"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "великолепный",
                     "церемония",
-                    "править",
+                    "трон",
+                    "королевство",
                     "власть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «prächtig»?",
                 "choices": [
+                    "править",
+                    "церемония",
                     "великолепный",
-                    "корона",
-                    "трон",
-                    "церемония"
+                    "королевство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2704,59 +2708,59 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "неблагодарность",
                     "гнев",
-                    "проклинать",
-                    "унижать"
+                    "унижать",
+                    "неблагодарность",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "унижать",
-                    "гнев",
+                    "неблагодарность",
                     "проклинать",
-                    "неблагодарность"
+                    "гнев",
+                    "унижать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
                     "неблагодарность",
-                    "проклятие",
-                    "изгонять",
-                    "обида"
+                    "сожалеть",
+                    "гнев",
+                    "проклятие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "сожалеть",
+                    "обида",
                     "проклинать",
                     "изгонять",
-                    "обида"
+                    "проклятие"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "проклятие",
                     "изгонять",
-                    "неблагодарность",
-                    "унижать"
+                    "обида",
+                    "проклинать",
+                    "проклятие"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "проклинать",
-                    "сожалеть",
                     "изгонять",
+                    "проклинать",
+                    "проклятие",
                     "обида"
                 ],
                 "correctIndex": 3
@@ -2764,22 +2768,22 @@
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "изгонять",
-                    "обида",
-                    "унижать",
-                    "сожалеть"
+                    "проклятие",
+                    "сожалеть",
+                    "проклинать",
+                    "обида"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "гнев",
                     "проклятие",
+                    "гнев",
                     "неблагодарность",
                     "унижать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3333,28 +3337,28 @@
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "отвергать",
-                    "жестокость",
                     "покидать",
-                    "отчаяние"
+                    "отчаяние",
+                    "жестокость",
+                    "отвергать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
                     "отчаяние",
-                    "отвергать",
                     "жестокость",
+                    "отвергать",
                     "покидать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
+                    "нужда",
                     "слеза",
-                    "отвергать",
                     "жестокость",
                     "покидать"
                 ],
@@ -3363,52 +3367,52 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "покидать",
-                    "слеза",
-                    "просить",
-                    "отчаяние"
+                    "нужда",
+                    "жестокость",
+                    "отчаяние",
+                    "слеза"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "просить",
-                    "слеза",
-                    "жестокость",
-                    "отчаяние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Einsamkeit»?",
-                "choices": [
-                    "покидать",
-                    "просить",
+                    "отчаяние",
                     "нужда",
-                    "одиночество"
+                    "одиночество",
+                    "просить"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Einsamkeit»?",
+                "choices": [
+                    "одиночество",
+                    "слеза",
+                    "просить",
+                    "покидать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "жестокость",
+                    "просить",
                     "покидать",
                     "слеза",
-                    "отчаяние"
+                    "жестокость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "покидать",
-                    "слеза",
-                    "нужда",
-                    "одиночество"
+                    "одиночество",
+                    "жестокость",
+                    "отчаяние",
+                    "нужда"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3950,81 +3954,81 @@
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "бушевать",
-                    "буря",
                     "гром",
-                    "безумие"
+                    "безумие",
+                    "буря"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "буря",
                     "бушевать",
-                    "гром",
-                    "безумие"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «toben»?",
-                "choices": [
-                    "бушевать",
-                    "молния",
-                    "гром",
-                    "кричать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Donner»?",
-                "choices": [
-                    "кричать",
-                    "гром",
                     "безумие",
-                    "голый"
+                    "гром",
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «der Blitz»?",
+                "question": "Что означает немецкое слово «toben»?",
                 "choices": [
-                    "кричать",
+                    "голый",
                     "хаос",
-                    "буря",
-                    "молния"
+                    "молния",
+                    "бушевать"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "хаос",
+                    "буря",
+                    "гром",
+                    "кричать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Blitz»?",
+                "choices": [
+                    "голый",
+                    "молния",
+                    "буря",
+                    "бушевать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
                     "кричать",
-                    "молния",
                     "хаос",
-                    "гром"
+                    "голый",
+                    "молния"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
+                    "хаос",
                     "гром",
                     "голый",
-                    "молния",
-                    "кричать"
+                    "бушевать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
-                    "безумие",
-                    "гром",
                     "хаос",
-                    "молния"
+                    "голый",
+                    "гром",
+                    "бушевать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4582,79 +4586,79 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "нищета",
                     "нищий",
                     "мёрзнуть",
-                    "бедный"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Bettler»?",
-                "choices": [
-                    "мёрзнуть",
-                    "нищета",
-                    "нищий",
-                    "бедный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «arm»?",
-                "choices": [
-                    "мёрзнуть",
-                    "шут",
-                    "нищета",
-                    "бедный"
+                    "бедный",
+                    "нищета"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «frieren»?",
+                "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
+                    "нищета",
+                    "нищий",
+                    "бедный",
+                    "мёрзнуть"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «arm»?",
+                "choices": [
+                    "бедный",
                     "мёрзнуть",
                     "познание",
-                    "страдать",
-                    "бедный"
+                    "нищий"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «frieren»?",
+                "choices": [
+                    "нищета",
+                    "бедный",
+                    "шут",
+                    "мёрзнуть"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "бедный",
                     "мёрзнуть",
+                    "нищета",
                     "хижина",
-                    "шут"
+                    "нищий"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "познание",
+                    "нищета",
                     "страдать",
-                    "бедный",
-                    "мёрзнуть",
-                    "нищета"
+                    "шут"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "нищета",
                     "шут",
-                    "мёрзнуть",
-                    "нищий"
+                    "нищета",
+                    "страдать",
+                    "познание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "хижина",
-                    "нищий",
                     "мёрзнуть",
+                    "бедный",
+                    "нищета",
                     "познание"
                 ],
                 "correctIndex": 3
@@ -5205,82 +5209,82 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
+                    "раскаяние",
+                    "понимать",
+                    "правда",
+                    "узнавать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verstehen»?",
+                "choices": [
                     "понимать",
                     "раскаяние",
+                    "узнавать",
                     "правда"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «verstehen»?",
-                "choices": [
-                    "узнавать",
-                    "понимать",
-                    "правда",
-                    "раскаяние"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "узнавать",
                     "правда",
-                    "раскаяние",
-                    "прозрение"
+                    "узнавать",
+                    "прозрение",
+                    "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
+                    "понимать",
+                    "раскаяние",
                     "узнавать",
-                    "виновный",
-                    "правда",
-                    "раскаяние"
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "виновный",
-                    "прозрение",
+                    "мудрость",
                     "правда",
-                    "мудрость"
+                    "раскаяние",
+                    "понимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
                     "правда",
                     "прощать",
-                    "прозрение",
-                    "мудрость"
+                    "понимать",
+                    "раскаяние"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsicht»?",
                 "choices": [
+                    "мудрость",
                     "узнавать",
                     "прозрение",
-                    "мудрость",
-                    "раскаяние"
+                    "правда"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
-                    "виновный",
+                    "прозрение",
                     "мудрость",
                     "правда",
-                    "узнавать"
+                    "виновный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5846,70 +5850,70 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "прощать",
-                    "конец",
                     "умирать",
+                    "конец",
+                    "прощать",
                     "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "смерть",
-                    "прощать",
+                    "умирать",
                     "конец",
-                    "умирать"
+                    "прощать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
+                    "прощать",
+                    "вечный",
                     "умирать",
-                    "конец",
-                    "прощание",
-                    "сердце"
+                    "смерть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "скорбь",
-                    "прощать",
+                    "смерть",
+                    "конец",
                     "вечный",
-                    "конец"
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "прощать",
-                    "прощание",
+                    "умирать",
+                    "скорбь",
                     "сердце",
-                    "смерть"
+                    "прощание"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "скорбь",
-                    "конец",
-                    "сердце",
-                    "прощать"
+                    "прощание",
+                    "вечный",
+                    "умирать",
+                    "скорбь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "умирать",
+                    "конец",
                     "вечный",
                     "прощание",
-                    "скорбь"
+                    "смерть"
                 ],
                 "correctIndex": 2
             },
@@ -5917,9 +5921,9 @@
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "вечный",
-                    "умирать",
-                    "сердце",
-                    "скорбь"
+                    "скорбь",
+                    "конец",
+                    "смерть"
                 ],
                 "correctIndex": 0
             }

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Освальда</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Освальда</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["служить", "послушание", "преданность", "слуга"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["послушание", "преданность", "слуга", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["преданность", "послушание", "служить", "слуга"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["служить", "послушание", "покорный", "управляющий"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["управляющий", "покорный", "преданность", "раболепный"], "correct_index": 0}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["управляющий", "покорный", "исполнять", "преданность"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["исполнять", "управляющий", "раболепный", "слуга"], "correct_index": 2}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["исполнять", "покорный", "служить", "управляющий"], "correct_index": 0}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "спешка", "поручение", "гонец"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["передавать", "поручение", "гонец", "спешка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["гонец", "послание", "спешка", "поручение"], "correct_index": 2}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["передавать", "послание", "спешка", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["торопиться", "спешить", "передавать", "спешка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["послание", "спешить", "спешка", "гонец"], "correct_index": 0}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["гонец", "спешить", "поручение", "торопиться"], "correct_index": 3}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["оскорблять", "оскорбление", "трусость", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорблять", "трусость", "оскорбление", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["дерзкий", "высмеивать", "оскорбление", "трусость"], "correct_index": 3}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["оскорблять", "оскорбление", "неуважение", "пренебрегать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["оскорблять", "высмеивать", "оскорбление", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «frech»?", "choices": ["трусливый", "дерзкий", "трусость", "оскорблять"], "correct_index": 1}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["оскорбление", "высмеивать", "оскорблять", "пренебрегать"], "correct_index": 3}, {"question": "Что означает немецкое слово «feige»?", "choices": ["трусость", "трусливый", "пренебрегать", "оскорбление"], "correct_index": 1}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпионить", "предательство", "скрытность", "шпион"], "correct_index": 3}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["скрытность", "шпион", "шпионить", "предательство"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["скрытность", "предательство", "шпион", "шпионить"], "correct_index": 0}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["вынюхивать", "шпион", "скрытность", "шпионить"], "correct_index": 3}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["подслушивать", "вынюхивать", "скрытность", "шпион"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["выдавать", "шпионить", "подслушивать", "предательство"], "correct_index": 0}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["предательство", "скрытность", "вынюхивать", "подслушивать"], "correct_index": 2}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["план", "коварство", "интрига", "ковать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["ковать", "план", "интрига", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["коварство", "интрига", "обманывать", "хитрый"], "correct_index": 0}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["ковать", "ловушка", "коварный", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["ловушка", "обманывать", "коварный", "коварство"], "correct_index": 1}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["коварство", "коварный", "хитрый", "план"], "correct_index": 1}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["хитрый", "план", "коварный", "интрига"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["хитрый", "обманывать", "ловушка", "интрига"], "correct_index": 2}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["охота", "преследовать", "гнаться", "преследование"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["преследование", "охота", "гнаться", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["преследовать", "выслеживать", "гнаться", "добыча"], "correct_index": 0}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["преследовать", "выслеживать", "травить", "гнаться"], "correct_index": 3}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["охота", "травить", "выслеживать", "преследовать"], "correct_index": 2}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["травить", "выслеживать", "преследование", "гнаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["добыча", "преследование", "выслеживать", "гнаться"], "correct_index": 0}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "поражение", "трусость", "смерть"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["поражение", "трусость", "смерть", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["поражение", "жалкий", "умолять", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["смерть", "падать", "умолять", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["проигрывать", "жалкий", "поражение", "смерть"], "correct_index": 0}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["смерть", "поражение", "жалкий", "хныкать"], "correct_index": 3}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["проигрывать", "жалкий", "хныкать", "умолять"], "correct_index": 3}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "проигрывать", "смерть", "жалкий"], "correct_index": 3}]}'>
+                    <div class="quiz-section" data-quiz-map='{"steward": [{"question": "Что означает немецкое слово «der Diener»?", "choices": ["слуга", "преданность", "послушание", "служить"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Gehorsam»?", "choices": ["преданность", "слуга", "послушание", "служить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Ergebenheit»?", "choices": ["преданность", "управляющий", "покорный", "послушание"], "correct_index": 0}, {"question": "Что означает немецкое слово «dienen»?", "choices": ["слуга", "преданность", "служить", "управляющий"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Verwalter»?", "choices": ["послушание", "слуга", "служить", "управляющий"], "correct_index": 3}, {"question": "Что означает немецкое слово «ergeben»?", "choices": ["раболепный", "покорный", "преданность", "служить"], "correct_index": 1}, {"question": "Что означает немецкое слово «unterwürfig»?", "choices": ["слуга", "преданность", "служить", "раболепный"], "correct_index": 3}, {"question": "Что означает немецкое слово «befolgen»?", "choices": ["преданность", "раболепный", "исполнять", "управляющий"], "correct_index": 2}], "messenger": [{"question": "Что означает немецкое слово «der Bote»?", "choices": ["передавать", "гонец", "спешка", "поручение"], "correct_index": 1}, {"question": "Что означает немецкое слово «der Auftrag»?", "choices": ["передавать", "поручение", "гонец", "спешка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Eile»?", "choices": ["спешить", "послание", "гонец", "спешка"], "correct_index": 3}, {"question": "Что означает немецкое слово «überbringen»?", "choices": ["поручение", "послание", "гонец", "передавать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hasten»?", "choices": ["спешить", "послание", "поручение", "торопиться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Botschaft»?", "choices": ["передавать", "послание", "гонец", "поручение"], "correct_index": 1}, {"question": "Что означает немецкое слово «eilen»?", "choices": ["спешка", "торопиться", "спешить", "гонец"], "correct_index": 1}], "insult": [{"question": "Что означает немецкое слово «die Beleidigung»?", "choices": ["трусость", "оскорбление", "неуважение", "оскорблять"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Respektlosigkeit»?", "choices": ["оскорбление", "трусость", "оскорблять", "неуважение"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["трусливый", "трусость", "оскорблять", "неуважение"], "correct_index": 1}, {"question": "Что означает немецкое слово «beleidigen»?", "choices": ["пренебрегать", "оскорблять", "оскорбление", "высмеивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["пренебрегать", "оскорбление", "дерзкий", "высмеивать"], "correct_index": 3}, {"question": "Что означает немецкое слово «frech»?", "choices": ["трусость", "оскорбление", "дерзкий", "пренебрегать"], "correct_index": 2}, {"question": "Что означает немецкое слово «missachten»?", "choices": ["оскорблять", "пренебрегать", "неуважение", "высмеивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «feige»?", "choices": ["пренебрегать", "трусость", "оскорбление", "трусливый"], "correct_index": 3}], "spy": [{"question": "Что означает немецкое слово «der Spion»?", "choices": ["шпион", "предательство", "шпионить", "скрытность"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Verrat»?", "choices": ["шпион", "скрытность", "предательство", "шпионить"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Heimlichkeit»?", "choices": ["шпионить", "предательство", "подслушивать", "скрытность"], "correct_index": 3}, {"question": "Что означает немецкое слово «spionieren»?", "choices": ["выдавать", "подслушивать", "шпионить", "шпион"], "correct_index": 2}, {"question": "Что означает немецкое слово «lauschen»?", "choices": ["подслушивать", "шпионить", "выдавать", "вынюхивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «verraten»?", "choices": ["скрытность", "вынюхивать", "выдавать", "подслушивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «schnüffeln»?", "choices": ["вынюхивать", "предательство", "выдавать", "скрытность"], "correct_index": 0}], "schemer": [{"question": "Что означает немецкое слово «die Intrige»?", "choices": ["интрига", "коварство", "ковать", "план"], "correct_index": 0}, {"question": "Что означает немецкое слово «der Plan»?", "choices": ["коварство", "план", "интрига", "ковать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Hinterlist»?", "choices": ["интрига", "ловушка", "ковать", "коварство"], "correct_index": 3}, {"question": "Что означает немецкое слово «schmieden»?", "choices": ["ловушка", "интрига", "коварство", "ковать"], "correct_index": 3}, {"question": "Что означает немецкое слово «hintergehen»?", "choices": ["ковать", "интрига", "план", "обманывать"], "correct_index": 3}, {"question": "Что означает немецкое слово «tückisch»?", "choices": ["интрига", "хитрый", "коварный", "план"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschlagen»?", "choices": ["ловушка", "обманывать", "хитрый", "коварство"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Falle»?", "choices": ["хитрый", "ловушка", "ковать", "обманывать"], "correct_index": 1}], "pursuer": [{"question": "Что означает немецкое слово «die Verfolgung»?", "choices": ["преследовать", "преследование", "охота", "гнаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Jagd»?", "choices": ["охота", "преследование", "преследовать", "гнаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verfolgen»?", "choices": ["добыча", "преследовать", "гнаться", "выслеживать"], "correct_index": 1}, {"question": "Что означает немецкое слово «jagen»?", "choices": ["преследование", "гнаться", "охота", "преследовать"], "correct_index": 1}, {"question": "Что означает немецкое слово «aufspüren»?", "choices": ["травить", "добыча", "выслеживать", "охота"], "correct_index": 2}, {"question": "Что означает немецкое слово «hetzen»?", "choices": ["травить", "гнаться", "добыча", "выслеживать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Beute»?", "choices": ["гнаться", "преследовать", "выслеживать", "добыча"], "correct_index": 3}], "coward_death": [{"question": "Что означает немецкое слово «der Tod»?", "choices": ["падать", "смерть", "трусость", "поражение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Feigheit»?", "choices": ["смерть", "трусость", "поражение", "падать"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Niederlage»?", "choices": ["умолять", "падать", "хныкать", "поражение"], "correct_index": 3}, {"question": "Что означает немецкое слово «fallen»?", "choices": ["падать", "умолять", "поражение", "жалкий"], "correct_index": 0}, {"question": "Что означает немецкое слово «unterliegen»?", "choices": ["умолять", "поражение", "проигрывать", "смерть"], "correct_index": 2}, {"question": "Что означает немецкое слово «wimmern»?", "choices": ["хныкать", "смерть", "жалкий", "падать"], "correct_index": 0}, {"question": "Что означает немецкое слово «betteln»?", "choices": ["хныкать", "проигрывать", "умолять", "жалкий"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbärmlich»?", "choices": ["трусость", "проигрывать", "жалкий", "поражение"], "correct_index": 2}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Управляющий</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,31 +433,31 @@
                         <div class="quiz-phase-container active" data-phase="steward">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Diener»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «der Gehorsam»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">послушание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                                         
@@ -467,25 +471,25 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">послушание</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «dienen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">служить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">послушание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">покорный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
                                         
@@ -493,17 +497,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «der Verwalter»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">послушание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -513,43 +517,43 @@
                                     <div class="quiz-question">Что означает немецкое слово «ergeben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">управляющий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">раболепный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">преданность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">служить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «unterwürfig»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">слуга</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">управляющий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">раболепный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">слуга</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">раболепный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «befolgen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">исполнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">преданность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">покорный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">раболепный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">служить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">исполнять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">управляющий</button>
                                         
@@ -564,17 +568,17 @@
                         <div class="quiz-phase-container" data-phase="messenger">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Bote»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спешка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гонец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -596,47 +600,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Eile»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">торопиться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">передавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">спешка</button>
                                         
@@ -644,33 +616,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «überbringen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">послание</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">поручение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">спешка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">передавать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «hasten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">гонец</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спешить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">спешить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">поручение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">торопиться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Botschaft»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">передавать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">послание</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">гонец</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поручение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «eilen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">спешка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">торопиться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">спешить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гонец</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -687,13 +691,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Beleidigung»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -703,109 +707,109 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Respektlosigkeit»?</div>
                                     <div class="quiz-choices">
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «frech»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">дерзкий</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
+                                    <div class="quiz-choices">
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">пренебрегать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">высмеивать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «feige»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">пренебрегать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">дерзкий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">трусость</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «beleidigen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">оскорбление</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">неуважение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорблять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорбление</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">неуважение</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «frech»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">трусливый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">дерзкий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорблять</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «missachten»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">оскорбление</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">высмеивать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">оскорблять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пренебрегать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «feige»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">трусость</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">трусливый</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пренебрегать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">оскорбление</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">трусливый</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -818,65 +822,65 @@
                         <div class="quiz-phase-container" data-phase="spy">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «der Spion»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">шпион</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">предательство</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">шпионить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «der Verrat»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Heimlichkeit»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">шпион</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «spionieren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шпион</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">подслушивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">шпионить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шпионить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -888,43 +892,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">подслушивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">скрытность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">шпион</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вынюхивать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verraten»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">выдавать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">скрытность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">шпионить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вынюхивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">подслушивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «schnüffeln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">предательство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вынюхивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">скрытность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">предательство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вынюхивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выдавать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">подслушивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">скрытность</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -937,17 +941,17 @@
                         <div class="quiz-phase-container" data-phase="schemer">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Intrige»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">коварство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -957,75 +961,75 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Plan»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">план</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">интрига</button>
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «die Hinterlist»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">обманывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрый</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «schmieden»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">коварство</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ковать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «hintergehen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ковать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">интрига</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">план</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «tückisch»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">коварство</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">интрига</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">коварный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">план</button>
                                         
@@ -1033,33 +1037,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verschlagen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ловушка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">план</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">коварный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">коварство</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Falle»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">хитрый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">обманывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">ловушка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">ловушка</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ковать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">интрига</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">обманывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1072,65 +1076,65 @@
                         <div class="quiz-phase-container" data-phase="pursuer">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Verfolgung»?</div>
                                     <div class="quiz-choices">
                                         
+                                        <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
+                                    <div class="quiz-choices">
+                                        
                                         <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">преследовать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">преследование</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Jagd»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">преследование</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">охота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">охота</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «verfolgen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">гнаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «jagen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">преследовать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">травить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,13 +1144,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «aufspüren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">охота</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">травить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">добыча</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">преследовать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">охота</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1158,27 +1162,27 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">травить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">выслеживать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">гнаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">преследование</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">добыча</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выслеживать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Beute»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">добыча</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">гнаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">преследование</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">преследовать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">выслеживать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">гнаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">добыча</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1191,17 +1195,17 @@
                         <div class="quiz-phase-container" data-phase="coward_death">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «der Tod»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">трусость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1211,11 +1215,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Feigheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">трусость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                                         
@@ -1223,31 +1227,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «die Niederlage»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">поражение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">падать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                                         
@@ -1255,15 +1243,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «fallen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">падать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">умолять</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «unterliegen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">умолять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проигрывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">смерть</button>
                                         
@@ -1271,39 +1275,39 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «wimmern»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">поражение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">смерть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">хныкать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">падать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «betteln»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проигрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хныкать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жалкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хныкать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">умолять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">умолять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «erbärmlich»?</div>
                                     <div class="quiz-choices">
                                         
@@ -1311,9 +1315,9 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">проигрывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">смерть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жалкий</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жалкий</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">поражение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1984,82 +1988,82 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "служить",
-                    "послушание",
-                    "преданность",
-                    "слуга"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Gehorsam»?",
-                "choices": [
-                    "послушание",
-                    "преданность",
                     "слуга",
+                    "преданность",
+                    "послушание",
                     "служить"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «der Gehorsam»?",
+                "choices": [
+                    "преданность",
+                    "слуга",
+                    "послушание",
+                    "служить"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
                     "преданность",
-                    "послушание",
-                    "служить",
-                    "слуга"
+                    "управляющий",
+                    "покорный",
+                    "послушание"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
+                    "слуга",
+                    "преданность",
                     "служить",
-                    "послушание",
-                    "покорный",
                     "управляющий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "управляющий",
-                    "покорный",
-                    "преданность",
-                    "раболепный"
+                    "послушание",
+                    "слуга",
+                    "служить",
+                    "управляющий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
-                    "управляющий",
+                    "раболепный",
                     "покорный",
-                    "исполнять",
-                    "преданность"
+                    "преданность",
+                    "служить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "исполнять",
-                    "управляющий",
-                    "раболепный",
-                    "слуга"
+                    "слуга",
+                    "преданность",
+                    "служить",
+                    "раболепный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
+                    "преданность",
+                    "раболепный",
                     "исполнять",
-                    "покорный",
-                    "служить",
                     "управляющий"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2486,11 +2490,11 @@
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
                     "передавать",
+                    "гонец",
                     "спешка",
-                    "поручение",
-                    "гонец"
+                    "поручение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Auftrag»?",
@@ -2505,52 +2509,52 @@
             {
                 "question": "Что означает немецкое слово «die Eile»?",
                 "choices": [
-                    "гонец",
+                    "спешить",
                     "послание",
-                    "спешка",
-                    "поручение"
+                    "гонец",
+                    "спешка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
-                    "передавать",
+                    "поручение",
                     "послание",
-                    "спешка",
-                    "торопиться"
+                    "гонец",
+                    "передавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
-                    "торопиться",
                     "спешить",
-                    "передавать",
-                    "спешка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Botschaft»?",
-                "choices": [
                     "послание",
-                    "спешить",
-                    "спешка",
-                    "гонец"
+                    "поручение",
+                    "торопиться"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Botschaft»?",
+                "choices": [
+                    "передавать",
+                    "послание",
+                    "гонец",
+                    "поручение"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "гонец",
+                    "спешка",
+                    "торопиться",
                     "спешить",
-                    "поручение",
-                    "торопиться"
+                    "гонец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3025,19 +3029,19 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "оскорблять",
-                    "оскорбление",
                     "трусость",
-                    "неуважение"
+                    "оскорбление",
+                    "неуважение",
+                    "оскорблять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорблять",
-                    "трусость",
                     "оскорбление",
+                    "трусость",
+                    "оскорблять",
                     "неуважение"
                 ],
                 "correctIndex": 3
@@ -3045,62 +3049,62 @@
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "дерзкий",
-                    "высмеивать",
-                    "оскорбление",
-                    "трусость"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «beleidigen»?",
-                "choices": [
+                    "трусливый",
+                    "трусость",
                     "оскорблять",
-                    "оскорбление",
-                    "неуважение",
-                    "пренебрегать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verhöhnen»?",
-                "choices": [
-                    "оскорблять",
-                    "высмеивать",
-                    "оскорбление",
                     "неуважение"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «frech»?",
+                "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
-                    "трусливый",
-                    "дерзкий",
-                    "трусость",
-                    "оскорблять"
+                    "пренебрегать",
+                    "оскорблять",
+                    "оскорбление",
+                    "высмеивать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «missachten»?",
+                "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
+                    "пренебрегать",
                     "оскорбление",
-                    "высмеивать",
-                    "оскорблять",
-                    "пренебрегать"
+                    "дерзкий",
+                    "высмеивать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «feige»?",
+                "question": "Что означает немецкое слово «frech»?",
                 "choices": [
                     "трусость",
-                    "трусливый",
+                    "оскорбление",
+                    "дерзкий",
+                    "пренебрегать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «missachten»?",
+                "choices": [
+                    "оскорблять",
                     "пренебрегать",
-                    "оскорбление"
+                    "неуважение",
+                    "высмеивать"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «feige»?",
+                "choices": [
+                    "пренебрегать",
+                    "трусость",
+                    "оскорбление",
+                    "трусливый"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3531,72 +3535,72 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
-                    "шпионить",
-                    "предательство",
-                    "скрытность",
-                    "шпион"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Verrat»?",
-                "choices": [
-                    "скрытность",
                     "шпион",
-                    "шпионить",
-                    "предательство"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Heimlichkeit»?",
-                "choices": [
-                    "скрытность",
                     "предательство",
-                    "шпион",
-                    "шпионить"
+                    "шпионить",
+                    "скрытность"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «spionieren»?",
+                "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "вынюхивать",
                     "шпион",
                     "скрытность",
+                    "предательство",
                     "шпионить"
                 ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Heimlichkeit»?",
+                "choices": [
+                    "шпионить",
+                    "предательство",
+                    "подслушивать",
+                    "скрытность"
+                ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «spionieren»?",
+                "choices": [
+                    "выдавать",
+                    "подслушивать",
+                    "шпионить",
+                    "шпион"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
                     "подслушивать",
-                    "вынюхивать",
-                    "скрытность",
-                    "шпион"
+                    "шпионить",
+                    "выдавать",
+                    "вынюхивать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
+                    "скрытность",
+                    "вынюхивать",
                     "выдавать",
-                    "шпионить",
-                    "подслушивать",
-                    "предательство"
+                    "подслушивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
-                    "предательство",
-                    "скрытность",
                     "вынюхивать",
-                    "подслушивать"
+                    "предательство",
+                    "выдавать",
+                    "скрытность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4083,82 +4087,82 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "план",
-                    "коварство",
                     "интрига",
-                    "ковать"
+                    "коварство",
+                    "ковать",
+                    "план"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "ковать",
+                    "коварство",
                     "план",
                     "интрига",
-                    "коварство"
+                    "ковать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hinterlist»?",
                 "choices": [
-                    "коварство",
                     "интрига",
-                    "обманывать",
-                    "хитрый"
+                    "ловушка",
+                    "ковать",
+                    "коварство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "ковать",
                     "ловушка",
-                    "коварный",
-                    "интрига"
+                    "интрига",
+                    "коварство",
+                    "ковать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
-                    "ловушка",
-                    "обманывать",
-                    "коварный",
-                    "коварство"
+                    "ковать",
+                    "интрига",
+                    "план",
+                    "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "коварство",
-                    "коварный",
+                    "интрига",
                     "хитрый",
+                    "коварный",
                     "план"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
+                    "ловушка",
+                    "обманывать",
                     "хитрый",
-                    "план",
-                    "коварный",
-                    "интрига"
+                    "коварство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
                     "хитрый",
-                    "обманывать",
                     "ловушка",
-                    "интрига"
+                    "ковать",
+                    "обманывать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4594,50 +4598,50 @@
             {
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
-                    "охота",
                     "преследовать",
-                    "гнаться",
-                    "преследование"
+                    "преследование",
+                    "охота",
+                    "гнаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
-                    "преследование",
                     "охота",
+                    "преследование",
+                    "преследовать",
+                    "гнаться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verfolgen»?",
+                "choices": [
+                    "добыча",
+                    "преследовать",
                     "гнаться",
+                    "выслеживать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «jagen»?",
+                "choices": [
+                    "преследование",
+                    "гнаться",
+                    "охота",
                     "преследовать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «verfolgen»?",
-                "choices": [
-                    "преследовать",
-                    "выслеживать",
-                    "гнаться",
-                    "добыча"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «jagen»?",
-                "choices": [
-                    "преследовать",
-                    "выслеживать",
-                    "травить",
-                    "гнаться"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «aufspüren»?",
                 "choices": [
-                    "охота",
                     "травить",
+                    "добыча",
                     "выслеживать",
-                    "преследовать"
+                    "охота"
                 ],
                 "correctIndex": 2
             },
@@ -4645,21 +4649,21 @@
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
                     "травить",
-                    "выслеживать",
-                    "преследование",
-                    "гнаться"
+                    "гнаться",
+                    "добыча",
+                    "выслеживать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "добыча",
-                    "преследование",
+                    "гнаться",
+                    "преследовать",
                     "выслеживать",
-                    "гнаться"
+                    "добыча"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5146,18 +5150,18 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "падать",
-                    "поражение",
+                    "смерть",
                     "трусость",
-                    "смерть"
+                    "поражение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "поражение",
-                    "трусость",
                     "смерть",
+                    "трусость",
+                    "поражение",
                     "падать"
                 ],
                 "correctIndex": 1
@@ -5165,62 +5169,62 @@
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "поражение",
-                    "жалкий",
                     "умолять",
+                    "падать",
+                    "хныкать",
+                    "поражение"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «fallen»?",
+                "choices": [
+                    "падать",
+                    "умолять",
+                    "поражение",
+                    "жалкий"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «unterliegen»?",
+                "choices": [
+                    "умолять",
+                    "поражение",
+                    "проигрывать",
+                    "смерть"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «wimmern»?",
+                "choices": [
+                    "хныкать",
+                    "смерть",
+                    "жалкий",
                     "падать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «fallen»?",
-                "choices": [
-                    "смерть",
-                    "падать",
-                    "умолять",
-                    "поражение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «unterliegen»?",
-                "choices": [
-                    "проигрывать",
-                    "жалкий",
-                    "поражение",
-                    "смерть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «wimmern»?",
-                "choices": [
-                    "смерть",
-                    "поражение",
-                    "жалкий",
-                    "хныкать"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "проигрывать",
-                    "жалкий",
                     "хныкать",
-                    "умолять"
+                    "проигрывать",
+                    "умолять",
+                    "жалкий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbärmlich»?",
                 "choices": [
                     "трусость",
                     "проигрывать",
-                    "смерть",
-                    "жалкий"
+                    "жалкий",
+                    "поражение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 Путь Реганы</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="../index.html" class="home-link">
+                    <span class="arrow">←</span>
+                    <span class="text">На главную</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">СПИСОК ИЗУЧЕНИЯ</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 Путь Реганы</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">
@@ -411,7 +415,7 @@
                 </button>
                 <div class="exercise-content collapsed">
                     
-                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["превосходить", "состязаться", "фальшь", "притворяться"], "correct_index": 3}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "фальшь", "превосходить", "состязаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "притворяться", "алчность", "выманивать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["фальшь", "хитрость", "разыгрывать", "состязаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["превосходить", "разыгрывать", "притворяться", "алчность"], "correct_index": 1}, {"question": "Что означает немецкое слово «die List»?", "choices": ["алчность", "превосходить", "хитрость", "выманивать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["превосходить", "выманивать", "хитрость", "фальшь"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["превосходить", "разыгрывать", "алчность", "хитрость"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["заговорить", "делить", "союз", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["делить", "планировать", "заговорить", "союз"], "correct_index": 0}, {"question": "Что означает немецкое слово «planen»?", "choices": ["стратегия", "заговорить", "сговор", "планировать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["заговорить", "союз", "планировать", "сговор"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["планировать", "сговор", "делить", "стратегия"], "correct_index": 1}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["союз", "стратегия", "делить", "договариваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["союз", "сговор", "планировать", "стратегия"], "correct_index": 3}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "унижать", "пытать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["унижать", "злоба", "пытать", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["жёсткость", "насмехаться", "пытать", "злоба"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["пытать", "злоба", "жёсткость", "жестокость"], "correct_index": 1}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестокость", "жестоко обращаться", "злоба", "насмехаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["пытать", "унижать", "жёсткость", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жестоко обращаться", "пытать", "отвергать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["пытать", "унижать", "отвергать", "жестокость"], "correct_index": 3}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["садизм", "наслаждаться", "ослеплять", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["ослеплять", "садизм", "наслаждаться", "выкалывать"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["беспощадный", "брутальность", "наслаждаться", "пытка"], "correct_index": 2}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["растаптывать", "беспощадный", "выкалывать", "ослеплять"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["выкалывать", "брутальность", "пытка", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["пытка", "брутальность", "выкалывать", "беспощадный"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["беспощадный", "растаптывать", "брутальность", "наслаждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["растаптывать", "ослеплять", "беспощадный", "брутальность"], "correct_index": 0}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["соблазнять", "вожделение", "вдова", "вожделеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["соблазнять", "вожделение", "вдова", "вожделеть"], "correct_index": 3}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["соблазнять", "добиваться", "вдова", "вожделение"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["похоть", "заманивать", "соблазнять", "вожделение"], "correct_index": 3}, {"question": "Что означает немецкое слово «locken»?", "choices": ["заманивать", "добиваться", "похоть", "вдова"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["вожделеть", "вдова", "вожделение", "похоть"], "correct_index": 3}, {"question": "Что означает немецкое слово «werben»?", "choices": ["похоть", "соблазнять", "добиваться", "вожделеть"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["угрожать", "соперничество", "ненавидеть", "соревноваться"], "correct_index": 3}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "соревноваться", "соперничество", "угрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["соперничество", "соревноваться", "угрожать", "ненавидеть"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соревноваться", "ненавидеть", "соперничество", "угрожать"], "correct_index": 2}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["ненавидеть", "бороться", "угрожать", "подозревать"], "correct_index": 1}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["не доверять", "соперничество", "бороться", "угрожать"], "correct_index": 0}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["подозревать", "ненавидеть", "соперничество", "бороться"], "correct_index": 0}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["мучение", "отравленный", "страдать", "издыхать"], "correct_index": 1}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["страдать", "издыхать", "мучение", "отравленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклинать", "страдать", "издыхать", "мучение"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["расплачиваться", "проклинать", "рок", "мучение"], "correct_index": 3}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклинать", "рок", "отравленный", "мучение"], "correct_index": 0}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "отравленный", "рок", "страдать"], "correct_index": 2}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["издыхать", "расплачиваться", "отравленный", "рок"], "correct_index": 1}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["проклятый", "отравленный", "рок", "издыхать"], "correct_index": 0}]}'>
+                    <div class="quiz-section" data-quiz-map='{"throne": [{"question": "Что означает немецкое слово «vortäuschen»?", "choices": ["фальшь", "притворяться", "состязаться", "превосходить"], "correct_index": 1}, {"question": "Что означает немецкое слово «übertreffen»?", "choices": ["притворяться", "состязаться", "фальшь", "превосходить"], "correct_index": 3}, {"question": "Что означает немецкое слово «wetteifern»?", "choices": ["состязаться", "алчность", "фальшь", "разыгрывать"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Falschheit»?", "choices": ["алчность", "фальшь", "превосходить", "состязаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «vorspielen»?", "choices": ["разыгрывать", "хитрость", "выманивать", "фальшь"], "correct_index": 0}, {"question": "Что означает немецкое слово «die List»?", "choices": ["фальшь", "хитрость", "притворяться", "выманивать"], "correct_index": 1}, {"question": "Что означает немецкое слово «erschleichen»?", "choices": ["разыгрывать", "выманивать", "алчность", "состязаться"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Habgier»?", "choices": ["хитрость", "превосходить", "алчность", "притворяться"], "correct_index": 2}], "goneril": [{"question": "Что означает немецкое слово «das Bündnis»?", "choices": ["заговорить", "планировать", "делить", "союз"], "correct_index": 3}, {"question": "Что означает немецкое слово «teilen»?", "choices": ["союз", "заговорить", "делить", "планировать"], "correct_index": 2}, {"question": "Что означает немецкое слово «planen»?", "choices": ["заговорить", "стратегия", "планировать", "договариваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «verschwören»?", "choices": ["сговор", "делить", "заговорить", "стратегия"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Absprache»?", "choices": ["сговор", "заговорить", "планировать", "стратегия"], "correct_index": 0}, {"question": "Что означает немецкое слово «vereinbaren»?", "choices": ["планировать", "союз", "договариваться", "сговор"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Strategie»?", "choices": ["заговорить", "сговор", "стратегия", "договариваться"], "correct_index": 2}], "regan": [{"question": "Что означает немецкое слово «foltern»?", "choices": ["насмехаться", "унижать", "пытать", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «erniedrigen»?", "choices": ["злоба", "насмехаться", "унижать", "пытать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verhöhnen»?", "choices": ["насмехаться", "жестокость", "злоба", "жестоко обращаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Bosheit»?", "choices": ["пытать", "жёсткость", "злоба", "отвергать"], "correct_index": 2}, {"question": "Что означает немецкое слово «misshandeln»?", "choices": ["жестокость", "отвергать", "жестоко обращаться", "злоба"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Härte»?", "choices": ["жёсткость", "отвергать", "жестокость", "насмехаться"], "correct_index": 0}, {"question": "Что означает немецкое слово «abweisen»?", "choices": ["жестокость", "насмехаться", "отвергать", "жёсткость"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Grausamkeit»?", "choices": ["жёсткость", "жестокость", "унижать", "отвергать"], "correct_index": 1}], "storm": [{"question": "Что означает немецкое слово «blenden»?", "choices": ["выкалывать", "наслаждаться", "ослеплять", "садизм"], "correct_index": 2}, {"question": "Что означает немецкое слово «der Sadismus»?", "choices": ["выкалывать", "садизм", "наслаждаться", "ослеплять"], "correct_index": 1}, {"question": "Что означает немецкое слово «genießen»?", "choices": ["выкалывать", "наслаждаться", "пытка", "садизм"], "correct_index": 1}, {"question": "Что означает немецкое слово «ausstechen»?", "choices": ["пытка", "беспощадный", "выкалывать", "наслаждаться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Folter»?", "choices": ["садизм", "беспощадный", "пытка", "выкалывать"], "correct_index": 2}, {"question": "Что означает немецкое слово «erbarmungslos»?", "choices": ["выкалывать", "беспощадный", "брутальность", "пытка"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Brutalität»?", "choices": ["садизм", "ослеплять", "растаптывать", "брутальность"], "correct_index": 3}, {"question": "Что означает немецкое слово «zertreten»?", "choices": ["беспощадный", "растаптывать", "ослеплять", "брутальность"], "correct_index": 1}], "hut": [{"question": "Что означает немецкое слово «die Witwe»?", "choices": ["вожделение", "вожделеть", "вдова", "соблазнять"], "correct_index": 2}, {"question": "Что означает немецкое слово «begehren»?", "choices": ["вожделеть", "соблазнять", "вдова", "вожделение"], "correct_index": 0}, {"question": "Что означает немецкое слово «verführen»?", "choices": ["похоть", "добиваться", "вожделеть", "соблазнять"], "correct_index": 3}, {"question": "Что означает немецкое слово «die Begierde»?", "choices": ["соблазнять", "похоть", "добиваться", "вожделение"], "correct_index": 3}, {"question": "Что означает немецкое слово «locken»?", "choices": ["вожделеть", "заманивать", "добиваться", "вожделение"], "correct_index": 1}, {"question": "Что означает немецкое слово «die Lust»?", "choices": ["похоть", "вожделеть", "добиваться", "соблазнять"], "correct_index": 0}, {"question": "Что означает немецкое слово «werben»?", "choices": ["заманивать", "вожделение", "добиваться", "соблазнять"], "correct_index": 2}], "dover": [{"question": "Что означает немецкое слово «wettkämpfen»?", "choices": ["соревноваться", "угрожать", "ненавидеть", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «hassen»?", "choices": ["ненавидеть", "соревноваться", "угрожать", "соперничество"], "correct_index": 0}, {"question": "Что означает немецкое слово «bedrohen»?", "choices": ["угрожать", "соперничество", "ненавидеть", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «die Rivalität»?", "choices": ["соперничество", "не доверять", "ненавидеть", "бороться"], "correct_index": 0}, {"question": "Что означает немецкое слово «bekämpfen»?", "choices": ["угрожать", "бороться", "соперничество", "соревноваться"], "correct_index": 1}, {"question": "Что означает немецкое слово «misstrauen»?", "choices": ["ненавидеть", "не доверять", "угрожать", "подозревать"], "correct_index": 1}, {"question": "Что означает немецкое слово «argwöhnen»?", "choices": ["бороться", "угрожать", "подозревать", "ненавидеть"], "correct_index": 2}], "prison": [{"question": "Что означает немецкое слово «vergiftet»?", "choices": ["страдать", "издыхать", "мучение", "отравленный"], "correct_index": 3}, {"question": "Что означает немецкое слово «leiden»?", "choices": ["мучение", "отравленный", "издыхать", "страдать"], "correct_index": 3}, {"question": "Что означает немецкое слово «verenden»?", "choices": ["проклинать", "рок", "издыхать", "расплачиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «die Qual»?", "choices": ["мучение", "рок", "проклинать", "отравленный"], "correct_index": 0}, {"question": "Что означает немецкое слово «verwünschen»?", "choices": ["проклятый", "мучение", "проклинать", "издыхать"], "correct_index": 2}, {"question": "Что означает немецкое слово «das Verhängnis»?", "choices": ["мучение", "проклинать", "рок", "расплачиваться"], "correct_index": 2}, {"question": "Что означает немецкое слово «büßen»?", "choices": ["страдать", "издыхать", "расплачиваться", "проклинать"], "correct_index": 2}, {"question": "Что означает немецкое слово «verflucht»?", "choices": ["отравленный", "издыхать", "проклятый", "рок"], "correct_index": 2}]}'>
                         <div class="quiz-stats-panel" aria-live="polite" data-phase="">
                             <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>Притворная любовь</span></h3>
                             <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
@@ -429,33 +433,33 @@
                         <div class="quiz-phase-container active" data-phase="throne">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «vortäuschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">состязаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «übertreffen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">притворяться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">состязаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">превосходить</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -467,25 +471,25 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">состязаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">притворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">алчность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">фальшь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">разыгрывать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Falschheit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">фальшь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">разыгрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">превосходить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                                         
@@ -493,31 +497,31 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «vorspielen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">выманивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">алчность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die List»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">алчность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">фальшь</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">хитрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">притворяться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">выманивать</button>
                                         
@@ -529,13 +533,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «erschleichen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">разыгрывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">выманивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">хитрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">фальшь</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">состязаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -545,13 +549,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Habgier»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">превосходить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">хитрость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">разыгрывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">превосходить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">алчность</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">хитрость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">притворяться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -564,31 +568,15 @@
                         <div class="quiz-phase-container" data-phase="goneril">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="2">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «das Bündnis»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">союз</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">делить</button>
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="1">планировать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">союз</button>
                                         
@@ -596,15 +584,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «planen»?</div>
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «teilen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">стратегия</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">сговор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">планировать</button>
                                         
@@ -612,47 +600,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «planen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
-                                        
                                         <button class="quiz-choice" type="button" data-choice-index="1">стратегия</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">делить</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
                                         
@@ -660,17 +616,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «verschwören»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">союз</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">делить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">заговорить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Absprache»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">заговорить</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">планировать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">стратегия</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «vereinbaren»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">планировать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">союз</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">договариваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">сговор</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Strategie»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">заговорить</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">сговор</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">стратегия</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">договариваться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -699,81 +703,81 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «erniedrigen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">унижать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
-                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">злоба</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «verhöhnen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">насмехаться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жестоко обращаться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «die Bosheit»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жёсткость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «misshandeln»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">жестоко обращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестоко обращаться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Härte»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отвергать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">жёсткость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">насмехаться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -783,29 +787,29 @@
                                     <div class="quiz-question">Что означает немецкое слово «abweisen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">жестоко обращаться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">насмехаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">злоба</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">жёсткость</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «die Grausamkeit»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">пытать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">жёсткость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">унижать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">жестокость</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отвергать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">унижать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">жестокость</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отвергать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -822,13 +826,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «blenden»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">садизм</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -838,43 +842,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «der Sadismus»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ослеплять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">садизм</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">наслаждаться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">ослеплять</button>
                                         
@@ -882,13 +854,13 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
+                                <div class="quiz-card" data-question-index="2" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «genießen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">наслаждаться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
                                         
@@ -898,31 +870,15 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
-                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «ausstechen»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">пытка</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">брутальность</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">выкалывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">беспощадный</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">наслаждаться</button>
                                         
@@ -930,15 +886,63 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
+                                    <div class="quiz-question">Что означает немецкое слово «die Folter»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">растаптывать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">пытка</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">выкалывать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «erbarmungslos»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">выкалывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">брутальность</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">пытка</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="6" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «die Brutalität»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">садизм</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">ослеплять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">беспощадный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">растаптывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="7" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «zertreten»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">беспощадный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">растаптывать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ослеплять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">брутальность</button>
                                         
@@ -957,45 +961,45 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Witwe»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «begehren»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">вдова</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="2" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «verführen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1005,11 +1009,11 @@
                                     <div class="quiz-question">Что означает немецкое слово «die Begierde»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соблазнять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">похоть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
                                         
@@ -1017,33 +1021,33 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="1">
                                     <div class="quiz-question">Что означает немецкое слово «locken»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">добиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">заманивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вдова</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделение</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Lust»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">вожделеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">вдова</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">вожделение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1053,13 +1057,13 @@
                                     <div class="quiz-question">Что означает немецкое слово «werben»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">похоть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">заманивать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соблазнять</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">вожделение</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">добиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">вожделеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соблазнять</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1072,17 +1076,17 @@
                         <div class="quiz-phase-container" data-phase="dover">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «wettkämpfen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1096,41 +1100,41 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соперничество</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="2" data-correct-index="2">
+                                <div class="quiz-card" data-question-index="2" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «bedrohen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
+                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">соперничество</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соревноваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">ненавидеть</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="3" data-correct-index="2">
-                                    <div class="quiz-question">Что означает немецкое слово «die Rivalität»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">соревноваться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1140,9 +1144,25 @@
                                     <div class="quiz-question">Что означает немецкое слово «bekämpfen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">угрожать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="1">бороться</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">соревноваться</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
+                                <div class="quiz-card" data-question-index="5" data-correct-index="1">
+                                    <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">ненавидеть</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">не доверять</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">угрожать</button>
                                         
@@ -1152,33 +1172,17 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="5" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «misstrauen»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">не доверять</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">соперничество</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">бороться</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">угрожать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="6" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «argwöhnen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">подозревать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">бороться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">ненавидеть</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">угрожать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">соперничество</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">подозревать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">бороться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">ненавидеть</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1191,24 +1195,8 @@
                         <div class="quiz-phase-container" data-phase="prison">
                             
                                 
-                                <div class="quiz-card active" data-question-index="0" data-correct-index="1">
+                                <div class="quiz-card active" data-question-index="0" data-correct-index="3">
                                     <div class="quiz-question">Что означает немецкое слово «vergiftet»?</div>
-                                    <div class="quiz-choices">
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="2">страдать</button>
-                                        
-                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
-                                        
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                
-                                <div class="quiz-card" data-question-index="1" data-correct-index="0">
-                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
@@ -1223,49 +1211,65 @@
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
+                                <div class="quiz-card" data-question-index="1" data-correct-index="3">
+                                    <div class="quiz-question">Что означает немецкое слово «leiden»?</div>
+                                    <div class="quiz-choices">
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
+                                        
+                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        
+                                    </div>
+                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
+                                </div>
+                                
                                 <div class="quiz-card" data-question-index="2" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verenden»?</div>
                                     <div class="quiz-choices">
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рок</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">издыхать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="3" data-correct-index="3">
+                                <div class="quiz-card" data-question-index="3" data-correct-index="0">
                                     <div class="quiz-question">Что означает немецкое слово «die Qual»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">расплачиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">рок</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">отравленный</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="4" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="4" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verwünschen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклинать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">рок</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">мучение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклинать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">мучение</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -1277,43 +1281,43 @@
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="0">мучение</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">проклинать</button>
                                         
                                         <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">страдать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">расплачиваться</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="6" data-correct-index="1">
+                                <div class="quiz-card" data-question-index="6" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «büßen»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">издыхать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">страдать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">расплачиваться</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">отравленный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">расплачиваться</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">проклинать</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
                                 </div>
                                 
-                                <div class="quiz-card" data-question-index="7" data-correct-index="0">
+                                <div class="quiz-card" data-question-index="7" data-correct-index="2">
                                     <div class="quiz-question">Что означает немецкое слово «verflucht»?</div>
                                     <div class="quiz-choices">
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="0">проклятый</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="0">отравленный</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="1">отравленный</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="1">издыхать</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="2">рок</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="2">проклятый</button>
                                         
-                                        <button class="quiz-choice" type="button" data-choice-index="3">издыхать</button>
+                                        <button class="quiz-choice" type="button" data-choice-index="3">рок</button>
                                         
                                     </div>
                                     <div class="quiz-feedback" role="status" aria-live="polite"></div>
@@ -2000,80 +2004,80 @@
             {
                 "question": "Что означает немецкое слово «vortäuschen»?",
                 "choices": [
-                    "превосходить",
-                    "состязаться",
                     "фальшь",
-                    "притворяться"
+                    "притворяться",
+                    "состязаться",
+                    "превосходить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
                     "притворяться",
+                    "состязаться",
                     "фальшь",
-                    "превосходить",
-                    "состязаться"
+                    "превосходить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
                     "состязаться",
-                    "притворяться",
                     "алчность",
-                    "выманивать"
+                    "фальшь",
+                    "разыгрывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falschheit»?",
                 "choices": [
+                    "алчность",
                     "фальшь",
-                    "хитрость",
-                    "разыгрывать",
-                    "состязаться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «vorspielen»?",
-                "choices": [
                     "превосходить",
-                    "разыгрывать",
-                    "притворяться",
-                    "алчность"
+                    "состязаться"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «vorspielen»?",
+                "choices": [
+                    "разыгрывать",
+                    "хитрость",
+                    "выманивать",
+                    "фальшь"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "алчность",
-                    "превосходить",
+                    "фальшь",
                     "хитрость",
+                    "притворяться",
                     "выманивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
-                    "превосходить",
+                    "разыгрывать",
                     "выманивать",
-                    "хитрость",
-                    "фальшь"
+                    "алчность",
+                    "состязаться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
+                    "хитрость",
                     "превосходить",
-                    "разыгрывать",
                     "алчность",
-                    "хитрость"
+                    "притворяться"
                 ],
                 "correctIndex": 2
             }
@@ -2504,71 +2508,71 @@
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
                     "заговорить",
+                    "планировать",
                     "делить",
+                    "союз"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «teilen»?",
+                "choices": [
                     "союз",
+                    "заговорить",
+                    "делить",
                     "планировать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «teilen»?",
-                "choices": [
-                    "делить",
-                    "планировать",
-                    "заговорить",
-                    "союз"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «planen»?",
                 "choices": [
-                    "стратегия",
                     "заговорить",
-                    "сговор",
-                    "планировать"
+                    "стратегия",
+                    "планировать",
+                    "договариваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschwören»?",
                 "choices": [
+                    "сговор",
+                    "делить",
                     "заговорить",
-                    "союз",
-                    "планировать",
-                    "сговор"
+                    "стратегия"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "планировать",
                     "сговор",
-                    "делить",
+                    "заговорить",
+                    "планировать",
                     "стратегия"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
+                    "планировать",
                     "союз",
-                    "стратегия",
-                    "делить",
-                    "договариваться"
+                    "договариваться",
+                    "сговор"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
-                    "союз",
+                    "заговорить",
                     "сговор",
-                    "планировать",
-                    "стратегия"
+                    "стратегия",
+                    "договариваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3104,72 +3108,72 @@
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "унижать",
                     "злоба",
-                    "пытать",
-                    "насмехаться"
+                    "насмехаться",
+                    "унижать",
+                    "пытать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "жёсткость",
                     "насмехаться",
-                    "пытать",
-                    "злоба"
+                    "жестокость",
+                    "злоба",
+                    "жестоко обращаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
                     "пытать",
-                    "злоба",
                     "жёсткость",
-                    "жестокость"
+                    "злоба",
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
                     "жестокость",
+                    "отвергать",
                     "жестоко обращаться",
-                    "злоба",
-                    "насмехаться"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Härte»?",
-                "choices": [
-                    "пытать",
-                    "унижать",
-                    "жёсткость",
                     "злоба"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Härte»?",
+                "choices": [
+                    "жёсткость",
+                    "отвергать",
+                    "жестокость",
+                    "насмехаться"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "жестоко обращаться",
-                    "пытать",
+                    "жестокость",
+                    "насмехаться",
                     "отвергать",
-                    "злоба"
+                    "жёсткость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "пытать",
+                    "жёсткость",
+                    "жестокость",
                     "унижать",
-                    "отвергать",
-                    "жестокость"
+                    "отвергать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3679,82 +3683,82 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "садизм",
+                    "выкалывать",
                     "наслаждаться",
                     "ослеплять",
-                    "выкалывать"
+                    "садизм"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "ослеплять",
+                    "выкалывать",
                     "садизм",
                     "наслаждаться",
-                    "выкалывать"
+                    "ослеплять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "беспощадный",
-                    "брутальность",
+                    "выкалывать",
                     "наслаждаться",
-                    "пытка"
+                    "пытка",
+                    "садизм"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "растаптывать",
+                    "пытка",
                     "беспощадный",
                     "выкалывать",
-                    "ослеплять"
+                    "наслаждаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "выкалывать",
-                    "брутальность",
+                    "садизм",
+                    "беспощадный",
                     "пытка",
-                    "садизм"
+                    "выкалывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "пытка",
-                    "брутальность",
                     "выкалывать",
-                    "беспощадный"
+                    "беспощадный",
+                    "брутальность",
+                    "пытка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Brutalität»?",
                 "choices": [
-                    "беспощадный",
+                    "садизм",
+                    "ослеплять",
                     "растаптывать",
-                    "брутальность",
-                    "наслаждаться"
+                    "брутальность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zertreten»?",
                 "choices": [
+                    "беспощадный",
                     "растаптывать",
                     "ослеплять",
-                    "беспощадный",
                     "брутальность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4195,39 +4199,39 @@
             {
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
-                    "соблазнять",
                     "вожделение",
+                    "вожделеть",
                     "вдова",
-                    "вожделеть"
+                    "соблазнять"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
+                    "вожделеть",
                     "соблазнять",
-                    "вожделение",
-                    "вдова",
-                    "вожделеть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verführen»?",
-                "choices": [
-                    "соблазнять",
-                    "добиваться",
                     "вдова",
                     "вожделение"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Begierde»?",
+                "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
                     "похоть",
-                    "заманивать",
+                    "добиваться",
+                    "вожделеть",
+                    "соблазнять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Begierde»?",
+                "choices": [
                     "соблазнять",
+                    "похоть",
+                    "добиваться",
                     "вожделение"
                 ],
                 "correctIndex": 3
@@ -4235,30 +4239,30 @@
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
+                    "вожделеть",
                     "заманивать",
                     "добиваться",
-                    "похоть",
-                    "вдова"
+                    "вожделение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
+                    "похоть",
                     "вожделеть",
-                    "вдова",
-                    "вожделение",
-                    "похоть"
+                    "добиваться",
+                    "соблазнять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
-                    "похоть",
-                    "соблазнять",
+                    "заманивать",
+                    "вожделение",
                     "добиваться",
-                    "вожделеть"
+                    "соблазнять"
                 ],
                 "correctIndex": 2
             }
@@ -4688,72 +4692,72 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
+                    "соревноваться",
                     "угрожать",
-                    "соперничество",
                     "ненавидеть",
-                    "соревноваться"
+                    "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
                     "ненавидеть",
                     "соревноваться",
-                    "соперничество",
-                    "угрожать"
+                    "угрожать",
+                    "соперничество"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bedrohen»?",
                 "choices": [
-                    "соперничество",
-                    "соревноваться",
                     "угрожать",
-                    "ненавидеть"
+                    "соперничество",
+                    "ненавидеть",
+                    "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
-                    "соревноваться",
-                    "ненавидеть",
                     "соперничество",
-                    "угрожать"
+                    "не доверять",
+                    "ненавидеть",
+                    "бороться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
-                    "ненавидеть",
-                    "бороться",
                     "угрожать",
-                    "подозревать"
+                    "бороться",
+                    "соперничество",
+                    "соревноваться"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
+                    "ненавидеть",
                     "не доверять",
-                    "соперничество",
-                    "бороться",
-                    "угрожать"
+                    "угрожать",
+                    "подозревать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
+                    "бороться",
+                    "угрожать",
                     "подозревать",
-                    "ненавидеть",
-                    "соперничество",
-                    "бороться"
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5235,82 +5239,82 @@
             {
                 "question": "Что означает немецкое слово «vergiftet»?",
                 "choices": [
-                    "мучение",
-                    "отравленный",
-                    "страдать",
-                    "издыхать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «leiden»?",
-                "choices": [
                     "страдать",
                     "издыхать",
                     "мучение",
                     "отравленный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «leiden»?",
+                "choices": [
+                    "мучение",
+                    "отравленный",
+                    "издыхать",
+                    "страдать"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
                     "проклинать",
-                    "страдать",
+                    "рок",
                     "издыхать",
-                    "мучение"
+                    "расплачиваться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "расплачиваться",
-                    "проклинать",
+                    "мучение",
                     "рок",
-                    "мучение"
+                    "проклинать",
+                    "отравленный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
+                    "проклятый",
+                    "мучение",
                     "проклинать",
-                    "рок",
-                    "отравленный",
-                    "мучение"
+                    "издыхать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
                     "мучение",
-                    "отравленный",
+                    "проклинать",
                     "рок",
-                    "страдать"
+                    "расплачиваться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
+                    "страдать",
                     "издыхать",
                     "расплачиваться",
-                    "отравленный",
-                    "рок"
+                    "проклинать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
-                    "проклятый",
                     "отравленный",
-                    "рок",
-                    "издыхать"
+                    "издыхать",
+                    "проклятый",
+                    "рок"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -127,19 +127,85 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: 16px;
+    gap: 18px;
     text-align: center;
     color: white;
     margin-bottom: 40px;
     animation: fadeInDown 0.8s ease;
 }
 
-.page-header-text {
+.header-nav {
     display: flex;
-    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    gap: 16px;
+}
+
+.home-link {
+    display: inline-flex;
     align-items: center;
     gap: 8px;
+    padding: 10px 20px;
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    text-decoration: none;
+    border-radius: 25px;
+    font-size: 0.95em;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+}
+
+.home-link:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateX(-5px);
+}
+
+.home-link .arrow {
+    font-size: 1.2em;
+    transition: transform 0.3s ease;
+}
+
+.home-link:hover .arrow {
+    transform: translateX(-3px);
+}
+
+.study-counter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 20px;
+    border-radius: 25px;
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    font-size: 0.9em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    backdrop-filter: blur(10px);
+    transition: all 0.3s ease;
+}
+
+.study-counter-badge--active {
+    background: rgba(76, 175, 80, 0.25);
+    box-shadow: 0 12px 32px rgba(76, 175, 80, 0.35);
+}
+
+.study-counter-label {
+    font-size: 0.85em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.counter-badge {
+    background: #4caf50;
+    color: #ffffff;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 0.9em;
+    font-weight: 700;
+    min-width: 28px;
+    text-align: center;
 }
 
 .page-header h1 {
@@ -153,56 +219,21 @@ body {
     opacity: 0.95;
 }
 
-.study-counter-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 18px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.18);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-    color: #f9fafb;
-}
-
-.study-counter-badge--active {
-    background: rgba(34, 197, 94, 0.3);
-    box-shadow: 0 12px 32px rgba(34, 197, 94, 0.35);
-}
-
-.study-counter-badge:hover {
-    transform: translateY(-2px);
-}
-
-.study-counter-label {
-    font-size: 0.95em;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
-.study-counter-value {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 36px;
-    padding: 4px 12px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.28);
-    font-size: 1.1em;
-}
-
-@media (min-width: 768px) {
-    .page-header {
-        flex-direction: row;
-        align-items: flex-end;
-        text-align: left;
+@media (max-width: 768px) {
+    .header-nav {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
     }
 
-    .page-header-text {
-        align-items: flex-start;
-        text-align: left;
+    .home-link,
+    .study-counter {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .home-link:hover {
+        transform: none;
     }
 }
 

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -127,19 +127,85 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: 16px;
+    gap: 18px;
     text-align: center;
     color: white;
     margin-bottom: 40px;
     animation: fadeInDown 0.8s ease;
 }
 
-.page-header-text {
+.header-nav {
     display: flex;
-    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    gap: 16px;
+}
+
+.home-link {
+    display: inline-flex;
     align-items: center;
     gap: 8px;
+    padding: 10px 20px;
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    text-decoration: none;
+    border-radius: 25px;
+    font-size: 0.95em;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+}
+
+.home-link:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: translateX(-5px);
+}
+
+.home-link .arrow {
+    font-size: 1.2em;
+    transition: transform 0.3s ease;
+}
+
+.home-link:hover .arrow {
+    transform: translateX(-3px);
+}
+
+.study-counter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 20px;
+    border-radius: 25px;
+    background: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    font-size: 0.9em;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    backdrop-filter: blur(10px);
+    transition: all 0.3s ease;
+}
+
+.study-counter-badge--active {
+    background: rgba(76, 175, 80, 0.25);
+    box-shadow: 0 12px 32px rgba(76, 175, 80, 0.35);
+}
+
+.study-counter-label {
+    font-size: 0.85em;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.counter-badge {
+    background: #4caf50;
+    color: #ffffff;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 0.9em;
+    font-weight: 700;
+    min-width: 28px;
+    text-align: center;
 }
 
 .page-header h1 {
@@ -153,56 +219,21 @@ body {
     opacity: 0.95;
 }
 
-.study-counter-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 18px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.18);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-    color: #f9fafb;
-}
-
-.study-counter-badge--active {
-    background: rgba(34, 197, 94, 0.3);
-    box-shadow: 0 12px 32px rgba(34, 197, 94, 0.35);
-}
-
-.study-counter-badge:hover {
-    transform: translateY(-2px);
-}
-
-.study-counter-label {
-    font-size: 0.95em;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-}
-
-.study-counter-value {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 36px;
-    padding: 4px 12px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.28);
-    font-size: 1.1em;
-}
-
-@media (min-width: 768px) {
-    .page-header {
-        flex-direction: row;
-        align-items: flex-end;
-        text-align: left;
+@media (max-width: 768px) {
+    .header-nav {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
     }
 
-    .page-header-text {
-        align-items: flex-start;
-        text-align: left;
+    .home-link,
+    .study-counter {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .home-link:hover {
+        transform: none;
     }
 }
 

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -11,14 +11,18 @@
 <body>
     <div class="container">
         <header class="page-header">
-            <div class="page-header-text">
-                <h1>👑 {{ character.title }}</h1>
-                <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
+            <div class="header-nav">
+                <a href="{{ navigation.home_href }}" class="home-link">
+                    <span class="arrow">{{ navigation.home_icon }}</span>
+                    <span class="text">{{ navigation.home_label }}</span>
+                </a>
+                <div class="study-counter" data-study-counter role="status" aria-live="polite">
+                    <span class="study-counter-label">{{ navigation.study_label }}</span>
+                    <span class="counter-badge" data-study-count>0</span>
+                </div>
             </div>
-            <div class="study-counter-badge" data-study-counter role="status" aria-live="polite">
-                <span class="study-counter-label">Список изучения</span>
-                <span class="study-counter-value" data-study-count>0</span>
-            </div>
+            <h1>👑 {{ character.title }}</h1>
+            <p class="subtitle">Изучаем немецкий через трагедию Шекспира</p>
         </header>
 
         <div class="journey-section">


### PR DESCRIPTION
## Summary
- add navigation metadata to the journey generator so templates can render a home shortcut and study counter
- update the journey template and stylesheet to surface the new navigation design
- regenerate all journey output pages and static assets with the refreshed header

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cee00c60bc83208fe72579429c451b