### PR TITLE
Implement bidirectional vocabulary quiz

### DIFF
--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -460,32 +460,61 @@ body {
     margin: 0;
 }
 
-.exercises-section .quiz-section {
-    margin: 0;
-    padding: 0;
-    background: transparent;
-    box-shadow: none;
+
+.quiz-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+    margin-bottom: 24px;
 }
 
-.exercises-section .quiz-section .quiz-intro {
-    margin-top: 16px;
+.quiz-progress {
+    flex: 1 1 260px;
 }
 
-.exercises-section .constructor-section {
-    border-radius: 12px;
+.quiz-progress .progress-text {
+    display: inline-block;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 8px;
 }
 
-.quiz-section--empty {
-    padding: 20px;
-    border-radius: 16px;
-    background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+.quiz-progress .progress-bar {
+    position: relative;
+    height: 8px;
+    border-radius: 999px;
+    background: #e5e7eb;
+    overflow: hidden;
+}
+
+.quiz-progress .progress-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    transition: width 0.35s ease;
+}
+
+.quiz-content {
+    background: #f8fafc;
+    border-radius: 20px;
+    padding: 36px;
+    box-shadow: 0 12px 32px rgba(102, 126, 234, 0.18);
+}
+
+.quiz-placeholder {
     text-align: center;
     color: #475569;
     font-weight: 500;
 }
 
-.quiz-empty-message {
-    margin: 0;
+.exercises-section .constructor-section {
+    border-radius: 12px;
 }
 
 @media (max-width: 900px) {
@@ -1506,21 +1535,22 @@ body {
         border-radius: 3px;
     }
 
-    .quiz-section {
-        padding: 20px 16px;
+    .quiz-content {
+        padding: 24px 18px;
     }
 
-    .quiz-card {
-        padding: 20px 16px;
+    .quiz-question-card {
+        gap: 16px;
     }
 
-    .quiz-question {
-        font-size: 1em;
+    .quiz-question-text {
+        font-size: 1.05em;
     }
 
-    .quiz-choice {
+    .quiz-option {
         font-size: 0.95em;
         padding: 12px 14px;
+        min-height: 48px;
     }
 }
 
@@ -1716,136 +1746,209 @@ body {
     margin-top: 40px;
 }
 
-.quiz-section {
-    background: white;
-    border-radius: 20px;
-    padding: 40px;
-    margin: 40px 0;
-    box-shadow: 0 10px 40px rgba(0,0,0,0.12);
+.quiz-mode-indicator {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
-.quiz-intro {
-    text-align: center;
-    color: #4b5563;
-    margin-bottom: 24px;
-    font-size: 1em;
-}
-
-.quiz-intro .quiz-count {
-    font-weight: 700;
-    color: #667eea;
-}
-
-.quiz-phase-container {
-    display: none;
-}
-
-.quiz-phase-container.active {
-    display: block;
-    animation: fadeIn 0.5s ease;
-}
-
-.quiz-card {
-    display: none;
-    background: linear-gradient(135deg, #f8fafc 0%, #e0e7ff 100%);
-    border-radius: 18px;
-    padding: 28px 32px;
-    box-shadow: 0 12px 30px rgba(102, 126, 234, 0.2);
+.mode-badge {
+    padding: 6px 18px;
+    background: #e3f2fd;
+    border-radius: 999px;
+    font-size: 0.9em;
+    font-weight: 600;
+    color: #1e3a8a;
+    opacity: 0.45;
     transition: all 0.3s ease;
+    box-shadow: inset 0 0 0 1px rgba(30, 58, 138, 0.15);
 }
 
-.quiz-card.active {
-    display: block;
+.mode-badge.active {
+    opacity: 1;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(102, 126, 234, 0.25);
 }
 
-.quiz-card.empty {
-    text-align: center;
-    background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
-    color: #475569;
-    box-shadow: none;
+.mode-badge[data-mode="forward"].active {
+    background: #2196f3;
+    color: #ffffff;
 }
 
-.quiz-question {
-    font-size: 1.25em;
-    font-weight: 700;
-    color: #1f2937;
-    margin-bottom: 22px;
-    text-align: center;
+.mode-badge[data-mode="reverse"].active {
+    background: #ff9800;
+    color: #ffffff;
 }
 
-.quiz-choices {
+.quiz-question-card {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 22px;
 }
 
-.quiz-choice {
+.quiz-question-text {
+    font-size: 1.3em;
+    font-weight: 700;
+    color: #1f2937;
+    text-align: center;
+    line-height: 1.4;
+}
+
+.quiz-word-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.quiz-word-meta .quiz-word {
+    font-size: 1.4em;
+    font-weight: 700;
+    color: #4338ca;
+}
+
+.quiz-word-meta .quiz-transcription {
+    font-size: 0.95em;
+    color: #6b7280;
+    font-style: italic;
+}
+
+.quiz-options {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.quiz-option {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    color: #ffffff;
     border: none;
     border-radius: 14px;
-    padding: 16px 20px;
+    padding: 16px 18px;
     font-size: 1.05em;
     font-weight: 600;
     cursor: pointer;
-    box-shadow: 0 6px 18px rgba(102, 126, 234, 0.35);
+    box-shadow: 0 12px 28px rgba(102, 126, 234, 0.35);
     transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-    min-height: 54px;
+    min-height: 56px;
+    text-align: center;
 }
 
-.quiz-choice:hover:not(.locked) {
+.quiz-option:hover:not(.locked) {
     transform: translateY(-2px);
-    box-shadow: 0 12px 24px rgba(118, 75, 162, 0.35);
+    box-shadow: 0 16px 32px rgba(118, 75, 162, 0.35);
 }
 
-.quiz-choice:active:not(.locked) {
+.quiz-option:active:not(.locked) {
     transform: scale(0.98);
 }
 
-.quiz-choice.locked {
+.quiz-option.locked {
     cursor: not-allowed;
     opacity: 0.75;
     box-shadow: none;
 }
 
-.quiz-choice.correct {
+.quiz-option.correct {
     background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
-    box-shadow: 0 8px 20px rgba(34, 197, 94, 0.35);
+    box-shadow: 0 12px 28px rgba(34, 197, 94, 0.35);
 }
 
-.quiz-choice.incorrect {
+.quiz-option.incorrect {
     background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
-    box-shadow: 0 8px 20px rgba(239, 68, 68, 0.3);
-}
-
-.quiz-choice.touching {
-    transform: scale(0.98);
-    opacity: 0.9;
+    box-shadow: 0 12px 28px rgba(239, 68, 68, 0.3);
 }
 
 .quiz-feedback {
     min-height: 24px;
     text-align: center;
-    margin-top: 18px;
     font-size: 0.95em;
     font-weight: 600;
     color: #475569;
+    margin-top: 18px;
 }
 
-.quiz-completion {
-    display: none;
-    margin-top: 28px;
-    padding: 18px 22px;
+.mode-transition {
+    text-align: center;
+    padding: 40px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
     border-radius: 16px;
+    box-shadow: 0 18px 36px rgba(102, 126, 234, 0.35);
+}
+
+.mode-transition h3 {
+    font-size: 1.6em;
+    margin-bottom: 12px;
+}
+
+.mode-transition button {
+    margin-top: 20px;
+    background: white;
+    color: #4c1d95;
+    border: none;
+    padding: 14px 28px;
+    border-radius: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 12px 24px rgba(255, 255, 255, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mode-transition button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 30px rgba(255, 255, 255, 0.45);
+}
+
+.quiz-results {
+    text-align: center;
+    padding: 36px;
+    background: #f8f9fa;
+    border-radius: 16px;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.quiz-results h3 {
+    font-size: 1.6em;
+    margin-bottom: 12px;
+    color: #1f2937;
+}
+
+.quiz-results button {
+    margin-top: 24px;
     background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
     color: white;
+    border: none;
+    padding: 14px 28px;
+    border-radius: 12px;
+    font-size: 1.05em;
     font-weight: 600;
-    text-align: center;
-    box-shadow: 0 10px 24px rgba(234, 88, 12, 0.35);
+    cursor: pointer;
+    box-shadow: 0 12px 28px rgba(234, 88, 12, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.quiz-completion.visible {
-    display: block;
+.quiz-results button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(234, 88, 12, 0.4);
+}
+
+.result-details {
+    margin: 24px 0;
+    padding: 22px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    color: #475569;
+    line-height: 1.6;
+}
+
+.result-details p {
+    margin: 0;
+}
+
+.result-details p + p {
+    margin-top: 6px;
 }
 
 .show-answer-btn {
@@ -1933,26 +2036,26 @@ body {
         line-height: 1.8;
     }
 
-    .quiz-section {
-        padding: 24px 20px;
+    .quiz-content {
+        padding: 28px 24px;
     }
 
-    .quiz-section h2 {
-        font-size: 1.6em;
+    .quiz-question-card {
+        gap: 18px;
     }
 
-    .quiz-card {
-        padding: 24px 20px;
+    .quiz-question-text {
+        font-size: 1.15em;
     }
 
-    .quiz-question {
-        font-size: 1.1em;
+    .quiz-options {
+        grid-template-columns: 1fr;
     }
 
-    .quiz-choice {
+    .quiz-option {
         font-size: 1em;
-        min-height: 48px;
-        padding: 14px 16px;
+        min-height: 50px;
+        padding: 14px 18px;
     }
 
     .exercise-text .blank {

--- a/static/js/journey_runtime.js
+++ b/static/js/journey_runtime.js
@@ -7,6 +7,38 @@ let progressLineLength = 0;
 const QUIZ_ADVANCE_DELAY = 1200;
 const constructorState = {};
 
+function shuffleWords(words) {
+    const shuffled = Array.isArray(words) ? [...words] : [];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+function collectGlobalWordValues(type) {
+    const values = [];
+    const seen = new Set();
+
+    Object.values(phaseVocabularies || {}).forEach(phase => {
+        const words = Array.isArray(phase.words) ? phase.words : [];
+        words.forEach(entry => {
+            const value = type === 'russian' ? entry.translation : entry.word;
+            if (value && !seen.has(value)) {
+                seen.add(value);
+                values.push(value);
+            }
+        });
+    });
+
+    return values;
+}
+
+const globalOptionPools = {
+    german: collectGlobalWordValues('german'),
+    russian: collectGlobalWordValues('russian'),
+};
+
 const studyQueueState = {
     queue: [],
     lookup: new Map(),
@@ -378,288 +410,6 @@ if (typeof window !== 'undefined') {
     });
 }
 
-function getPhaseStorageKey(phaseKey) {
-    const safePhase = phaseKey || 'unknown';
-    return `${STORAGE_PREFIX}:${characterId}:${safePhase}:quizAttempts`;
-}
-
-function loadPhaseQuizState(phaseKey) {
-    if (quizStateCache[phaseKey]) {
-        return quizStateCache[phaseKey];
-    }
-
-    if (typeof localStorage === 'undefined') {
-        quizStateCache[phaseKey] = {};
-        return quizStateCache[phaseKey];
-    }
-
-    let storedValue = null;
-    try {
-        storedValue = localStorage.getItem(getPhaseStorageKey(phaseKey));
-    } catch (error) {
-        console.warn(`[QuizState] Unable to access storage for ${phaseKey}`, error);
-    }
-
-    if (!storedValue) {
-        quizStateCache[phaseKey] = {};
-        return quizStateCache[phaseKey];
-    }
-
-    try {
-        const parsed = JSON.parse(storedValue);
-        if (parsed && typeof parsed === 'object') {
-            quizStateCache[phaseKey] = parsed;
-            return parsed;
-        }
-    } catch (error) {
-        console.warn(`[QuizState] Failed to parse stored state for ${phaseKey}`, error);
-    }
-
-    quizStateCache[phaseKey] = {};
-    return quizStateCache[phaseKey];
-}
-
-function savePhaseQuizState(phaseKey, state) {
-    quizStateCache[phaseKey] = state;
-    if (phaseVocabularies[phaseKey]) {
-        phaseVocabularies[phaseKey].quizAttempts = state;
-    }
-
-    if (typeof localStorage === 'undefined') {
-        return;
-    }
-
-    try {
-        localStorage.setItem(getPhaseStorageKey(phaseKey), JSON.stringify(state));
-    } catch (error) {
-        console.warn(`[QuizState] Unable to save state for ${phaseKey}`, error);
-    }
-}
-
-function getPhaseQuizState(phaseKey) {
-    const phase = phaseVocabularies[phaseKey];
-    if (!phase) {
-        return {};
-    }
-
-    const storedState = loadPhaseQuizState(phaseKey);
-    if (!phase.quizAttempts || phase.quizAttempts !== storedState) {
-        phase.quizAttempts = storedState;
-    }
-
-    return phase.quizAttempts;
-}
-
-function extractQuizWord(questionText) {
-    if (!questionText || typeof questionText !== 'string') {
-        return '';
-    }
-
-    const angleMatch = questionText.match(/«([^»]+)»/);
-    if (angleMatch && angleMatch[1]) {
-        return angleMatch[1].trim();
-    }
-
-    const quoteMatch = questionText.match(/"([^"]+)"/);
-    if (quoteMatch && quoteMatch[1]) {
-        return quoteMatch[1].trim();
-    }
-
-    return '';
-}
-
-function findPhaseWord(phaseKey, targetWord) {
-    if (!targetWord) {
-        return null;
-    }
-
-    const phase = phaseVocabularies[phaseKey];
-    if (!phase || !Array.isArray(phase.words)) {
-        return null;
-    }
-
-    const normalizedTarget = targetWord.toLowerCase();
-    return phase.words.find(entry => {
-        const wordValue = (entry.word || '').toLowerCase();
-        return wordValue === normalizedTarget;
-    }) || null;
-}
-
-function recordQuizAttempt(phaseKey, questionIndex, selectedIndex, correctIndex, choiceLabels) {
-    if (!phaseKey) {
-        return;
-    }
-
-    const phase = phaseVocabularies[phaseKey];
-    if (!phase) {
-        return;
-    }
-
-    const quizState = getPhaseQuizState(phaseKey);
-    const quizList = Array.isArray(phase.quizzes) ? phase.quizzes : [];
-    const questionMeta = quizList[questionIndex] || {};
-    const questionText = questionMeta.question || '';
-    const detectedWord = questionMeta.targetWord || extractQuizWord(questionText);
-    if (detectedWord && !questionMeta.targetWord) {
-        questionMeta.targetWord = detectedWord;
-    }
-
-    const timestamp = new Date().toISOString();
-    const attemptRecord = {
-        selectedIndex: selectedIndex,
-        correctIndex: correctIndex,
-        isCorrect: selectedIndex === correctIndex,
-        timestamp: timestamp,
-        selectedChoice: Array.isArray(choiceLabels) && choiceLabels[selectedIndex] !== undefined
-            ? choiceLabels[selectedIndex]
-            : null,
-        correctChoice: Array.isArray(choiceLabels) && choiceLabels[correctIndex] !== undefined
-            ? choiceLabels[correctIndex]
-            : null,
-    };
-
-    if (!quizState[questionIndex] || typeof quizState[questionIndex] !== 'object') {
-        quizState[questionIndex] = {
-            attempts: [],
-            targetWord: detectedWord || '',
-            question: questionText,
-        };
-    }
-
-    const questionState = quizState[questionIndex];
-    if (detectedWord && !questionState.targetWord) {
-        questionState.targetWord = detectedWord;
-    }
-    if (questionText && !questionState.question) {
-        questionState.question = questionText;
-    }
-
-    questionState.attempts.push(attemptRecord);
-    questionState.lastCorrect = attemptRecord.isCorrect;
-    questionState.lastUpdated = timestamp;
-    questionState.lastSelectedChoice = attemptRecord.selectedChoice;
-    questionState.correctChoice = attemptRecord.correctChoice;
-
-    savePhaseQuizState(phaseKey, quizState);
-    updateQuizStatsUI(phaseKey);
-}
-
-function computePhaseQuizStats(phaseKey) {
-    const phase = phaseVocabularies[phaseKey];
-    const quizList = phase && Array.isArray(phase.quizzes) ? phase.quizzes : [];
-    const quizState = getPhaseQuizState(phaseKey);
-
-    const total = quizList.length;
-    let answered = 0;
-    let correct = 0;
-    const incorrectDetails = [];
-
-    quizList.forEach((quizItem, index) => {
-        const stateEntry = quizState[index];
-        if (!stateEntry || !Array.isArray(stateEntry.attempts) || stateEntry.attempts.length === 0) {
-            return;
-        }
-
-        answered += 1;
-        const lastAttempt = stateEntry.attempts[stateEntry.attempts.length - 1];
-        const questionText = stateEntry.question || (quizItem ? quizItem.question : '');
-        const targetWord = stateEntry.targetWord || (quizItem ? quizItem.targetWord : '');
-        const wordData = findPhaseWord(phaseKey, targetWord);
-
-        if (lastAttempt.isCorrect) {
-            correct += 1;
-        } else {
-            incorrectDetails.push({
-                word: targetWord || (wordData ? wordData.word : ''),
-                translation: wordData ? wordData.translation : '',
-                question: questionText,
-                selected: lastAttempt.selectedChoice,
-                correctAnswer: lastAttempt.correctChoice,
-                questionIndex: index,
-            });
-        }
-    });
-
-    return {
-        total: total,
-        answered: answered,
-        correct: correct,
-        incorrectDetails: incorrectDetails,
-    };
-}
-
-function updateQuizStatsUI(phaseKey) {
-    const statsPanel = document.querySelector('.quiz-stats-panel');
-    if (!statsPanel) {
-        return;
-    }
-
-    const phase = phaseVocabularies[phaseKey];
-    const stats = computePhaseQuizStats(phaseKey);
-    const phaseNameElement = statsPanel.querySelector('[data-quiz-phase-name]');
-    const summaryElement = statsPanel.querySelector('[data-quiz-summary]');
-    const progressElement = statsPanel.querySelector('[data-quiz-progress]');
-    const errorsContainer = statsPanel.querySelector('[data-quiz-errors]');
-
-    statsPanel.dataset.phase = phaseKey || '';
-
-    if (phaseNameElement) {
-        phaseNameElement.textContent = phase ? phase.title : '—';
-    }
-
-    if (summaryElement) {
-        if (!stats.total) {
-            summaryElement.textContent = 'Для этой фазы пока нет викторины.';
-        } else {
-            summaryElement.textContent = `Пройдено ${stats.answered} из ${stats.total} вопросов.`;
-        }
-    }
-
-    if (progressElement) {
-        if (!stats.total) {
-            progressElement.textContent = '—';
-        } else {
-            const percent = Math.round((stats.correct / stats.total) * 100);
-            progressElement.textContent = `${stats.correct} из ${stats.total} верно (${percent}%)`;
-        }
-    }
-
-    if (errorsContainer) {
-        if (!stats.total) {
-            errorsContainer.innerHTML = '<p class="quiz-errors-empty">Ошибок пока нет — вопросы появятся позже.</p>';
-        } else if (!stats.incorrectDetails.length) {
-            errorsContainer.innerHTML = '<p class="quiz-errors-empty">Ошибок пока нет — отличная работа!</p>';
-        } else {
-            const items = stats.incorrectDetails.map(detail => {
-                const translation = detail.translation ? ` — ${detail.translation}` : '';
-                const question = detail.question
-                    ? `<div class="quiz-error-question">${detail.question}</div>`
-                    : '';
-                const userAnswer = detail.selected
-                    ? `<span class="quiz-error-answer">Ваш ответ: ${detail.selected}</span>`
-                    : '';
-                const correctAnswer = detail.correctAnswer
-                    ? `<span class="quiz-error-correct">Верно: ${detail.correctAnswer}</span>`
-                    : '';
-                return `
-                    <li class="quiz-error-item" data-question-index="${detail.questionIndex}">
-                        <strong>${detail.word || 'Слово'}</strong>${translation}
-                        ${question}
-                        <div class="quiz-error-meta">
-                            ${userAnswer}
-                            ${correctAnswer}
-                        </div>
-                    </li>
-                `;
-            }).join('');
-            errorsContainer.innerHTML = `<ul class="quiz-error-list">${items}</ul>`;
-        }
-    }
-
-    statsPanel.classList.toggle('quiz-stats-empty', !stats.total);
-    statsPanel.classList.toggle('quiz-stats-has-errors', stats.incorrectDetails.length > 0);
-}
-
 function queuePhaseReview(detail) {
     if (typeof localStorage === 'undefined') {
         return;
@@ -692,45 +442,6 @@ function queuePhaseReview(detail) {
     } catch (error) {
         console.warn('[ReviewQueue] Unable to update review queue', error);
     }
-}
-
-function handlePhaseCompletion(phaseKey) {
-    if (!phaseKey) {
-        return;
-    }
-
-    const stats = computePhaseQuizStats(phaseKey);
-    if (!stats.total || stats.answered < stats.total) {
-        return;
-    }
-
-    const timestamp = new Date().toISOString();
-    const phase = phaseVocabularies[phaseKey] || {};
-    const eventDetail = {
-        characterId: characterId,
-        phaseId: phaseKey,
-        phaseTitle: phase.title || '',
-        completedAt: timestamp,
-        incorrectWords: stats.incorrectDetails.map(item => ({
-            word: item.word,
-            translation: item.translation,
-            question: item.question,
-            selected: item.selected,
-            correctAnswer: item.correctAnswer,
-        })),
-    };
-
-    queuePhaseReview(eventDetail);
-
-    try {
-        document.dispatchEvent(new CustomEvent('journeyPhaseCompleted', { detail: eventDetail }));
-    } catch (error) {
-        console.warn('[JourneyPhase] Unable to dispatch completion event', error);
-    }
-
-    const quizState = getPhaseQuizState(phaseKey);
-    quizState.__lastCompletion = timestamp;
-    savePhaseQuizState(phaseKey, quizState);
 }
 
 // Device detection
@@ -1168,8 +879,8 @@ function displayVocabulary(phaseKey) {
     const phase = phaseVocabularies[phaseKey];
     const grid = document.querySelector('.vocabulary-grid');
     const phaseTitle = document.getElementById('current-phase');
-    const progressFill = document.querySelector('.progress-fill');
-    const progressText = document.querySelector('.progress-text');
+    const progressFill = document.querySelector('.journey-progress .progress-fill');
+    const progressText = document.querySelector('.journey-progress .progress-text');
     
     if (!phase || !grid || !phaseTitle) {
         console.error('Missing required elements');
@@ -1212,21 +923,7 @@ function displayVocabulary(phaseKey) {
     });
 
     // Update quizzes
-    const quizContainers = document.querySelectorAll('.quiz-phase-container');
-    quizContainers.forEach(container => {
-        const isCurrent = container.dataset.phase === phaseKey;
-        container.classList.toggle('active', isCurrent);
-        resetQuizContainer(container, isCurrent);
-    });
-
-    const quizCountElement = document.querySelector('.quiz-count');
-    if (quizCountElement) {
-        const quizData = Array.isArray(phase.quizzes) ? phase.quizzes : [];
-        quizCountElement.textContent = quizData.length;
-    }
-
-    getPhaseQuizState(phaseKey);
-    updateQuizStatsUI(phaseKey);
+    initializeVocabularyQuiz(phaseKey);
 
     // Setup relations for current phase
     setupRelationsForPhase(phaseKey);
@@ -1322,192 +1019,514 @@ function displayVocabulary(phaseKey) {
     }, 500);
 }
 
-// ============= QUIZ FUNCTIONS (lines 240-400) =============
+let activeVocabularyQuiz = null;
 
-function resetQuizContainer(container, activateFirstCard = false) {
-    if (!container) return;
+class VocabularyQuiz {
+    constructor(phaseKey, words, phaseTitle) {
+        this.phaseKey = phaseKey;
+        this.phaseTitle = phaseTitle || '';
+        this.originalWords = Array.isArray(words)
+            ? words.map(word => ({ ...word }))
+            : [];
+        this.words = [];
+        this.currentIndex = 0;
+        this.correctAnswers = 0;
+        this.totalQuestions = this.originalWords.length * 2;
+        this.currentMode = 'forward';
+        this.completedForward = false;
+        this.answeredQuestions = 0;
+        this.isTransition = false;
+        this.optionLocked = false;
+        this.incorrectAnswers = [];
+        this.advanceTimeout = null;
+        this.quizCompleted = false;
+        this.advanceDelay = QUIZ_ADVANCE_DELAY;
+        this.optionButtons = [];
+        this.feedbackElement = null;
+        this.elements = {
+            content: document.querySelector('.quiz-content'),
+            currentQuestion: document.getElementById('current-question'),
+            totalQuestions: document.getElementById('total-questions'),
+            progressFill: document.querySelector('.quiz-progress .progress-fill'),
+            forwardBadge: document.querySelector('.mode-badge[data-mode="forward"]'),
+            reverseBadge: document.querySelector('.mode-badge[data-mode="reverse"]'),
+        };
+    }
 
-    const cards = Array.from(container.querySelectorAll('.quiz-card'));
-    let firstVisibleSet = false;
+    start() {
+        this.resetState();
+        this.totalQuestions = this.originalWords.length * 2;
+        this.updateModeIndicator();
+        this.updateProgressDisplay();
 
-    cards.forEach(card => {
-        const isPlaceholder = card.classList.contains('empty');
-        if (activateFirstCard && !firstVisibleSet && !isPlaceholder) {
-            card.classList.add('active');
-            firstVisibleSet = true;
+        if (!this.originalWords.length) {
+            this.renderEmptyState();
+            return;
+        }
+
+        const question = this.nextQuestion();
+        if (question) {
+            this.renderQuestion(question);
+        }
+    }
+
+    resetState() {
+        this.clearAdvanceTimeout();
+        this.words = shuffleWords(this.originalWords);
+        this.currentIndex = 0;
+        this.correctAnswers = 0;
+        this.currentMode = 'forward';
+        this.completedForward = false;
+        this.answeredQuestions = 0;
+        this.isTransition = false;
+        this.optionLocked = false;
+        this.incorrectAnswers = [];
+        this.quizCompleted = false;
+        this.optionButtons = [];
+        this.feedbackElement = null;
+    }
+
+    clearAdvanceTimeout() {
+        if (this.advanceTimeout) {
+            clearTimeout(this.advanceTimeout);
+            this.advanceTimeout = null;
+        }
+    }
+
+    updateModeIndicator() {
+        if (this.elements.forwardBadge) {
+            this.elements.forwardBadge.classList.toggle('active', this.currentMode === 'forward' && !this.quizCompleted);
+        }
+        if (this.elements.reverseBadge) {
+            this.elements.reverseBadge.classList.toggle('active', this.currentMode === 'reverse' && !this.quizCompleted);
+        }
+        if (this.quizCompleted) {
+            if (this.elements.forwardBadge) {
+                this.elements.forwardBadge.classList.remove('active');
+            }
+            if (this.elements.reverseBadge) {
+                this.elements.reverseBadge.classList.add('active');
+            }
+        }
+    }
+
+    updateProgressDisplay() {
+        const total = this.totalQuestions;
+        const answered = this.answeredQuestions;
+
+        if (this.elements.totalQuestions) {
+            this.elements.totalQuestions.textContent = total || 0;
+        }
+
+        let currentValue = 0;
+        if (!total) {
+            currentValue = 0;
+        } else if (answered >= total) {
+            currentValue = total;
         } else {
-            card.classList.remove('active');
+            currentValue = answered + 1;
         }
 
-        card.dataset.answered = 'false';
-
-        const choices = card.querySelectorAll('.quiz-choice');
-        choices.forEach(choice => {
-            choice.disabled = false;
-            choice.classList.remove('correct', 'incorrect', 'locked', 'touching');
-            choice.removeAttribute('aria-disabled');
-        });
-
-        const feedback = card.querySelector('.quiz-feedback');
-        if (feedback) {
-            feedback.textContent = '';
+        if (this.elements.currentQuestion) {
+            this.elements.currentQuestion.textContent = currentValue;
         }
-    });
 
-    const completion = container.querySelector('.quiz-completion');
-    if (completion) {
-        completion.classList.remove('visible');
-        completion.setAttribute('aria-hidden', 'true');
-    }
-
-    if (activateFirstCard && !firstVisibleSet) {
-        const placeholder = container.querySelector('.quiz-card');
-        if (placeholder) {
-            placeholder.classList.add('active');
+        if (this.elements.progressFill) {
+            const percent = total ? Math.min(100, Math.round((answered / total) * 100)) : 0;
+            this.elements.progressFill.style.width = `${percent}%`;
         }
     }
-}
 
-function advanceQuiz(currentCard) {
-    const container = currentCard ? currentCard.closest('.quiz-phase-container') : null;
-    if (!container) return;
+    renderEmptyState() {
+        if (!this.elements.content) {
+            return;
+        }
+        this.clearAdvanceTimeout();
+        this.elements.content.innerHTML = '<div class="quiz-placeholder">Слова для этой викторины появятся позже.</div>';
+        this.updateModeIndicator();
+        this.updateProgressDisplay();
+        refreshActiveExerciseContentHeight();
+    }
 
-    const phaseKey = container.dataset.phase || null;
-    const cards = Array.from(container.querySelectorAll('.quiz-card')).filter(card => !card.classList.contains('empty'));
-    const currentIndex = cards.indexOf(currentCard);
+    generateForwardQuestion(word) {
+        const options = this.generateOptions(word.russian, 'russian');
+        return {
+            question: `Что означает немецкое слово «${word.german}»?`,
+            germanWord: word.german,
+            transcription: word.transcription,
+            options: options,
+            correct: word.russian,
+            type: 'forward',
+        };
+    }
 
-    if (currentIndex === -1) return;
+    generateReverseQuestion(word) {
+        const options = this.generateOptions(word.german, 'german');
+        return {
+            question: `Как переводится на немецкий слово «${word.russian}»?`,
+            russianWord: word.russian,
+            germanWord: word.german,
+            options: options,
+            correct: word.german,
+            type: 'reverse',
+        };
+    }
 
-    if (currentIndex < cards.length - 1) {
-        currentCard.classList.remove('active');
-        const nextCard = cards[currentIndex + 1];
-        nextCard.classList.add('active');
-        nextCard.dataset.answered = 'false';
-
-        const choices = nextCard.querySelectorAll('.quiz-choice');
-        choices.forEach(choice => {
-            choice.disabled = false;
-            choice.classList.remove('correct', 'incorrect', 'locked', 'touching');
-            choice.removeAttribute('aria-disabled');
-        });
-
-        const feedback = nextCard.querySelector('.quiz-feedback');
-        if (feedback) {
-            feedback.textContent = '';
+    generateOptions(correctAnswer, type) {
+        const options = new Set();
+        if (correctAnswer) {
+            options.add(correctAnswer);
         }
 
-        if (isTouchDevice && window.innerWidth < 768) {
-            setTimeout(() => {
-                nextCard.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'center'
-                });
-            }, 150);
-        }
-    } else {
-        const completion = container.querySelector('.quiz-completion');
-        if (completion) {
-            completion.classList.add('visible');
-            completion.setAttribute('aria-hidden', 'false');
+        const localValues = this.originalWords
+            .map(word => (type === 'russian' ? word.russian : word.german))
+            .filter(Boolean);
+        const globalValues = globalOptionPools[type] || [];
+        const combinedPool = shuffleWords([...new Set([...localValues, ...globalValues])]);
 
-            if (isTouchDevice && window.innerWidth < 768) {
-                setTimeout(() => {
-                    completion.scrollIntoView({
-                        behavior: 'smooth',
-                        block: 'center'
-                    });
-                }, 150);
+        for (const candidate of combinedPool) {
+            if (!candidate || options.has(candidate)) {
+                continue;
+            }
+            options.add(candidate);
+            if (options.size === 4) {
+                break;
             }
         }
 
-        if (phaseKey) {
-            handlePhaseCompletion(phaseKey);
+        if (options.size < 4) {
+            const fallbackPool = shuffleWords(globalValues);
+            for (const candidate of fallbackPool) {
+                if (!candidate || options.has(candidate)) {
+                    continue;
+                }
+                options.add(candidate);
+                if (options.size === 4) {
+                    break;
+                }
+            }
         }
+
+        return shuffleWords(Array.from(options).slice(0, 4));
     }
 
-    if (phaseKey) {
-        updateQuizStatsUI(phaseKey);
-    }
-
-    refreshActiveExerciseContentHeight();
-}
-
-function handleQuizChoiceSelection(button) {
-    if (!button) return;
-
-    const quizCard = button.closest('.quiz-card');
-    if (!quizCard || quizCard.dataset.answered === 'true') {
-        return;
-    }
-
-    const container = quizCard.closest('.quiz-phase-container');
-    const phaseKey = container ? container.dataset.phase : null;
-    const questionIndex = parseInt(quizCard.dataset.questionIndex || '0', 10);
-    const selectedIndex = parseInt(button.dataset.choiceIndex || '0', 10);
-    const correctIndex = parseInt(quizCard.dataset.correctIndex || '0', 10);
-    const choices = Array.from(quizCard.querySelectorAll('.quiz-choice'));
-    const feedback = quizCard.querySelector('.quiz-feedback');
-
-    quizCard.dataset.answered = 'true';
-
-    choices.forEach(choice => {
-        choice.disabled = true;
-        choice.classList.add('locked');
-        choice.setAttribute('aria-disabled', 'true');
-    });
-
-    const correctChoice = choices.find(choice => parseInt(choice.dataset.choiceIndex || '0', 10) === correctIndex);
-
-    if (selectedIndex === correctIndex) {
-        button.classList.add('correct');
-        if (feedback) {
-            feedback.textContent = 'Верно! Отличная работа.';
+    renderQuestion(question) {
+        if (!this.elements.content) {
+            return;
         }
-    } else {
-        button.classList.add('incorrect');
-        if (correctChoice) {
-            correctChoice.classList.add('correct');
+
+        this.clearAdvanceTimeout();
+        this.isTransition = false;
+        this.optionLocked = false;
+        this.activeQuestion = question;
+
+        const card = document.createElement('div');
+        card.className = 'quiz-question-card';
+        card.dataset.mode = question.type;
+
+        const questionText = document.createElement('div');
+        questionText.className = 'quiz-question-text';
+        questionText.textContent = question.question;
+        card.appendChild(questionText);
+
+        const meta = document.createElement('div');
+        meta.className = 'quiz-word-meta';
+
+        if (question.type === 'forward') {
+            const wordSpan = document.createElement('span');
+            wordSpan.className = 'quiz-word';
+            wordSpan.textContent = question.germanWord;
+            meta.appendChild(wordSpan);
+
+            if (question.transcription) {
+                const transcriptionSpan = document.createElement('span');
+                transcriptionSpan.className = 'quiz-transcription';
+                transcriptionSpan.textContent = question.transcription;
+                meta.appendChild(transcriptionSpan);
+            }
+        } else {
+            const wordSpan = document.createElement('span');
+            wordSpan.className = 'quiz-word';
+            wordSpan.textContent = question.russianWord;
+            meta.appendChild(wordSpan);
         }
-        if (feedback) {
-            feedback.textContent = 'Неверно. Правильный ответ подсвечен.';
-        }
-    }
 
-    const choiceLabels = choices.map(choice => choice.textContent.trim());
-    recordQuizAttempt(phaseKey, questionIndex, selectedIndex, correctIndex, choiceLabels);
+        card.appendChild(meta);
 
-    if (navigator.vibrate && isTouchDevice) {
-        navigator.vibrate(selectedIndex === correctIndex ? 20 : 40);
-    }
+        const optionsWrapper = document.createElement('div');
+        optionsWrapper.className = 'quiz-options';
+        this.optionButtons = [];
 
-    refreshActiveExerciseContentHeight();
-
-    setTimeout(() => {
-        advanceQuiz(quizCard);
-    }, QUIZ_ADVANCE_DELAY);
-}
-
-function attachQuizHandlers() {
-    const choiceButtons = document.querySelectorAll('.quiz-choice');
-    choiceButtons.forEach(button => {
-        button.addEventListener('click', function(event) {
-            event.preventDefault();
-            event.stopPropagation();
-            handleQuizChoiceSelection(this);
+        question.options.forEach(option => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'quiz-option';
+            button.textContent = option;
+            button.dataset.value = option;
+            button.addEventListener('click', () => this.handleOptionSelect(button, question));
+            optionsWrapper.appendChild(button);
+            this.optionButtons.push(button);
         });
 
-        if (isTouchDevice) {
-            button.addEventListener('touchstart', function() {
-                this.classList.add('touching');
-            });
+        card.appendChild(optionsWrapper);
 
-            button.addEventListener('touchend', function() {
-                setTimeout(() => {
-                    this.classList.remove('touching');
-                }, 120);
+        this.feedbackElement = document.createElement('div');
+        this.feedbackElement.className = 'quiz-feedback';
+        this.feedbackElement.setAttribute('aria-live', 'polite');
+        card.appendChild(this.feedbackElement);
+
+        this.elements.content.innerHTML = '';
+        this.elements.content.appendChild(card);
+
+        this.updateModeIndicator();
+        this.updateProgressDisplay();
+        refreshActiveExerciseContentHeight();
+    }
+
+    handleOptionSelect(button, question) {
+        if (this.optionLocked || !button || !question) {
+            return;
+        }
+
+        this.optionLocked = true;
+        const selectedValue = button.dataset.value || button.textContent || '';
+        const correctValue = question.correct;
+
+        this.optionButtons.forEach(optionButton => {
+            optionButton.classList.add('locked');
+            optionButton.disabled = true;
+            if (optionButton.dataset.value === correctValue || optionButton.textContent === correctValue) {
+                optionButton.classList.add('correct');
+            }
+        });
+
+        if (selectedValue === correctValue) {
+            button.classList.add('correct');
+            if (this.feedbackElement) {
+                this.feedbackElement.textContent = 'Верно! Отличная работа.';
+            }
+            this.correctAnswers += 1;
+        } else {
+            button.classList.add('incorrect');
+            if (this.feedbackElement) {
+                this.feedbackElement.textContent = 'Неверно. Правильный ответ подсвечен.';
+            }
+            this.incorrectAnswers.push({
+                word: question.germanWord,
+                translation: question.type === 'forward' ? correctValue : question.russianWord,
+                selected: selectedValue,
+                correct: correctValue,
+                mode: question.type,
             });
         }
-    });
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(selectedValue === correctValue ? 20 : 40);
+        }
+
+        this.answeredQuestions += 1;
+        this.updateProgressDisplay();
+
+        this.advanceTimeout = setTimeout(() => {
+            this.prepareNextStep();
+        }, this.advanceDelay);
+    }
+
+    prepareNextStep() {
+        this.clearAdvanceTimeout();
+        this.currentIndex += 1;
+        this.optionLocked = false;
+        this.activeQuestion = null;
+        this.renderNext();
+    }
+
+    renderNext() {
+        const nextQuestion = this.nextQuestion();
+        if (nextQuestion) {
+            this.renderQuestion(nextQuestion);
+        }
+    }
+
+    nextQuestion() {
+        if (!this.originalWords.length) {
+            this.renderEmptyState();
+            return null;
+        }
+
+        if (this.currentIndex >= this.words.length && !this.completedForward) {
+            this.completedForward = true;
+            this.currentMode = 'reverse';
+            this.currentIndex = 0;
+            this.words = shuffleWords(this.originalWords);
+            this.isTransition = true;
+            this.updateModeIndicator();
+            this.updateProgressDisplay();
+            this.showModeTransition();
+            return null;
+        }
+
+        if (this.currentIndex >= this.words.length && this.completedForward) {
+            this.showFinalResults();
+            return null;
+        }
+
+        const word = this.words[this.currentIndex];
+        if (!word) {
+            this.showFinalResults();
+            return null;
+        }
+
+        return this.currentMode === 'forward'
+            ? this.generateForwardQuestion(word)
+            : this.generateReverseQuestion(word);
+    }
+
+    showModeTransition() {
+        if (!this.elements.content) {
+            return;
+        }
+        this.clearAdvanceTimeout();
+        this.elements.content.innerHTML = `
+            <div class="mode-transition">
+                <h3>🎉 Отлично! Первый этап пройден!</h3>
+                <p>Теперь проверим обратное направление:</p>
+                <p><strong>Русский → Немецкий</strong></p>
+                <button type="button" onclick="continueQuiz()">Продолжить</button>
+            </div>
+        `;
+        const continueButton = this.elements.content.querySelector('button');
+        if (continueButton) {
+            continueButton.addEventListener('click', () => this.continueToReverse());
+        }
+        this.updateModeIndicator();
+        this.updateProgressDisplay();
+        refreshActiveExerciseContentHeight();
+    }
+
+    continueToReverse() {
+        if (!this.completedForward) {
+            return;
+        }
+
+        this.isTransition = false;
+        this.optionLocked = false;
+        this.updateModeIndicator();
+        this.renderNext();
+    }
+
+    showFinalResults() {
+        if (!this.elements.content) {
+            return;
+        }
+
+        this.clearAdvanceTimeout();
+        this.quizCompleted = true;
+        this.isTransition = false;
+        this.answeredQuestions = this.totalQuestions;
+        this.updateModeIndicator();
+        this.updateProgressDisplay();
+
+        const percentage = this.totalQuestions
+            ? Math.round((this.correctAnswers / this.totalQuestions) * 100)
+            : 0;
+
+        this.elements.content.innerHTML = `
+            <div class="quiz-results">
+                <h3>🏆 Викторина завершена!</h3>
+                <p>Результат: ${this.correctAnswers} из ${this.totalQuestions} (${percentage}%)</p>
+                <div class="result-details">
+                    <p>✅ Прямой режим (DE→RU): пройден</p>
+                    <p>✅ Обратный режим (RU→DE): пройден</p>
+                </div>
+                <button type="button" onclick="restartQuiz()">Начать заново</button>
+            </div>
+        `;
+
+        const restartButton = this.elements.content.querySelector('button');
+        if (restartButton) {
+            restartButton.addEventListener('click', () => this.restart());
+        }
+
+        refreshActiveExerciseContentHeight();
+        this.dispatchCompletionEvent();
+    }
+
+    dispatchCompletionEvent() {
+        if (!this.phaseKey) {
+            return;
+        }
+
+        const detail = {
+            characterId: typeof characterId === 'string' ? characterId : '',
+            phaseId: this.phaseKey,
+            phaseTitle: this.phaseTitle || '',
+            completedAt: new Date().toISOString(),
+            totalQuestions: this.totalQuestions,
+            correctAnswers: this.correctAnswers,
+            incorrectWords: this.incorrectAnswers.map(item => ({
+                word: item.word,
+                translation: item.translation,
+                selected: item.selected,
+                correctAnswer: item.correct,
+                mode: item.mode,
+            })),
+        };
+
+        if (typeof queuePhaseReview === 'function') {
+            queuePhaseReview(detail);
+        }
+
+        try {
+            document.dispatchEvent(new CustomEvent('journeyPhaseCompleted', { detail }));
+        } catch (error) {
+            console.warn('[VocabularyQuiz] Unable to dispatch completion event', error);
+        }
+    }
+
+    restart() {
+        this.start();
+    }
+}
+
+function buildPhaseQuizWords(phase) {
+    if (!phase || !Array.isArray(phase.words)) {
+        return [];
+    }
+
+    return phase.words
+        .map(word => ({
+            german: word.word || '',
+            russian: word.translation || '',
+            transcription: word.transcription || '',
+        }))
+        .filter(word => word.german && word.russian);
+}
+
+function initializeVocabularyQuiz(phaseKey) {
+    const phase = phaseVocabularies[phaseKey];
+    const words = buildPhaseQuizWords(phase);
+    const phaseTitle = phase ? phase.title : '';
+
+    if (activeVocabularyQuiz) {
+        activeVocabularyQuiz.clearAdvanceTimeout();
+    }
+
+    activeVocabularyQuiz = new VocabularyQuiz(phaseKey, words, phaseTitle);
+    activeVocabularyQuiz.start();
+}
+
+if (typeof window !== 'undefined') {
+    window.continueQuiz = function() {
+        if (activeVocabularyQuiz) {
+            activeVocabularyQuiz.continueToReverse();
+        }
+    };
+
+    window.restartQuiz = function() {
+        if (activeVocabularyQuiz) {
+            activeVocabularyQuiz.restart();
+        }
+    };
 }
 
 // ============= RELATIONS FUNCTIONS (lines 400-600) =============
@@ -2226,7 +2245,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const journeyPoints = document.querySelectorAll('.journey-point');
     initializeProgressLine();
     initializeConstructorSection();
-    attachQuizHandlers();
 
     const exerciseToggles = document.querySelectorAll('.exercise-toggle');
     const exerciseContents = document.querySelectorAll('.exercise-content');

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -127,52 +127,25 @@
             <div class="exercise-item">
                 <button class="exercise-toggle" type="button">
                     <span class="toggle-icon">▶</span>
-                    🧠 Викторина по фазам
+                    🧠 Викторина по словам
                 </button>
                 <div class="exercise-content collapsed">
-                    {% if quizzes %}
-                    <div class="quiz-section" data-quiz-map='{{ quizzes_json | safe }}'>
-                        <div class="quiz-stats-panel" aria-live="polite" data-phase="">
-                            <h3 class="quiz-stats-title">📊 Статистика фазы: <span data-quiz-phase-name>{{ first_phase_title or '—' }}</span></h3>
-                            <p class="quiz-stats-summary" data-quiz-summary>Пройдено 0 из 0 вопросов.</p>
-                            <div class="quiz-progress-row">
-                                <span class="quiz-progress-label">Прогресс:</span>
-                                <span class="quiz-progress-value" data-quiz-progress>—</span>
-                            </div>
-                            <div class="quiz-errors-container" data-quiz-errors>
-                                <p class="quiz-errors-empty">Ошибок пока нет — начните викторину!</p>
+                    <div class="quiz-header">
+                        <div class="quiz-progress">
+                            <span class="progress-text">Вопрос <span id="current-question">1</span> из <span id="total-questions">1</span></span>
+                            <div class="progress-bar">
+                                <div class="progress-fill" style="width: 0%"></div>
                             </div>
                         </div>
-                        <p class="quiz-intro">Проверьте знание слов: в текущей фазе <span class="quiz-count">{% if quizzes and quizzes[0].questions %}{{ quizzes[0].questions | length }}{% else %}0{% endif %}</span> вопрос(ов).</p>
+                        <div class="quiz-mode-indicator">
+                            <span class="mode-badge active" data-mode="forward">DE → RU</span>
+                            <span class="mode-badge" data-mode="reverse">RU → DE</span>
+                        </div>
+                    </div>
 
-                        {% for quiz in quizzes %}
-                        <div class="quiz-phase-container{% if quiz.is_active %} active{% endif %}" data-phase="{{ quiz.phase_id }}">
-                            {% if quiz.questions %}
-                                {% for question in quiz.questions %}
-                                <div class="quiz-card{% if loop.first %} active{% endif %}" data-question-index="{{ loop.index0 }}" data-correct-index="{{ question.correct_index }}">
-                                    <div class="quiz-question">{{ question.question }}</div>
-                                    <div class="quiz-choices">
-                                        {% for choice in question.choices %}
-                                        <button class="quiz-choice" type="button" data-choice-index="{{ loop.index0 }}">{{ choice }}</button>
-                                        {% endfor %}
-                                    </div>
-                                    <div class="quiz-feedback" role="status" aria-live="polite"></div>
-                                </div>
-                                {% endfor %}
-                            {% else %}
-                                <div class="quiz-card empty active">
-                                    <div class="quiz-question">Вопросы для этой фазы скоро появятся.</div>
-                                </div>
-                            {% endif %}
-                            <div class="quiz-completion" aria-hidden="true">🎉 Викторина пройдена! Так держать!</div>
-                        </div>
-                        {% endfor %}
+                    <div class="quiz-content">
+                        <div class="quiz-placeholder">Выберите фазу, чтобы начать викторину.</div>
                     </div>
-                    {% else %}
-                    <div class="quiz-section quiz-section--empty">
-                        <p class="quiz-empty-message">Викторина появится позже.</p>
-                    </div>
-                    {% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- rename the journey quiz to "Викторина по словам" and introduce the new progress header and content container
- add refreshed styles for the quiz header, mode badges, question cards, transitions, and results screen
- replace the phase quiz logic with a bidirectional VocabularyQuiz class that randomizes questions in both directions and tracks progress

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cede3fee2c83209cebab2d2fdbb9bd