### PR TITLE
Expand word selection exercise layout

### DIFF
--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -437,6 +437,11 @@ body {
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.35s ease, padding 0.35s ease;
+    position: relative;
+}
+
+.exercise-content.expanded {
+    overflow: visible;
 }
 
 .exercise-content:not(.collapsed) {
@@ -941,8 +946,224 @@ body {
     padding: 0 24px;
 }
 
+.relations-content.word-selection-host {
+    padding: 0;
+}
+
 .relation-section.expanded .relations-content {
     padding: 18px 24px 24px;
+    overflow: visible;
+}
+
+.relation-section.expanded .relations-content.word-selection-host {
+    padding: 0;
+}
+
+.word-selection-container {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(238, 242, 255, 0.95));
+    border: 1px solid rgba(102, 126, 234, 0.25);
+    border-radius: 20px;
+    padding: 28px 28px 80px;
+    min-height: 600px;
+    max-height: 80vh;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: inset 0 12px 24px rgba(79, 70, 229, 0.06);
+}
+
+.word-selection-container .exercise-description {
+    margin: 0;
+    text-align: center;
+    color: #4b5563;
+    font-size: 0.95em;
+}
+
+.word-columns {
+    display: flex;
+    gap: 40px;
+    min-height: 400px;
+    padding: 8px;
+}
+
+.word-column {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    max-height: 520px;
+    overflow-y: auto;
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 16px;
+    border: 1px solid rgba(129, 140, 248, 0.3);
+    padding: 18px;
+    position: relative;
+}
+
+.word-column h4 {
+    margin: 0;
+    font-size: 0.85em;
+    letter-spacing: 0.08em;
+    color: #4338ca;
+    font-weight: 700;
+    text-transform: uppercase;
+    text-align: center;
+}
+
+.word-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.word-item {
+    border: 2px solid #c7d2fe;
+    border-radius: 14px;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(129, 140, 248, 0.15));
+    color: #312e81;
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+    box-shadow: 0 8px 18px rgba(99, 102, 241, 0.18);
+    user-select: none;
+}
+
+.word-item:hover,
+.word-item.selected {
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: #ffffff;
+    transform: translateY(-2px);
+    box-shadow: 0 12px 26px rgba(99, 102, 241, 0.32);
+}
+
+.word-item.matched {
+    background: linear-gradient(135deg, #34d399, #10b981);
+    color: #ffffff;
+    border-color: rgba(16, 185, 129, 0.85);
+    box-shadow: 0 12px 26px rgba(16, 185, 129, 0.28);
+    cursor: default;
+}
+
+.word-item.incorrect {
+    background: linear-gradient(135deg, #f87171, #ef4444);
+    border-color: rgba(239, 68, 68, 0.85);
+    color: #ffffff;
+    box-shadow: 0 12px 24px rgba(239, 68, 68, 0.28);
+}
+
+.word-item:disabled {
+    cursor: default;
+    opacity: 0.9;
+}
+
+.selection-button {
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    padding-top: 16px;
+    padding-bottom: 12px;
+    background: linear-gradient(180deg, rgba(248, 250, 255, 0) 0%, rgba(248, 250, 255, 0.92) 38%, rgba(255, 255, 255, 0.98) 100%);
+    display: flex;
+    justify-content: center;
+    z-index: 5;
+}
+
+.select-pair-btn {
+    width: 100%;
+    max-width: 520px;
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    border-radius: 999px;
+    padding: 14px 24px;
+    background: #ffffff;
+    color: #4338ca;
+    font-weight: 600;
+    font-size: 0.95em;
+    cursor: default;
+    box-shadow: 0 12px 32px rgba(99, 102, 241, 0.12);
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.select-pair-btn.is-success {
+    border-color: rgba(16, 185, 129, 0.5);
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(5, 150, 105, 0.18));
+    color: #0f766e;
+    box-shadow: 0 12px 28px rgba(16, 185, 129, 0.22);
+}
+
+.select-pair-btn.is-error {
+    border-color: rgba(239, 68, 68, 0.45);
+    background: linear-gradient(135deg, rgba(248, 113, 113, 0.12), rgba(239, 68, 68, 0.16));
+    color: #b91c1c;
+    box-shadow: 0 12px 24px rgba(239, 68, 68, 0.2);
+}
+
+.word-list {
+    scrollbar-width: thin;
+    scrollbar-color: #888 #f1f1f1;
+}
+
+.word-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.word-list::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+
+.word-list::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 4px;
+}
+
+.word-list::-webkit-scrollbar-thumb:hover {
+    background: #555;
+}
+
+.word-column::after {
+    content: '↓ Прокрутите для больше слов ↓';
+    position: sticky;
+    bottom: 8px;
+    left: 0;
+    right: 0;
+    padding: 8px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.92));
+    text-align: center;
+    font-size: 0.75em;
+    color: #6366f1;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.word-column.has-scroll::after {
+    opacity: 1;
+}
+
+@media (max-height: 768px) {
+    .word-selection-container {
+        max-height: 70vh;
+    }
+
+    .word-column {
+        max-height: 360px;
+    }
+}
+
+@media (min-height: 1080px) {
+    .word-selection-container {
+        max-height: 900px;
+    }
+
+    .word-column {
+        max-height: 700px;
+    }
 }
 
 .relation-group,


### PR DESCRIPTION
## Summary
- enlarge the word selection exercise container with scrollable columns, sticky footer messaging, and new visual states
- rebuild the pair-matching activity to render the refreshed layout and surface feedback through the pinned status control
- adjust exercise toggle logic to recalculate heights and scroll hints, keeping the expanded section fully visible on resize

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cedf64538083208beb22e1c3a7f924