### PR TITLE
Remove collocations exercises and data

### DIFF
--- a/data/vocabulary/vocabulary.json
+++ b/data/vocabulary/vocabulary.json
@@ -64,9 +64,6 @@
         "отвергать",
         "verstoßen — тоже «отвергать»"
       ],
-      "collocations": [
-        "Ich weise alle seine Bitten ab. — Я отвергаю все его просьбы."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -97,9 +94,6 @@
       "synonyms": [
         "уважать"
       ],
-      "collocations": [
-        "Ich achte beide Söhne, Edgar und Edmund. — Я уважаю обоих сыновей, Эдгара и Эдмунда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -129,9 +123,6 @@
       ],
       "synonyms": [
         "предчувствовать"
-      ],
-      "collocations": [
-        "Ich ahne das schlimme Ende voraus. — Я предчувствую плохой конец."
       ],
       "visual_hint": "📚"
     },
@@ -166,9 +157,6 @@
         "misstrauen — тоже «не»",
         "подозревающий"
       ],
-      "collocations": [
-        "Ahnungslos vertraue ich meinem Bruder. — Ничего не подозревая, я доверяю брату."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -196,9 +184,6 @@
       ],
       "synonyms": [
         "атаковать"
-      ],
-      "collocations": [
-        "Das Angreifen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело атаковать."
       ],
       "visual_hint": "📚"
     },
@@ -229,9 +214,6 @@
       ],
       "synonyms": [
         "наниматься"
-      ],
-      "collocations": [
-        "Als Кай heuere ich beim König an. — Как Кай я нанимаюсь к королю."
       ],
       "visual_hint": "📚"
     },
@@ -265,9 +247,6 @@
         "beschuldigen — тоже «обвинять»",
         "verklagen — тоже «обвинять»"
       ],
-      "collocations": [
-        "Ich klage sie ihrer Unmenschlichkeit an. — Я обвиняю её в бесчеловечности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -298,9 +277,6 @@
       "synonyms": [
         "подстрекать"
       ],
-      "collocations": [
-        "Ich stachle sie zu größerer Grausamkeit an. — Я подстрекаю её к большей жестокости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -328,9 +304,6 @@
       ],
       "synonyms": [
         "отвечать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Antworten auch ohne Stolz möglich ist. — Корделия показывает, что отвечать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -361,9 +334,6 @@
       ],
       "synonyms": [
         "простодушный"
-      ],
-      "collocations": [
-        "Ich bin zu arglos für solche Intrigen. — Я слишком простодушен для таких интриг."
       ],
       "visual_hint": "📚"
     },
@@ -396,9 +366,6 @@
         "подозревать",
         "verdächtigen — тоже «подозревать»"
       ],
-      "collocations": [
-        "Ich argwöhne Gift in meinem Wein. — Я подозреваю яд в моём вине."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -428,9 +395,6 @@
       ],
       "synonyms": [
         "бедный"
-      ],
-      "collocations": [
-        "Die Armen leiden mehr als Könige jemals wissen. — Бедные страдают больше, чем короли когда-либо узнают."
       ],
       "visual_hint": "📚"
     },
@@ -462,9 +426,6 @@
       "synonyms": [
         "строить"
       ],
-      "collocations": [
-        "Ich baue auf, was zerstört wurde. — Я строю то, что было разрушено."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -494,9 +455,6 @@
       ],
       "synonyms": [
         "восставать"
-      ],
-      "collocations": [
-        "Ich begehre auf gegen das Unrecht. — Я восстаю против несправедливости."
       ],
       "visual_hint": "📚"
     },
@@ -531,10 +489,6 @@
       "synonyms": [
         "сдаваться"
       ],
-      "collocations": [
-        "Ich gebe auf, nachdem mein Herr gestorben ist. — Я сдаюсь после смерти моего господина.",
-        "Ich will das Leben aufgeben. — Я хочу отказаться от жизни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -564,9 +518,6 @@
       ],
       "synonyms": [
         "принимать"
-      ],
-      "collocations": [
-        "Der König von Frankreich nimmt mich liebevoll auf. — Король Франции принимает меня с любовью."
       ],
       "visual_hint": "📚"
     },
@@ -598,9 +549,6 @@
       "synonyms": [
         "искренний"
       ],
-      "collocations": [
-        "Ich bin aufrichtig, auch wenn es gefährlich ist. — Я искренен, даже если это опасно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -631,9 +579,6 @@
       "synonyms": [
         "выслеживать"
       ],
-      "collocations": [
-        "Ich spüre den Flüchtling überall auf. — Я выслеживаю беглеца повсюду."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -663,9 +608,6 @@
       ],
       "synonyms": [
         "возвышаться"
-      ],
-      "collocations": [
-        "Ich will über alle aufsteigen. — Я хочу возвыситься над всеми."
       ],
       "visual_hint": "📚"
     },
@@ -698,9 +640,6 @@
         "просыпаться",
         "erwachen — тоже «просыпаться»"
       ],
-      "collocations": [
-        "Ich wache auf aus meinem langen Schlaf. — Я просыпаюсь от долгого сна."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -729,9 +668,6 @@
       "synonyms": [
         "расти",
         "wachsen — тоже «расти»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Aufwachsen ist. — Во время бури становится понятно, насколько важно расти."
       ],
       "visual_hint": "📚"
     },
@@ -762,9 +698,6 @@
         "выдерживать",
         "ausharren — тоже «выдерживать»",
         "durchhalten — тоже «выдерживать»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Aushalten alle verändert. — Шут чувствует, как умение выдерживать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -798,9 +731,6 @@
         "aushalten — тоже «выдерживать»",
         "durchhalten — тоже «выдерживать»"
       ],
-      "collocations": [
-        "Ich harre aus bis zur Befreiung. — Я выдерживаю до освобождения."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -833,9 +763,6 @@
         "verheiraten — тоже «выдавать»",
         "verraten — тоже «выдавать»"
       ],
-      "collocations": [
-        "Ich liefere ihn seinen Feinden aus. — Я выдаю его врагам."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -865,9 +792,6 @@
       ],
       "synonyms": [
         "использовать"
-      ],
-      "collocations": [
-        "Ich nutze ihre Leidenschaft aus. — Я использую их страсть."
       ],
       "visual_hint": "📚"
     },
@@ -901,10 +825,6 @@
       "synonyms": [
         "выкалывать"
       ],
-      "collocations": [
-        "Stecht ihm beide Augen aus! — Выколите ему оба глаза!",
-        "Seine Augen steche ich mit Freude aus. — Его глаза я выкалываю с радостью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -936,9 +856,6 @@
         "угрожать",
         "drohen — тоже «угрожать»"
       ],
-      "collocations": [
-        "Ich bedrohe sie mit dem Tod. — Я угрожаю ей смертью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -966,10 +883,6 @@
       ],
       "synonyms": [
         "приказывать"
-      ],
-      "collocations": [
-        "Das Befehlen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело приказывать.",
-        "Ich befehle, und alle gehorchen mir. — Я приказываю, и все подчиняются мне."
       ],
       "visual_hint": "📚"
     },
@@ -1002,9 +915,6 @@
         "исполнять",
         "erfüllen — тоже «исполнять»"
       ],
-      "collocations": [
-        "Jeden Befehl befolge ich sofort. — Каждый приказ я исполняю немедленно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1033,9 +943,6 @@
       "synonyms": [
         "освобождать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Befreien auch ohne Stolz möglich ist. — Корделия показывает, что освобождать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1063,9 +970,6 @@
       ],
       "synonyms": [
         "встречать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Begegnen alle verändert. — Шут чувствует, как умение встречать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -1097,12 +1001,6 @@
         "желать",
         "verlangen — тоже «желать»",
         "wünschen — тоже «желать»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Begehren ist. — Во время бури становится понятно, насколько важно желать.",
-        "Ich begehre Edmund mit brennender Lust. — Я вожделею Эдмунда с пылающей страстью.",
-        "Ich begehre die Krone für mich selbst. — Я вожделею корону для себя.",
-        "Ich begehre Edmund mehr als mein Leben. — Я желаю Эдмунда больше жизни."
       ],
       "visual_hint": "📚"
     },
@@ -1138,11 +1036,6 @@
       "synonyms": [
         "сопровождать"
       ],
-      "collocations": [
-        "Als Tom begleite ich Lear durch seine dunkelste Stunde. — Как Том, я сопровождаю Лира в его самый тёмный час.",
-        "Ich begleite ihn durch Wind und Regen. — Я сопровождаю его сквозь ветер и дождь.",
-        "Treu begleite ich meinen verrückten König. — Верно я сопровождаю своего безумного короля."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1172,10 +1065,6 @@
         "понимать",
         "verstehen — тоже «понимать»"
       ],
-      "collocations": [
-        "Das Begreifen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело понимать.",
-        "Ich begreife das Ausmaß ihrer Grausamkeit. — Я понимаю масштаб её жестокости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1203,9 +1092,6 @@
       ],
       "synonyms": [
         "сохранять"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Behalten auch ohne Stolz möglich ist. — Корделия показывает, что сохранять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -1235,10 +1121,6 @@
       "synonyms": [
         "владеть",
         "господствовать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Beherrschen ist. — Во время бури становится понятно, насколько важно владеть.",
-        "Ich beherrsche das Spiel der Macht. — Я господствую в игре власти."
       ],
       "visual_hint": "📚"
     },
@@ -1271,9 +1153,6 @@
         "бороться",
         "kämpfen — тоже «бороться»"
       ],
-      "collocations": [
-        "Ich bekämpfe sie mit allen Mitteln. — Я борюсь с ней всеми средствами."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1301,10 +1180,6 @@
       ],
       "synonyms": [
         "оскорблять"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Beleidigen alle verändert. — Шут чувствует, как умение оскорблять меняет всех.",
-        "Ich beleidige den alten König ohne Scham. — Я оскорбляю старого короля без стыда."
       ],
       "visual_hint": "📚"
     },
@@ -1334,9 +1209,6 @@
       "synonyms": [
         "награждать"
       ],
-      "collocations": [
-        "Das Belohnen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело награждать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1365,9 +1237,6 @@
       "synonyms": [
         "лгать",
         "lügen — тоже «лгать»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Belügen auch ohne Stolz möglich ist. — Корделия показывает, что лгать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -1399,9 +1268,6 @@
       "synonyms": [
         "обделённый"
       ],
-      "collocations": [
-        "Ich bin von Geburt an benachteiligt. — Я обделён с рождения."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1429,13 +1295,6 @@
       ],
       "synonyms": [
         "сожалеть"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Bereuen ist. — Во время бури становится понятно, насколько важно сожалеть.",
-        "Sie wird ihre Grausamkeit bereuen! — Она пожалеет о своей жестокости!",
-        "Am Ende bereue ich meine Taten. — В конце я сожалею о своих делах.",
-        "Später werde ich diese Tat bitter bereuen. — Позже я горько пожалею об этом поступке.",
-        "Zu spät bereue ich meine Taten. — Слишком поздно я сожалею о своих делах."
       ],
       "visual_hint": "📚"
     },
@@ -1466,9 +1325,6 @@
       ],
       "synonyms": [
         "ограничивать"
-      ],
-      "collocations": [
-        "Ich beschränke seine Dienerschaft auf null. — Я ограничиваю его свиту до нуля."
       ],
       "visual_hint": "📚"
     },
@@ -1502,9 +1358,6 @@
         "anklagen — тоже «обвинять»",
         "verklagen — тоже «обвинять»"
       ],
-      "collocations": [
-        "Ich beschuldige Edgar des Verrats. — Я обвиняю Эдгара в предательстве."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1535,12 +1388,6 @@
         "schützen — тоже «защищать»",
         "verteidigen — тоже «защищать»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Beschützen alle verändert. — Шут чувствует, как умение защищать меняет всех.",
-        "Die Unschuldigen will ich beschützen. — Невинных я хочу защитить.",
-        "Heimlich beschütze ich den wahnsinnigen König. — Тайно я защищаю безумного короля.",
-        "Ich kann ihn aus der Ferne nicht beschützen. — Я не могу защитить его издалека."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1570,9 +1417,6 @@
       ],
       "synonyms": [
         "устранять"
-      ],
-      "collocations": [
-        "Ich muss meine Schwester beseitigen. — Я должна устранить свою сестру."
       ],
       "visual_hint": "📚"
     },
@@ -1605,10 +1449,6 @@
         "strafen — тоже «наказывать»",
         "züchtigen — тоже «наказывать»"
       ],
-      "collocations": [
-        "Das Bestrafen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело наказывать.",
-        "Ich bestrafe Kent für seine Frechheit. — Я караю Кента за его дерзость."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1638,9 +1478,6 @@
       ],
       "synonyms": [
         "молиться"
-      ],
-      "collocations": [
-        "Jeden Tag bete ich für seine Sicherheit. — Каждый день я молюсь за его безопасность."
       ],
       "visual_hint": "📚"
     },
@@ -1673,10 +1510,6 @@
         "обманывать",
         "hintergehen — тоже «обманывать»",
         "täuschen — тоже «обманывать»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Betrügen auch ohne Stolz möglich ist. — Корделия показывает, что обманывать можно и без гордыни.",
-        "Ich betrüge ihn mit Edmund. — Я изменяю ему с Эдмундом."
       ],
       "visual_hint": "📚"
     },
@@ -1713,10 +1546,6 @@
         "просить",
         "bitten — тоже «просить»"
       ],
-      "collocations": [
-        "Um mein Leben bettle ich vergeblich. — О жизни я умоляю напрасно.",
-        "Muss ich um Unterkunft betteln bei meinen eigenen Kindern? — Должен ли я просить крова у собственных детей?"
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1746,9 +1575,6 @@
       ],
       "synonyms": [
         "тревожить"
-      ],
-      "collocations": [
-        "Ihre Grausamkeit beunruhigt mich zunehmend. — Её жестокость всё больше тревожит меня."
       ],
       "visual_hint": "📚"
     },
@@ -1780,9 +1606,6 @@
       "synonyms": [
         "охранять"
       ],
-      "collocations": [
-        "Heimlich bewache ich meinen alten Herrn. — Тайно я охраняю своего старого господина."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1810,9 +1633,6 @@
       ],
       "synonyms": [
         "оплакивать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Beweinen ist. — Во время бури становится понятно, насколько важно оплакивать."
       ],
       "visual_hint": "📚"
     },
@@ -1842,9 +1662,6 @@
       "synonyms": [
         "доказывать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Beweisen alle verändert. — Шут чувствует, как умение доказывать меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1872,9 +1689,6 @@
       ],
       "synonyms": [
         "платить"
-      ],
-      "collocations": [
-        "Das Bezahlen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело платить."
       ],
       "visual_hint": "📚"
     },
@@ -1906,9 +1720,6 @@
       "synonyms": [
         "одобрять"
       ],
-      "collocations": [
-        "Ich billige alle ihre grausamen Pläne. — Я одобряю все её жестокие планы."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -1937,9 +1748,6 @@
       "synonyms": [
         "просить",
         "betteln — тоже «просить»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Bitten auch ohne Stolz möglich ist. — Корделия показывает, что просить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -1971,9 +1779,6 @@
       "synonyms": [
         "горький"
       ],
-      "collocations": [
-        "Die Wahrheit schmeckt bitter wie Galle. — Правда горька как желчь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2002,9 +1807,6 @@
       "synonyms": [
         "оставаться"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Bleiben ist. — Во время бури становится понятно, насколько важно оставаться."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2032,13 +1834,6 @@
       ],
       "synonyms": [
         "ослеплять"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Blenden alle verändert. — Шут чувствует, как умение ослеплять меняет всех.",
-        "Sie blenden ihn auf meinen Hinweis. — Они ослепляют его по моей наводке.",
-        "Wir blenden den treuen Grafen Gloucester. — Мы ослепляем верного графа Глостера.",
-        "Eigenhändig blende ich Gloucester. — Собственноручно я ослепляю Глостера.",
-        "Sie blenden mich für meinen Verrat. — Они ослепляют меня за мою измену."
       ],
       "visual_hint": "📚"
     },
@@ -2073,10 +1868,6 @@
       "synonyms": [
         "слепой"
       ],
-      "collocations": [
-        "Mein blinder Vater erkennt mich nicht. — Мой слепой отец не узнаёт меня.",
-        "Ich bin blind für die Wahrheit. — Я слеп к правде."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2107,9 +1898,6 @@
       "synonyms": [
         "кровоточить"
       ],
-      "collocations": [
-        "Ich blute wie ein geschlachtetes Schwein. — Я кровоточу как зарезанная свинья."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2137,9 +1925,6 @@
       ],
       "synonyms": [
         "ломать"
-      ],
-      "collocations": [
-        "Das Brechen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ломать."
       ],
       "visual_hint": "📚"
     },
@@ -2171,9 +1956,6 @@
       "synonyms": [
         "брутальный"
       ],
-      "collocations": [
-        "Brutal zerschlage ich jeden Widerstand. — Брутально я сокрушаю любое сопротивление."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2204,9 +1986,6 @@
       "synonyms": [
         "расплачиваться"
       ],
-      "collocations": [
-        "Ich büße für all meine Grausamkeiten. — Я расплачиваюсь за все свои жестокости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2235,9 +2014,6 @@
       "synonyms": [
         "благодарить"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Danken auch ohne Stolz möglich ist. — Корделия показывает, что благодарить можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2265,9 +2041,6 @@
       ],
       "synonyms": [
         "возраст"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Alter ein ständiges Thema. — Для придворных «возраст» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2299,9 +2072,6 @@
         "убежище",
         "die Zuflucht — тоже «убежище»"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Asyl zur Sprache kommt. — Сердце Лира тяжелеет: «убежище» звучит слишком близко."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2330,9 +2100,6 @@
       ],
       "synonyms": [
         "лист"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Blatt nie. — В тронном зале постоянно звучит слово «лист»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2363,10 +2130,6 @@
       "synonyms": [
         "кровь"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald das Blut erwähnt wird. — Шут насмехается, едва кто-то произносит «кровь».",
-        "Das Blut des Grafen befleckt meine Hände. — Кровь графа пятнает мои руки."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2395,9 +2158,6 @@
       ],
       "synonyms": [
         "зло"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Böse verteilt wird. — Корделия внимательно следит, кому достанется «зло»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2433,10 +2193,6 @@
       "synonyms": [
         "союз"
       ],
-      "collocations": [
-        "Unser Bündnis ist stark und grausam. — Наш союз силён и жесток.",
-        "Ein Bündnis mit Goneril gegen unseren Vater. — Союз с Гонерильей против нашего отца."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2464,10 +2220,6 @@
       ],
       "synonyms": [
         "хаос"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt das Chaos noch bedrückender. — Во время бури само «хаос» звучит ещё тяжелее.",
-        "Das Chaos in der Natur spiegelt meine Seele! — Хаос в природе отражает мою душу!"
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2498,11 +2250,6 @@
       "synonyms": [
         "дуэль"
       ],
-      "collocations": [
-        "Für die Höflinge bleibt das Duell ein ständiges Thema. — Для придворных «дуэль» — постоянная тема.",
-        "Das Duell mit Edgar ist mein Ende. — Дуэль с Эдгаром - мой конец.",
-        "In diesem Duell kämpfe ich für die Gerechtigkeit. — В этой дуэли я сражаюсь за справедливость."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2531,9 +2278,6 @@
       ],
       "synonyms": [
         "собственность"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Eigentum zur Sprache kommt. — Сердце Лира тяжелеет: «собственность» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2564,11 +2308,6 @@
       "synonyms": [
         "нищета"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Elend nie. — В тронном зале постоянно звучит слово «нищета».",
-        "Im Elend erkenne ich die Wahrheit der Welt. — В нищете я познаю истину мира.",
-        "Im Elend lerne ich die wahre Natur des Menschen. — В нищете я познаю истинную природу человека."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2597,13 +2336,6 @@
       ],
       "synonyms": [
         "конец"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald das Ende erwähnt wird. — Шут насмехается, едва кто-то произносит «конец».",
-        "Das Ende kommt, aber mit dir bin ich nicht allein. — Конец приходит, но с тобой я не одинок.",
-        "Das Ende kommt schnell und gerecht. — Конец приходит быстро и справедливо.",
-        "Dies ist nicht das Ende, nur ein Übergang. — Это не конец, только переход.",
-        "Mein Ende kommt durch eines Dieners Hand. — Мой конец приходит от руки слуги."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2637,9 +2369,6 @@
         "ужас",
         "das Grauen — тоже «ужас»"
       ],
-      "collocations": [
-        "Mit Entsetzen sehe ich ihr wahres Gesicht. — С ужасом я вижу её истинное лицо."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2667,10 +2396,6 @@
       ],
       "synonyms": [
         "наследство"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Erbe verteilt wird. — Корделия внимательно следит, кому достанется «наследство».",
-        "Das Erbe ist endlich mein. — Наследство наконец моё."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2700,9 +2425,6 @@
       ],
       "synonyms": [
         "пробуждение"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt das Erwachen noch bedrückender. — Во время бури само «пробуждение» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2734,9 +2456,6 @@
         "изгнание",
         "die Verbannung — тоже «изгнание»"
       ],
-      "collocations": [
-        "Für die Höflinge bleibt das Exil ein ständiges Thema. — Для придворных «изгнание» — постоянная тема."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2765,9 +2484,6 @@
       ],
       "synonyms": [
         "окно"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Fenster zur Sprache kommt. — Сердце Лира тяжелеет: «окно» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2798,9 +2514,6 @@
       "synonyms": [
         "свита"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Gefolge nie. — В тронном зале постоянно звучит слово «свита»."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2829,10 +2542,6 @@
       ],
       "synonyms": [
         "тюрьма"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald das Gefängnis erwähnt wird. — Шут насмехается, едва кто-то произносит «тюрьма».",
-        "Dieses Gefängnis kann meine Liebe nicht einsperren. — Эта тюрьма не может запереть мою любовь."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2863,10 +2572,6 @@
       "synonyms": [
         "тайна"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Geheimnis verteilt wird. — Корделия внимательно следит, кому достанется «тайна».",
-        "Mein Verschwinden bleibt ein ewiges Geheimnis. — Моё исчезновение остаётся вечной тайной."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -2895,10 +2600,6 @@
       ],
       "synonyms": [
         "совесть"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt das Gewissen noch bedrückender. — Во время бури само «совесть» звучит ещё тяжелее.",
-        "Mein Gewissen beginnt mich zu quälen. — Моя совесть начинает мучить меня."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2931,9 +2632,6 @@
       "synonyms": [
         "яд"
       ],
-      "collocations": [
-        "Das Gift ist bereit für meine Schwester. — Яд готов для моей сестры."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -2961,9 +2659,6 @@
       ],
       "synonyms": [
         "равновесие"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Gleichgewicht ein ständiges Thema. — Для придворных «равновесие» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -2994,9 +2689,6 @@
       "synonyms": [
         "золото"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Gold zur Sprache kommt. — Сердце Лира тяжелеет: «золото» звучит слишком близко."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3025,9 +2717,6 @@
       ],
       "synonyms": [
         "могила"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Grab nie. — В тронном зале постоянно звучит слово «могила»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3059,9 +2748,6 @@
         "ужас",
         "das Entsetzen — тоже «ужас»"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald das Grauen erwähnt wird. — Шут насмехается, едва кто-то произносит «ужас»."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3090,9 +2776,6 @@
       ],
       "synonyms": [
         "добро"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Gute verteilt wird. — Корделия внимательно следит, кому достанется «добро»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3123,11 +2806,6 @@
       "synonyms": [
         "сердце"
       ],
-      "collocations": [
-        "Während des Sturms wirkt das Herz noch bedrückender. — Во время бури само «сердце» звучит ещё тяжелее.",
-        "Mein Herz bricht vor Schmerz und Liebe. — Моё сердце разбивается от боли и любви.",
-        "Mein Herz zerbricht vor Glück und Leid. — Моё сердце разрывается от счастья и горя."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3156,9 +2834,6 @@
       ],
       "synonyms": [
         "заговор"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Komplott ein ständiges Thema. — Для придворных «заговор» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3189,11 +2864,6 @@
       "synonyms": [
         "королевство"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Königreich zur Sprache kommt. — Сердце Лира тяжелеет: «королевство» звучит слишком близко.",
-        "Mein Königreich teile ich unter meinen Töchtern. — Моё королевство я делю между дочерьми.",
-        "Ich diene dem Königreich mit Ehre. — Я служу королевству с честью."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3222,9 +2892,6 @@
       ],
       "synonyms": [
         "страна"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Land nie. — В тронном зале постоянно звучит слово «страна»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3255,9 +2922,6 @@
       "synonyms": [
         "жизнь"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald das Leben erwähnt wird. — Шут насмехается, едва кто-то произносит «жизнь»."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3286,9 +2950,6 @@
       ],
       "synonyms": [
         "страдание"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Leid verteilt wird. — Корделия внимательно следит, кому достанется «страдание»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3321,9 +2982,6 @@
       "synonyms": [
         "песня"
       ],
-      "collocations": [
-        "Mein Lied erzählt von vergangenen Tagen. — Моя песня рассказывает о прошлых днях."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3351,10 +3009,6 @@
       ],
       "synonyms": [
         "сострадание"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt das Mitleid noch bedrückender. — Во время бури само «сострадание» звучит ещё тяжелее.",
-        "Mitleid erfüllt mein Herz für Lear. — Сострадание наполняет моё сердце к Лиру."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3387,9 +3041,6 @@
       "synonyms": [
         "знамение"
       ],
-      "collocations": [
-        "Jedes Omen zeigt auf Untergang. — Каждое знамение указывает на гибель."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3417,10 +3068,6 @@
       ],
       "synonyms": [
         "жертва"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Opfer ein ständiges Thema. — Для придворных «жертва» — постоянная тема.",
-        "Ich bin das Opfer der Wahrheit und Liebe. — Я жертва правды и любви."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3453,9 +3100,6 @@
       "synonyms": [
         "принцип"
       ],
-      "collocations": [
-        "Meine Prinzipien sind wichtiger als meine Ehe. — Мои принципы важнее моего брака."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3483,10 +3127,6 @@
       ],
       "synonyms": [
         "право"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Recht nie. — В тронном зале постоянно звучит слово «право».",
-        "Das Recht muss über das Unrecht siegen. — Право должно победить неправду."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3516,9 +3156,6 @@
       ],
       "synonyms": [
         "империя"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Reich zur Sprache kommt. — Сердце Лира тяжелеет: «империя» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3551,9 +3188,6 @@
       "synonyms": [
         "загадка"
       ],
-      "collocations": [
-        "In Rätseln spreche ich von der Zukunft. — В загадках я говорю о будущем."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3581,11 +3215,6 @@
       ],
       "synonyms": [
         "судьба"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald das Schicksal erwähnt wird. — Шут насмехается, едва кто-то произносит «судьба».",
-        "Unser Schicksal ist miteinander verwoben. — Наши судьбы переплетены.",
-        "Das Schicksal macht Narren aus uns allen. — Судьба делает дураков из всех нас."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3615,9 +3244,6 @@
       ],
       "synonyms": [
         "замок"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Schloss verteilt wird. — Корделия внимательно следит, кому достанется «замок»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3650,9 +3276,6 @@
       "synonyms": [
         "молчание"
       ],
-      "collocations": [
-        "Mein Schweigen macht mich zum Mitschuldigen. — Моё молчание делает меня соучастником."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3680,10 +3303,6 @@
       ],
       "synonyms": [
         "меч"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt das Schwert noch bedrückender. — Во время бури само «меч» звучит ещё тяжелее.",
-        "Mein Schwert ist die Waffe der Wahrheit. — Мой меч - оружие правды."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3716,9 +3335,6 @@
       "synonyms": [
         "беспокойство"
       ],
-      "collocations": [
-        "Ein tiefes Unbehagen erfüllt meine Seele. — Глубокое беспокойство наполняет мою душу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3746,9 +3362,6 @@
       ],
       "synonyms": [
         "несчастье"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Unglück ein ständiges Thema. — Для придворных «несчастье» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3779,9 +3392,6 @@
       "synonyms": [
         "приговор"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn das Urteil zur Sprache kommt. — Сердце Лира тяжелеет: «приговор» звучит слишком близко."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -3810,9 +3420,6 @@
       ],
       "synonyms": [
         "преступление"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über das Verbrechen nie. — В тронном зале постоянно звучит слово «преступление»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3845,9 +3452,6 @@
       "synonyms": [
         "погибель"
       ],
-      "collocations": [
-        "Das Verderben holt mich ein. — Погибель настигает меня."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3877,9 +3481,6 @@
       ],
       "synonyms": [
         "рок"
-      ],
-      "collocations": [
-        "Das Verhängnis ereilt mich gerecht. — Рок настигает меня справедливо."
       ],
       "visual_hint": "📚"
     },
@@ -3911,9 +3512,6 @@
       "synonyms": [
         "состояние"
       ],
-      "collocations": [
-        "Sein ganzes Vermögen wird mir gehören. — Всё его состояние будет моим."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -3941,9 +3539,6 @@
       ],
       "synonyms": [
         "доверие"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald das Vertrauen erwähnt wird. — Шут насмехается, едва кто-то произносит «доверие»."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -3974,9 +3569,6 @@
       "synonyms": [
         "погода"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie das Wetter verteilt wird. — Корделия внимательно следит, кому достанется «погода»."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -4006,9 +3598,6 @@
       "synonyms": [
         "цель"
       ],
-      "collocations": [
-        "Während des Sturms wirkt das Ziel noch bedrückender. — Во время бури само «цель» звучит ещё тяжелее."
-      ],
       "visual_hint": "📚",
       "gender": "neuter"
     },
@@ -4037,9 +3626,6 @@
       ],
       "synonyms": [
         "дом"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt das Zuhause ein ständiges Thema. — Для придворных «дом» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "neuter"
@@ -4077,11 +3663,6 @@
         "унижать",
         "erniedrigen — тоже «унижать»"
       ],
-      "collocations": [
-        "Meine eigene Tochter will mich demütigen! — Моя собственная дочь хочет меня унизить!",
-        "Ich demütige ihn vor aller Augen. — Я унижаю его на глазах у всех.",
-        "Ich demütige meinen alten Vater ohne Mitleid. — Я унижаю старого отца без жалости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4112,9 +3693,6 @@
       "synonyms": [
         "доносить"
       ],
-      "collocations": [
-        "Ich denunziere meinen Vater als Verräter. — Я доношу на отца как на предателя."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4144,9 +3722,6 @@
       ],
       "synonyms": [
         "пропасть"
-      ],
-      "collocations": [
-        "Der Abgrund ruft nach mir. — Пропасть зовёт меня."
       ],
       "visual_hint": "📚"
     },
@@ -4186,12 +3761,6 @@
       "synonyms": [
         "прощание"
       ],
-      "collocations": [
-        "Das ist unser letzter Abschied, mein Kind. — Это наше последнее прощание, дитя моё.",
-        "Unser Abschied ist nur vorübergehend. — Наше прощание лишь временно.",
-        "Der Abschied vom Hof schmerzt mich tief. — Прощание с двором глубоко ранит меня.",
-        "Der Abschied von meinem König bricht mein Herz. — Прощание с моим королём разбивает моё сердце."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4222,11 +3791,6 @@
         "kennen — тоже «знать»",
         "wissen — тоже «знать»",
         "дворянство"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Adel zur Sprache kommt. — Сердце Лира тяжелеет: «дворянство» звучит слишком близко.",
-        "Der Adel erwartet von mir ehrenhaftes Verhalten. — Знать ожидает от меня достойного поведения.",
-        "Als Adel diene ich meinem König treu. — Как знать я верно служу своему королю."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4259,9 +3823,6 @@
       "synonyms": [
         "поручение"
       ],
-      "collocations": [
-        "Jeden Auftrag erfülle ich gewissenhaft. — Каждое поручение я выполняю добросовестно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4292,9 +3853,6 @@
       "synonyms": [
         "борода"
       ],
-      "collocations": [
-        "Mit falschem Bart bin ich nicht zu erkennen. — С фальшивой бородой меня не узнать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4322,10 +3880,6 @@
       ],
       "synonyms": [
         "бастард"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Bastard nie. — В тронном зале постоянно звучит слово «бастард».",
-        "Als Bastard habe ich keine Rechte. — Как бастард я не имею прав."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4355,9 +3909,6 @@
       ],
       "synonyms": [
         "приказ"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Befehl erwähnt wird. — Шут насмехается, едва кто-то произносит «приказ»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4390,9 +3941,6 @@
       "synonyms": [
         "поддержка"
       ],
-      "collocations": [
-        "Mein Beistand ist alles, was ich bieten kann. — Моя поддержка - всё, что я могу предложить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4421,11 +3969,6 @@
       "synonyms": [
         "обман",
         "die Täuschung — тоже «обман»"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Betrug verteilt wird. — Корделия внимательно следит, кому достанется «обман».",
-        "Dieser Betrug wird eines Tages aufgedeckt. — Этот обман однажды раскроется.",
-        "Ich erkenne den Betrug nicht. — Я не распознаю обман."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4460,10 +4003,6 @@
       "synonyms": [
         "нищий"
       ],
-      "collocations": [
-        "Dieser Bettler ist glücklicher als ich, der König! — Этот нищий счастливее меня, короля!",
-        "Als Bettler bin ich unsichtbar für meine Feinde. — Как нищий, я невидим для врагов."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4491,9 +4030,6 @@
       ],
       "synonyms": [
         "доказательство"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Beweis noch bedrückender. — Во время бури само «доказательство» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4523,11 +4059,6 @@
       ],
       "synonyms": [
         "молния"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Blitz ein ständiges Thema. — Для придворных «молния» — постоянная тема.",
-        "Die Blitze sollen meine weißen Haare verbrennen! — Пусть молнии сожгут мои седые волосы!",
-        "Die Blitze erhellen unser Elend. — Молнии освещают нашу нищету."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4559,10 +4090,6 @@
         "гонец",
         "посланник"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Bote zur Sprache kommt. — Сердце Лира тяжелеет: «посланник» звучит слишком близко.",
-        "Als Bote überbringe ich böse Nachrichten. — Как гонец я приношу дурные вести."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -4591,11 +4118,6 @@
       ],
       "synonyms": [
         "письмо"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Brief nie. — В тронном зале постоянно звучит слово «письмо».",
-        "Der gefälschte Brief ist mein Beweis. — Поддельное письмо - моё доказательство.",
-        "Dieser Brief beweist Edgars Verrat. — Это письмо доказывает предательство Эдгара."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4626,10 +4148,6 @@
       "synonyms": [
         "брат"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald der Bruder erwähnt wird. — Шут насмехается, едва кто-то произносит «брат».",
-        "Mein Bruder muss für seine Verbrechen büßen. — Мой брат должен поплатиться за свои преступления."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -4659,9 +4177,6 @@
       "synonyms": [
         "благодарность"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Dank verteilt wird. — Корделия внимательно следит, кому достанется «благодарность»."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -4690,11 +4205,6 @@
       ],
       "synonyms": [
         "слуга"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Diener noch bedrückender. — Во время бури само «слуга» звучит ещё тяжелее.",
-        "Als Diener gehorche ich meiner Herrin blind. — Как слуга я слепо подчиняюсь своей госпоже.",
-        "Als treuer Diener spreche ich offen. — Как верный слуга, я говорю открыто."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4727,9 +4237,6 @@
       "synonyms": [
         "служба"
       ],
-      "collocations": [
-        "Mein Dienst geht über die Verbannung hinaus. — Моя служба идёт дальше изгнания."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4757,11 +4264,6 @@
       ],
       "synonyms": [
         "гром"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Donner ein ständiges Thema. — Для придворных «гром» — постоянная тема.",
-        "Der Donner ist die Stimme der Götter! — Гром - это голос богов!",
-        "Der Donner übertönt unsere Schreie. — Гром заглушает наши крики."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4791,9 +4293,6 @@
       ],
       "synonyms": [
         "дурак"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Dummkopf zur Sprache kommt. — Сердце Лира тяжелеет: «дурак» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4826,9 +4325,6 @@
       "synonyms": [
         "честолюбие"
       ],
-      "collocations": [
-        "Mein Ehrgeiz kennt keine Grenzen mehr. — Моё честолюбие не знает больше границ."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4856,10 +4352,6 @@
       ],
       "synonyms": [
         "наследник"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Erbe nie. — В тронном зале постоянно звучит слово «наследник».",
-        "Als rechtmäßiger Erbe habe ich Pflichten. — Как законный наследник, у меня есть обязанности."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4892,9 +4384,6 @@
       "synonyms": [
         "успех"
       ],
-      "collocations": [
-        "Mein Erfolg ist vollkommen. — Мой успех полный."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -4922,9 +4411,6 @@
       ],
       "synonyms": [
         "враг"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Feind erwähnt wird. — Шут насмехается, едва кто-то произносит «враг»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -4955,10 +4441,6 @@
       "synonyms": [
         "проклятие"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Fluch verteilt wird. — Корделия внимательно следит, кому достанется «проклятие».",
-        "Mein Fluch soll über dich kommen! — Моё проклятие падёт на тебя!"
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -4987,9 +4469,6 @@
       ],
       "synonyms": [
         "друг"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Freund noch bedrückender. — Во время бури само «друг» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5023,9 +4502,6 @@
         "мир",
         "die Welt — тоже «мир»"
       ],
-      "collocations": [
-        "Der Friede soll wieder ins Land kommen. — Мир должен вернуться в страну."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5053,9 +4529,6 @@
       ],
       "synonyms": [
         "супруг"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Gatte ein ständiges Thema. — Для придворных «супруг» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5088,9 +4561,6 @@
       "synonyms": [
         "послушание"
       ],
-      "collocations": [
-        "Mein Gehorsam kennt keine Fragen. — Моё послушание не знает вопросов."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5118,9 +4588,6 @@
       ],
       "synonyms": [
         "дух"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Geist zur Sprache kommt. — Сердце Лира тяжелеет: «дух» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5151,11 +4618,6 @@
       "synonyms": [
         "граф"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Graf nie. — В тронном зале постоянно звучит слово «граф».",
-        "Mein Vater, der Graf, ist ein edler Mann. — Мой отец, граф, благородный человек.",
-        "Als Graf habe ich große Verantwortung. — Как граф я несу большую ответственность."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5184,9 +4646,6 @@
       ],
       "synonyms": [
         "причина"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Grund erwähnt wird. — Шут насмехается, едва кто-то произносит «причина»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5217,9 +4676,6 @@
       "synonyms": [
         "ненависть"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Hass verteilt wird. — Корделия внимательно следит, кому достанется «ненависть»."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5248,9 +4704,6 @@
       ],
       "synonyms": [
         "господин"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Herr noch bedrückender. — Во время бури само «господин» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5281,9 +4734,6 @@
       "synonyms": [
         "герцог"
       ],
-      "collocations": [
-        "Für die Höflinge bleibt der Herzog ein ständiges Thema. — Для придворных «герцог» — постоянная тема."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5313,9 +4763,6 @@
       "synonyms": [
         "небо"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Himmel zur Sprache kommt. — Сердце Лира тяжелеет: «небо» звучит слишком близко."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5344,9 +4791,6 @@
       ],
       "synonyms": [
         "двор"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Hof nie. — В тронном зале постоянно звучит слово «двор»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5378,10 +4822,6 @@
         "заблуждение",
         "ошибка"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald der Irrtum erwähnt wird. — Шут насмехается, едва кто-то произносит «ошибка».",
-        "Mein Irrtum zerstört meine Familie. — Моё заблуждение разрушает мою семью."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5412,12 +4852,6 @@
         "бой",
         "борьба"
       ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Kampf verteilt wird. — Корделия внимательно следит, кому достанется «борьба».",
-        "Der Kampf für das Recht beginnt jetzt. — Борьба за право начинается сейчас.",
-        "Der Kampf gegen meinen Bruder ist unvermeidlich. — Бой с моим братом неизбежен.",
-        "Dieser Kampf ist für die Ehre meines Vaters. — Эта борьба за честь моего отца."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5446,9 +4880,6 @@
       ],
       "synonyms": [
         "война"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Krieg ein ständiges Thema. — Для придворных «война» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5479,9 +4910,6 @@
       "synonyms": [
         "король"
       ],
-      "collocations": [
-        "Während des Sturms wirkt der König noch bedrückender. — Во время бури само «король» звучит ещё тяжелее."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5511,11 +4939,6 @@
       "synonyms": [
         "мужество"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Mut zur Sprache kommt. — Сердце Лира тяжелеет: «мужество» звучит слишком близко.",
-        "Endlich finde ich den Mut zu widersprechen. — Наконец я нахожу мужество возражать.",
-        "Der Mut fordert mich, die Wahrheit zu sagen. — Мужество требует от меня говорить правду."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -5544,11 +4967,6 @@
       ],
       "synonyms": [
         "шут"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Narr nie. — В тронном зале постоянно звучит слово «шут».",
-        "Mein Narr ist weiser als ich je war. — Мой шут мудрее, чем я когда-либо был.",
-        "Als Narr sage ich die Wahrheit durch Scherze. — Как шут я говорю правду через шутки."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5581,9 +4999,6 @@
       "synonyms": [
         "туман"
       ],
-      "collocations": [
-        "Im Nebel verliere ich mich für immer. — В тумане я теряюсь навсегда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5613,9 +5028,6 @@
       ],
       "synonyms": [
         "зависть"
-      ],
-      "collocations": [
-        "Der Neid auf Edgar verzehrt mich. — Зависть к Эдгару пожирает меня."
       ],
       "visual_hint": "📚"
     },
@@ -5647,9 +5059,6 @@
       "synonyms": [
         "новое",
         "начало"
-      ],
-      "collocations": [
-        "Ein Neuanfang für das Königreich beginnt. — Новое начало для королевства начинается."
       ],
       "visual_hint": "📚"
     },
@@ -5684,10 +5093,6 @@
       "synonyms": [
         "план"
       ],
-      "collocations": [
-        "Mein hinterhältiger Plan wird funktionieren. — Мой коварный план сработает.",
-        "Mein Plan wird perfekt ausgeführt. — Мой план выполняется идеально."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5715,9 +5120,6 @@
       ],
       "synonyms": [
         "дождь"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Regen erwähnt wird. — Шут насмехается, едва кто-то произносит «дождь»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5750,9 +5152,6 @@
       "synonyms": [
         "рифма"
       ],
-      "collocations": [
-        "Jeder Reim verbirgt eine tiefe Wahrheit. — Каждая рифма скрывает глубокую правду."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5780,9 +5179,6 @@
       ],
       "synonyms": [
         "рыцарь"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Ritter verteilt wird. — Корделия внимательно следит, кому достанется «рыцарь»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5817,10 +5213,6 @@
       "synonyms": [
         "садизм"
       ],
-      "collocations": [
-        "Mein Sadismus findet Befriedigung. — Мой садизм находит удовлетворение.",
-        "Mein Sadismus kennt keine Grenzen. — Мой садизм не знает границ."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5851,9 +5243,6 @@
       "synonyms": [
         "шутка"
       ],
-      "collocations": [
-        "Jeder Scherz enthält eine bittere Lehre. — Каждая шутка содержит горький урок."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5881,11 +5270,6 @@
       ],
       "synonyms": [
         "боль"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Schmerz noch bedrückender. — Во время бури само «боль» звучит ещё тяжелее.",
-        "Der Schmerz durchbohrt meinen Körper. — Боль пронзает моё тело.",
-        "Der Schmerz durchbohrt meine Seele. — Боль пронзает мою душу."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -5918,9 +5302,6 @@
       "synonyms": [
         "защита"
       ],
-      "collocations": [
-        "Ich biete Schutz, ohne erkannt zu werden. — Я предоставляю защиту, не будучи узнанным."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -5950,9 +5331,6 @@
       ],
       "synonyms": [
         "победа"
-      ],
-      "collocations": [
-        "Der Sieg über Edgar ist süß. — Победа над Эдгаром сладка."
       ],
       "visual_hint": "📚"
     },
@@ -5984,9 +5362,6 @@
       "synonyms": [
         "смысл"
       ],
-      "collocations": [
-        "Der Sinn des Lebens ist ein schlechter Witz. — Смысл жизни - плохая шутка."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6014,9 +5389,6 @@
       ],
       "synonyms": [
         "сын"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Sohn ein ständiges Thema. — Для придворных «сын» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6049,9 +5421,6 @@
       "synonyms": [
         "забава"
       ],
-      "collocations": [
-        "Der Spaß ist meine Maske vor der Welt. — Забава - моя маска перед миром."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6079,9 +5448,6 @@
       ],
       "synonyms": [
         "зеркало"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Spiegel zur Sprache kommt. — Сердце Лира тяжелеет: «зеркало» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6114,9 +5480,6 @@
       "synonyms": [
         "шпион"
       ],
-      "collocations": [
-        "Als Spion lausche ich an jeder Tür. — Как шпион я подслушиваю у каждой двери."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6144,9 +5507,6 @@
       ],
       "synonyms": [
         "насмешка"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Spott nie. — В тронном зале постоянно звучит слово «насмешка»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6179,9 +5539,6 @@
       "synonyms": [
         "колодка"
       ],
-      "collocations": [
-        "Im Stock sitze ich die ganze Nacht. — В колодке я сижу всю ночь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6209,9 +5566,6 @@
       ],
       "synonyms": [
         "гордость"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Stolz erwähnt wird. — Шут насмехается, едва кто-то произносит «гордость»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6244,9 +5598,6 @@
       "synonyms": [
         "спор"
       ],
-      "collocations": [
-        "Der Streit mit meiner Frau eskaliert. — Спор с моей женой обостряется."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6274,13 +5625,6 @@
       ],
       "synonyms": [
         "буря"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Sturm verteilt wird. — Корделия внимательно следит, кому достанется «буря».",
-        "Der Sturm in meinem Kopf ist schlimmer als draußen! — Буря в моей голове хуже, чем снаружи!",
-        "Der Sturm tobt über unseren Köpfen. — Буря бушует над нашими головами.",
-        "Im Sturm bleibe ich bei meinem König. — В буре я остаюсь с моим королём.",
-        "Der Sturm soll sein neues Zuhause sein. — Буря пусть будет его новым домом."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6311,11 +5655,6 @@
       "synonyms": [
         "трон"
       ],
-      "collocations": [
-        "Während des Sturms wirkt der Thron noch bedrückender. — Во время бури само «трон» звучит ещё тяжелее.",
-        "Vom Thron herab verkünde ich meinen Willen. — С трона я провозглашаю свою волю.",
-        "Der Thron meines Vaters wird bald leer sein. — Трон моего отца скоро опустеет."
-      ],
       "visual_hint": "📚",
       "gender": "masculine"
     },
@@ -6344,14 +5683,6 @@
       ],
       "synonyms": [
         "смерть"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Tod ein ständiges Thema. — Для придворных «смерть» — постоянная тема.",
-        "Der Tod ereilt mich durch Эдгars Hand. — Смерть настигает меня от руки Эдгара.",
-        "Der Tod ist gnädiger als das Leben ohne dich. — Смерть милосерднее жизни без тебя.",
-        "Der Tod trennt uns nur für kurze Zeit. — Смерть разлучает нас лишь ненадолго.",
-        "Bis zum Tod bleibe ich an seiner Seite. — До смерти я остаюсь рядом с ним.",
-        "Der Tod kommt für mich zu früh. — Смерть приходит ко мне слишком рано."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6384,9 +5715,6 @@
       "synonyms": [
         "утешение"
       ],
-      "collocations": [
-        "Mit Liedern bringe ich kleinen Trost. — Песнями я приношу малое утешение."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6414,9 +5742,6 @@
       ],
       "synonyms": [
         "мечтатель"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Träumer zur Sprache kommt. — Сердце Лира тяжелеет: «мечтатель» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6449,9 +5774,6 @@
       "synonyms": [
         "падение"
       ],
-      "collocations": [
-        "Mein Untergang ist gerecht. — Моё падение справедливо."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6479,9 +5801,6 @@
       ],
       "synonyms": [
         "отец"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über der Vater nie. — В тронном зале постоянно звучит слово «отец»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6512,12 +5831,6 @@
       "synonyms": [
         "предательство",
         "измена"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald der Verrat erwähnt wird. — Шут насмехается, едва кто-то произносит «предательство».",
-        "Der Verrat ist mein tägliches Geschäft. — Предательство - моё ежедневное дело.",
-        "Der Verrat meines Bruders zerstört mein Leben. — Предательство моего брата разрушает мою жизнь.",
-        "Meine Hilfe gilt als Verrat. — Моя помощь считается изменой."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6550,9 +5863,6 @@
       "synonyms": [
         "управляющий"
       ],
-      "collocations": [
-        "Als Verwalter kontrolliere ich den Haushalt. — Как управляющий я контролирую дом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6580,12 +5890,6 @@
       ],
       "synonyms": [
         "безумие"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt der Wahnsinn noch bedrückender. — Во время бури само «безумие» звучит ещё тяжелее.",
-        "Der Wahnsinn ist gnädiger als die Vernunft! — Безумие милосерднее разума!",
-        "Ich spiele den Wahnsinn, um zu überleben. — Я играю безумие, чтобы выжить.",
-        "Im Wahnsinn finden wir uns als Brüder. — В безумии мы находим друг друга как братья."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6615,9 +5919,6 @@
       ],
       "synonyms": [
         "лес"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie der Wald verteilt wird. — Корделия внимательно следит, кому достанется «лес»."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6650,9 +5951,6 @@
       "synonyms": [
         "сопротивление"
       ],
-      "collocations": [
-        "Mein Widerstand gegen das Böse beginnt. — Моё сопротивление злу начинается."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6680,9 +5978,6 @@
       ],
       "synonyms": [
         "ветер"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt der Wind ein ständiges Thema. — Для придворных «ветер» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6715,9 +6010,6 @@
       "synonyms": [
         "остроумие"
       ],
-      "collocations": [
-        "Mein Witz ist scharf wie ein Schwert. — Моё остроумие остро как меч."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6745,13 +6037,6 @@
       ],
       "synonyms": [
         "гнев"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn der Zorn zur Sprache kommt. — Сердце Лира тяжелеет: «гнев» звучит слишком близко.",
-        "Mein Zorn brennt wie Feuer in meiner Brust! — Мой гнев горит как огонь в моей груди!",
-        "Sein Zorn ist grenzenlos und blind. — Его гнев безграничен и слеп.",
-        "Der Zorn des Königs trifft mich ungerecht. — Гнев короля поражает меня несправедливо.",
-        "Mein Zorn kennt keine Barmherzigkeit. — Мой гнев не знает милосердия."
       ],
       "visual_hint": "📚",
       "gender": "masculine"
@@ -6784,9 +6069,6 @@
       "synonyms": [
         "сомнение"
       ],
-      "collocations": [
-        "Der Zweifel an ihrer Güte wächst in mir. — Сомнение в её доброте растёт во мне."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6817,9 +6099,6 @@
       "synonyms": [
         "толковать"
       ],
-      "collocations": [
-        "Die Zeichen deute ich besser als alle. — Знаки я толкую лучше всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6849,9 +6128,6 @@
       ],
       "synonyms": [
         "сговор"
-      ],
-      "collocations": [
-        "Unsere Absprache ist perfekt. — Наш сговор совершенен."
       ],
       "visual_hint": "📚"
     },
@@ -6884,9 +6160,6 @@
         "интрига",
         "die Intrige — тоже «интрига»"
       ],
-      "collocations": [
-        "Diese Affäre wird tödlich enden. — Эта интрига закончится смертью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6916,9 +6189,6 @@
       ],
       "synonyms": [
         "альянс"
-      ],
-      "collocations": [
-        "Unsere Allianz wird alle Feinde vernichten. — Наш альянс уничтожит всех врагов."
       ],
       "visual_hint": "📚"
     },
@@ -6950,9 +6220,6 @@
       "synonyms": [
         "амбиция"
       ],
-      "collocations": [
-        "Meine Ambition kennt keine Grenzen. — Моя амбиция не знает границ."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -6982,10 +6249,6 @@
         "страх",
         "die Furcht — тоже «страх»"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Angst nie. — В тронном зале постоянно звучит слово «страх».",
-        "Die Angst um meinen Vater wächst täglich. — Страх за отца растёт с каждым днём."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -7014,9 +6277,6 @@
       ],
       "synonyms": [
         "ответ"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Antwort erwähnt wird. — Шут насмехается, едва кто-то произносит «ответ»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7049,9 +6309,6 @@
       "synonyms": [
         "армия"
       ],
-      "collocations": [
-        "Diese Armee kämpft für Gerechtigkeit und Liebe. — Эта армия сражается за справедливость и любовь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7079,9 +6336,6 @@
       ],
       "synonyms": [
         "задача"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Aufgabe verteilt wird. — Корделия внимательно следит, кому достанется «задача»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7111,9 +6365,6 @@
       ],
       "synonyms": [
         "угроза"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Bedrohung noch bedrückender. — Во время бури само «угроза» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7146,9 +6397,6 @@
       "synonyms": [
         "вожделение"
       ],
-      "collocations": [
-        "Meine Begierde brennt wie Feuer. — Моё вожделение горит как огонь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7178,9 +6426,6 @@
       ],
       "synonyms": [
         "оскорбление"
-      ],
-      "collocations": [
-        "Jede Beleidigung spreche ich mit Genuss aus. — Каждое оскорбление я произношу с наслаждением."
       ],
       "visual_hint": "📚"
     },
@@ -7212,9 +6457,6 @@
       "synonyms": [
         "награда"
       ],
-      "collocations": [
-        "Die Belohnung für meine Intrige ist groß. — Награда за мою интригу велика."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7244,9 +6486,6 @@
       ],
       "synonyms": [
         "добыча"
-      ],
-      "collocations": [
-        "Der Graf ist meine leichte Beute. — Граф - моя лёгкая добыча."
       ],
       "visual_hint": "📚"
     },
@@ -7281,10 +6520,6 @@
       "synonyms": [
         "злоба"
       ],
-      "collocations": [
-        "Meine Bosheit kennt kein Erbarmen. — Моя злоба не знает милосердия.",
-        "Unsere Bosheit macht uns zum perfekten Paar. — Наша злоба делает нас идеальной парой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7314,9 +6549,6 @@
       ],
       "synonyms": [
         "послание"
-      ],
-      "collocations": [
-        "Die Botschaft meiner Herrin ist grausam. — Послание моей госпожи жестоко."
       ],
       "visual_hint": "📚"
     },
@@ -7348,9 +6580,6 @@
       "synonyms": [
         "брутальность"
       ],
-      "collocations": [
-        "Meine Brutalität erschreckt sogar Cornwall. — Моя брутальность пугает даже Корнуолла."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7378,9 +6607,6 @@
       ],
       "synonyms": [
         "крепость"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Burg ein ständiges Thema. — Для придворных «крепость» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7413,9 +6639,6 @@
       "synonyms": [
         "смирение"
       ],
-      "collocations": [
-        "In der Demut finden wir wahre Größe. — В смирении мы находим истинное величие."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7446,9 +6669,6 @@
       "synonyms": [
         "унижение"
       ],
-      "collocations": [
-        "Die Demütigung macht mich nur stärker. — Унижение делает меня только сильнее."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7476,10 +6696,6 @@
       ],
       "synonyms": [
         "темнота"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Dunkelheit zur Sprache kommt. — Сердце Лира тяжелеет: «темнота» звучит слишком близко.",
-        "Ewige Dunkelheit umgibt mich nun. — Вечная темнота окружает меня теперь."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7512,9 +6728,6 @@
       "synonyms": [
         "брак"
       ],
-      "collocations": [
-        "Die Ehe bindet mich an eine grausame Frau. — Брак связывает меня с жестокой женой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7542,12 +6755,6 @@
       ],
       "synonyms": [
         "честь"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Ehre nie. — В тронном зале постоянно звучит слово «честь».",
-        "Die Ehre der Familie liegt in meinen Händen. — Честь семьи в моих руках.",
-        "Unsere Ehre bleibt unbefleckt. — Наша честь остаётся незапятнанной.",
-        "Meine Ehre ist mein höchstes Gut. — Моя честь - моё высшее благо."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7577,10 +6784,6 @@
       ],
       "synonyms": [
         "ревность"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Eifersucht erwähnt wird. — Шут насмехается, едва кто-то произносит «ревность».",
-        "Die Eifersucht verzehrt mich von innen. — Ревность пожирает меня изнутри."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7613,9 +6816,6 @@
       "synonyms": [
         "спешка"
       ],
-      "collocations": [
-        "In großer Eile renne ich hin und her. — В большой спешке я бегаю туда-сюда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7643,11 +6843,6 @@
       ],
       "synonyms": [
         "одиночество"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Einsamkeit verteilt wird. — Корделия внимательно следит, кому достанется «одиночество».",
-        "Die Einsamkeit umgibt mich wie ein kalter Mantel. — Одиночество окружает меня как холодный плащ.",
-        "In der Einsamkeit denke ich an ihn. — В одиночестве я думаю о нём."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7680,9 +6875,6 @@
       "synonyms": [
         "прозрение"
       ],
-      "collocations": [
-        "Die Einsicht verbrennt meine Seele. — Прозрение сжигает мою душу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7710,10 +6902,6 @@
       ],
       "synonyms": [
         "решение"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Entscheidung noch bedrückender. — Во время бури само «решение» звучит ещё тяжелее.",
-        "Meine Entscheidung steht fest: ich wähle das Gute. — Моё решение твёрдо: я выбираю добро."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7743,9 +6931,6 @@
       ],
       "synonyms": [
         "земля"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Erde ein ständiges Thema. — Для придворных «земля» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7778,9 +6963,6 @@
       "synonyms": [
         "преданность"
       ],
-      "collocations": [
-        "Meine Ergebenheit gilt nur Lady Goneril. — Моя преданность принадлежит только леди Гонерилье."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7808,9 +6990,6 @@
       ],
       "synonyms": [
         "воспоминание"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Erinnerung nie. — В тронном зале постоянно звучит слово «воспоминание»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7842,12 +7021,6 @@
         "осознание",
         "познание"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Erkenntnis zur Sprache kommt. — Сердце Лира тяжелеет: «познание» звучит слишком близко.",
-        "Die Erkenntnis ihrer Bosheit erschüttert mich. — Осознание её злобы потрясает меня.",
-        "Die Erkenntnis kommt durch Schmerz und Verlust. — Познание приходит через боль и утрату.",
-        "Die späte Erkenntnis bricht mein Herz. — Позднее осознание разбивает моё сердце."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -7876,10 +7049,6 @@
       ],
       "synonyms": [
         "спасение"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Erlösung erwähnt wird. — Шут насмехается, едва кто-то произносит «спасение».",
-        "Im Tod finde ich Erlösung und Frieden. — В смерти я нахожу спасение и покой."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -7912,9 +7081,6 @@
       "synonyms": [
         "завоевание"
       ],
-      "collocations": [
-        "Die Eroberung des Throns ist mein Ziel. — Завоевание трона - моя цель."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7945,9 +7111,6 @@
       "synonyms": [
         "истощение"
       ],
-      "collocations": [
-        "Die Erschöpfung überwältigt meinen alten Körper. — Истощение одолевает моё старое тело."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -7975,9 +7138,6 @@
       ],
       "synonyms": [
         "вечность"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Ewigkeit verteilt wird. — Корделия внимательно следит, кому достанется «вечность»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8013,10 +7173,6 @@
       "synonyms": [
         "ловушка"
       ],
-      "collocations": [
-        "Ich stelle Fallen für die Ahnungslosen. — Я ставлю ловушки для ничего не подозревающих.",
-        "Ich tappe blind in Edmunds Falle. — Я слепо попадаю в ловушку Эдмунда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8047,9 +7203,6 @@
       "synonyms": [
         "фальшь"
       ],
-      "collocations": [
-        "Meine Falschheit kennt keine Grenzen. — Моя фальшь не знает границ."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8077,9 +7230,6 @@
       ],
       "synonyms": [
         "семья"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Familie noch bedrückender. — Во время бури само «семья» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8114,10 +7264,6 @@
       "synonyms": [
         "трусость"
       ],
-      "collocations": [
-        "Aus Feigheit greife ich nur Schwache an. — Из трусости я нападаю только на слабых.",
-        "Meine Feigheit führt zu meinem Ende. — Моя трусость приводит к моему концу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8145,9 +7291,6 @@
       ],
       "synonyms": [
         "бегство"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Flucht ein ständiges Thema. — Для придворных «бегство» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8185,12 +7328,6 @@
       "synonyms": [
         "пытка"
       ],
-      "collocations": [
-        "Die Folter meines Vaters stört mich nicht. — Пытка моего отца меня не тревожит.",
-        "Die Folter ist meine Unterhaltung. — Пытка - моё развлечение.",
-        "Die Folter ist mein liebstes Werkzeug. — Пытка - мой любимый инструмент.",
-        "Die Folter ist grausam und erbarmungslos. — Пытка жестока и беспощадна."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8218,9 +7355,6 @@
       ],
       "synonyms": [
         "вопрос"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Frage zur Sprache kommt. — Сердце Лира тяжелеет: «вопрос» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8251,9 +7385,6 @@
       "synonyms": [
         "женщина"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Frau nie. — В тронном зале постоянно звучит слово «женщина»."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -8283,9 +7414,6 @@
       "synonyms": [
         "свобода"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald die Freiheit erwähnt wird. — Шут насмехается, едва кто-то произносит «свобода»."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -8314,9 +7442,6 @@
       ],
       "synonyms": [
         "радость"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Freude verteilt wird. — Корделия внимательно следит, кому достанется «радость»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8349,9 +7474,6 @@
       "synonyms": [
         "дружба"
       ],
-      "collocations": [
-        "Unsere Freundschaft überdauert den Sturm. — Наша дружба переживёт бурю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8383,9 +7505,6 @@
         "страх",
         "die Angst — тоже «страх»"
       ],
-      "collocations": [
-        "Durch Furcht halte ich alle unter Kontrolle. — Страхом я держу всех под контролем."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8413,9 +7532,6 @@
       ],
       "synonyms": [
         "супруга"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Gattin noch bedrückender. — Во время бури само «супруга» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8446,12 +7562,6 @@
       "synonyms": [
         "опасность"
       ],
-      "collocations": [
-        "Für die Höflinge bleibt die Gefahr ein ständiges Thema. — Для придворных «опасность» — постоянная тема.",
-        "Die Gefahr lauert überall um mich herum. — Опасность подстерегает меня повсюду.",
-        "Trotz Gefahr bleibe ich beim König. — Несмотря на опасность, я остаюсь с королём.",
-        "Die Gefahr der Entdeckung ist groß. — Опасность разоблачения велика."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -8480,12 +7590,6 @@
       ],
       "synonyms": [
         "справедливость"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Gerechtigkeit zur Sprache kommt. — Сердце Лира тяжелеет: «справедливость» звучит слишком близко.",
-        "Für Gerechtigkeit will ich kämpfen. — За справедливость я хочу бороться.",
-        "Die Gerechtigkeit fordert diesen Kampf. — Справедливость требует этого боя.",
-        "Die Gerechtigkeit führt meine Klinge. — Справедливость ведёт мой клинок."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8516,9 +7620,6 @@
       "synonyms": [
         "история"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Geschichte nie. — В тронном зале постоянно звучит слово «история»."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -8547,11 +7648,6 @@
       ],
       "synonyms": [
         "жадность"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Gier erwähnt wird. — Шут насмехается, едва кто-то произносит «жадность».",
-        "Die Gier nach Macht verzehrt meine Seele. — Жадность к власти пожирает мою душу.",
-        "Die Gier nach Macht treibt mich an. — Жадность к власти движет мной."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8592,12 +7688,6 @@
       "synonyms": [
         "жестокость"
       ],
-      "collocations": [
-        "Ihre Grausamkeit übertrifft die ihrer Schwester! — Её жестокость превосходит жестокость сестры!",
-        "Meine Grausamkeit kennt keine Grenzen. — Моя жестокость не знает границ.",
-        "Meine Grausamkeit übertrifft die meiner Schwester. — Моя жестокость превосходит жестокость сестры.",
-        "Die Grausamkeit meiner Frau gefällt mir. — Жестокость моей жены мне нравится."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8625,9 +7715,6 @@
       ],
       "synonyms": [
         "граница"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Grenze verteilt wird. — Корделия внимательно следит, кому достанется «граница»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8657,9 +7744,6 @@
       ],
       "synonyms": [
         "яма"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Grube noch bedrückender. — Во время бури само «яма» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8692,9 +7776,6 @@
       "synonyms": [
         "доброта"
       ],
-      "collocations": [
-        "Mit Güte will ich das Böse besiegen. — Добротой я хочу победить зло."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8725,9 +7806,6 @@
       "synonyms": [
         "алчность"
       ],
-      "collocations": [
-        "Die Habgier treibt meine süßen Worte. — Алчность движет моими сладкими словами."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8755,9 +7833,6 @@
       ],
       "synonyms": [
         "родина"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Heimat ein ständiges Thema. — Для придворных «родина» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8789,9 +7864,6 @@
       ],
       "synonyms": [
         "скрытность"
-      ],
-      "collocations": [
-        "In Heimlichkeit sammle ich Informationen. — В скрытности я собираю информацию."
       ],
       "visual_hint": "📚"
     },
@@ -8827,10 +7899,6 @@
         "правление",
         "господство"
       ],
-      "collocations": [
-        "Die Herrschaft fällt nun in meine Hände. — Правление теперь переходит в мои руки.",
-        "Die Herrschaft über alle ist mein Ziel. — Господство над всеми - моя цель."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8861,9 +7929,6 @@
       "synonyms": [
         "властолюбие"
       ],
-      "collocations": [
-        "Die Herrschsucht bestimmt all meine Taten. — Властолюбие определяет все мои поступки."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8891,9 +7956,6 @@
       ],
       "synonyms": [
         "герцогиня"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Herzogin zur Sprache kommt. — Сердце Лира тяжелеет: «герцогиня» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8923,9 +7985,6 @@
       ],
       "synonyms": [
         "лицемерие"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Heuchelei nie. — В тронном зале постоянно звучит слово «лицемерие»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -8958,9 +8017,6 @@
       "synonyms": [
         "коварство"
       ],
-      "collocations": [
-        "Mit Hinterlist verfolge ich meine Ziele. — С коварством я преследую свои цели."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -8988,10 +8044,6 @@
       ],
       "synonyms": [
         "надежда"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Hoffnung erwähnt wird. — Шут насмехается, едва кто-то произносит «надежда».",
-        "Die Hoffnung auf Versöhnung stirbt nie in meinem Herzen. — Надежда на примирение никогда не умирает в моём сердце."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9023,9 +8075,6 @@
       ],
       "synonyms": [
         "безнадёжность"
-      ],
-      "collocations": [
-        "Die Hoffnungslosigkeit erdrückt mich. — Безнадёжность давит меня."
       ],
       "visual_hint": "📚"
     },
@@ -9061,10 +8110,6 @@
         "суровость",
         "жёсткость"
       ],
-      "collocations": [
-        "Mit eiserner Härte stoße ich ihn fort. — С железной жёсткостью я отталкиваю его.",
-        "Mit eiserner Härte regieren wir zusammen. — С железной суровостью мы правим вместе."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9092,10 +8137,6 @@
       ],
       "synonyms": [
         "ад"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Hölle verteilt wird. — Корделия внимательно следит, кому достанется «ад».",
-        "Die Hölle wartet auf meine schwarze Seele. — Ад ждёт мою чёрную душу."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9131,10 +8172,6 @@
       "synonyms": [
         "хижина"
       ],
-      "collocations": [
-        "Diese Hütte ist ein Palast für die Verlassenen. — Эта хижина - дворец для покинутых.",
-        "In dieser armseligen Hütte finden wir Zuflucht. — В этой жалкой хижине мы находим убежище."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9163,12 +8200,6 @@
       "synonyms": [
         "интрига",
         "die Affäre — тоже «интрига»"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Intrige noch bedrückender. — Во время бури само «интрига» звучит ещё тяжелее.",
-        "Jede Intrige spinne ich mit Freude. — Каждую интригу я плету с радостью.",
-        "Edmunds Intrige hat mich zum Geächteten gemacht. — Интрига Эдмунда сделала меня изгоем.",
-        "Meine Intrige wird sie vernichten. — Моя интрига уничтожит её."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9201,9 +8232,6 @@
       "synonyms": [
         "ирония"
       ],
-      "collocations": [
-        "Die Ironie ist meine letzte Waffe. — Ирония - моё последнее оружие."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9233,9 +8261,6 @@
       ],
       "synonyms": [
         "охота"
-      ],
-      "collocations": [
-        "Die Jagd auf Gloucester macht mir Spaß. — Охота на Глостера доставляет мне удовольствие."
       ],
       "visual_hint": "📚"
     },
@@ -9267,9 +8292,6 @@
       "synonyms": [
         "утёс"
       ],
-      "collocations": [
-        "Er glaubt, wir stehen am Rand der Klippe. — Он думает, мы стоим на краю утёса."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9297,9 +8319,6 @@
       ],
       "synonyms": [
         "сила"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Kraft zur Sprache kommt. — Сердце Лира тяжелеет: «сила» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9329,10 +8348,6 @@
       ],
       "synonyms": [
         "корона"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Krone nie. — В тронном зале постоянно звучит слово «корона».",
-        "Diese Krone ist schwer geworden für mein altes Haupt. — Эта корона стала тяжела для моей старой головы."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9364,9 +8379,6 @@
       ],
       "synonyms": [
         "обида"
-      ],
-      "collocations": [
-        "Diese Kränkung werde ich nicht vergessen! — Эту обиду я не забуду!"
       ],
       "visual_hint": "📚"
     },
@@ -9400,10 +8412,6 @@
       "synonyms": [
         "холод"
       ],
-      "collocations": [
-        "Die Kälte dringt in unsere Knochen. — Холод проникает в наши кости.",
-        "Die Kälte meines Herzens übertrifft den Winter. — Холод моего сердца превосходит зиму."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9431,9 +8439,6 @@
       ],
       "synonyms": [
         "королева"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Königin ein ständiges Thema. — Для придворных «королева» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9466,9 +8471,6 @@
       "synonyms": [
         "пустота"
       ],
-      "collocations": [
-        "Ich hinterlasse nur Leere und Erinnerung. — Я оставляю только пустоту и воспоминание."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9496,10 +8498,6 @@
       ],
       "synonyms": [
         "страсть"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Leidenschaft erwähnt wird. — Шут насмехается, едва кто-то произносит «страсть».",
-        "Meine Leidenschaft gilt nur Edmund. — Моя страсть принадлежит только Эдмунду."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9529,9 +8527,6 @@
       ],
       "synonyms": [
         "любовь"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Liebe verteilt wird. — Корделия внимательно следит, кому достанется «любовь»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9564,9 +8559,6 @@
       "synonyms": [
         "любовная",
         "связь"
-      ],
-      "collocations": [
-        "Meine Liebschaft mit beiden Schwestern ist gefährlich. — Моя любовная связь с обеими сёстрами опасна."
       ],
       "visual_hint": "📚"
     },
@@ -9604,11 +8596,6 @@
       "synonyms": [
         "хитрость"
       ],
-      "collocations": [
-        "Meine List bewahrt ihn vor dem Selbstmord. — Моя хитрость спасает его от самоубийства.",
-        "Mit List gewinne ich sein Vertrauen. — Хитростью я завоёвываю его доверие.",
-        "Mit List kehre ich an den Hof zurück. — Хитростью я возвращаюсь ко двору."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9642,10 +8629,6 @@
       "synonyms": [
         "похоть"
       ],
-      "collocations": [
-        "Ihre Lust macht sie blind. — Их похоть делает их слепыми.",
-        "Die Lust macht mich blind für Gefahr. — Похоть делает меня слепой к опасности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9673,10 +8656,6 @@
       ],
       "synonyms": [
         "ложь"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Lüge noch bedrückender. — Во время бури само «ложь» звучит ещё тяжелее.",
-        "Die Lüge klingt süßer als die Wahrheit. — Ложь звучит слаще правды."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9706,13 +8685,6 @@
       ],
       "synonyms": [
         "власть"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Macht ein ständiges Thema. — Для придворных «власть» — постоянная тема.",
-        "Die Macht gebe ich an jene, die mich am meisten liebt. — Власть я отдаю той, кто любит меня больше всех.",
-        "Die Macht über das Königreich ist nah. — Власть над королевством близка.",
-        "Die Macht bedeutet nichts ohne wahre Liebe. — Власть ничего не значит без истинной любви.",
-        "Die Macht über das halbe Königreich ist mein. — Власть над половиной королевства моя."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9745,9 +8717,6 @@
       "synonyms": [
         "мелодия"
       ],
-      "collocations": [
-        "Die Melodie erinnert an bessere Zeiten. — Мелодия напоминает о лучших временах."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9777,9 +8746,6 @@
       ],
       "synonyms": [
         "приданое"
-      ],
-      "collocations": [
-        "Ohne Mitgift bin ich reicher an Ehre. — Без приданого я богаче честью."
       ],
       "visual_hint": "📚"
     },
@@ -9811,9 +8777,6 @@
       "synonyms": [
         "мораль"
       ],
-      "collocations": [
-        "Die Moral leitet nun meine Entscheidungen. — Мораль теперь руководит моими решениями."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9844,9 +8807,6 @@
       "synonyms": [
         "известие"
       ],
-      "collocations": [
-        "Schreckliche Nachrichten erreichen mich aus England. — Ужасные известия доходят до меня из Англии."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9874,9 +8834,6 @@
       ],
       "synonyms": [
         "ночь"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Nacht zur Sprache kommt. — Сердце Лира тяжелеет: «ночь» звучит слишком близко."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9907,10 +8864,6 @@
       "synonyms": [
         "природа",
         "die Wildnis — тоже «природа»"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Natur nie. — В тронном зале постоянно звучит слово «природа».",
-        "Die Natur ist meine Göttin, nicht das Gesetz. — Природа - моя богиня, не закон."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -9946,10 +8899,6 @@
       "synonyms": [
         "поражение"
       ],
-      "collocations": [
-        "Die Niederlage ist mein letztes Schicksal. — Поражение - моя последняя судьба.",
-        "Die Niederlage ist vollkommen. — Поражение полное."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -9977,10 +8926,6 @@
       ],
       "synonyms": [
         "нужда"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Not erwähnt wird. — Шут насмехается, едва кто-то произносит «нужда».",
-        "In meiner Not erkennen sie mich nicht als Vater. — В моей нужде они не признают меня отцом."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10013,9 +8958,6 @@
       "synonyms": [
         "порядок"
       ],
-      "collocations": [
-        "Neue Ordnung muss aus dem Chaos entstehen. — Новый порядок должен возникнуть из хаоса."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10043,11 +8985,6 @@
       ],
       "synonyms": [
         "долг"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Pflicht verteilt wird. — Корделия внимательно следит, кому достанется «долг».",
-        "Meine Pflicht ist es, ehrlich zu sein. — Мой долг - быть честной.",
-        "Meine Pflicht ruft mich zum König. — Мой долг зовёт меня к королю."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10080,9 +9017,6 @@
       "synonyms": [
         "философия"
       ],
-      "collocations": [
-        "Meine Philosophie ist einfach: Alles ist Narretei. — Моя философия проста: всё - глупость."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10113,9 +9047,6 @@
       "synonyms": [
         "пророчество"
       ],
-      "collocations": [
-        "Meine Prophezeiung wird wahr werden. — Моё пророчество сбудется."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10143,9 +9074,6 @@
       ],
       "synonyms": [
         "испытание"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Prüfung noch bedrückender. — Во время бури само «испытание» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10182,10 +9110,6 @@
         "мука",
         "мучение"
       ],
-      "collocations": [
-        "Die Qual des Giftes zerreißt mich. — Мучение от яда разрывает меня.",
-        "Seine Qual bereitet mir Vergnügen. — Его мука доставляет мне удовольствие."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10213,13 +9137,6 @@
       ],
       "synonyms": [
         "месть"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Rache ein ständiges Thema. — Для придворных «месть» — постоянная тема.",
-        "Die Rache an der Gesellschaft ist mein Ziel. — Месть обществу - моя цель.",
-        "Nicht Rache, sondern Gerechtigkeit leitet meine Klinge. — Не месть, а справедливость ведёт мой клинок.",
-        "Dies ist ihre Rache für meine Treue. — Это их месть за мою верность.",
-        "Die Rache für Jahre der Unterwerfung. — Месть за годы подчинения."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10252,9 +9169,6 @@
       "synonyms": [
         "неуважение"
       ],
-      "collocations": [
-        "Meine Respektlosigkeit kennt keine Grenzen. — Моё неуважение не знает границ."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10282,12 +9196,6 @@
       ],
       "synonyms": [
         "раскаяние"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Reue zur Sprache kommt. — Сердце Лира тяжелеет: «раскаяние» звучит слишком близко.",
-        "Die Reue brennt heißer als alle Feuer der Hölle. — Раскаяние жжёт горячее всех адских огней.",
-        "Deine Reue ist nicht nötig, nur deine Liebe. — Твоё раскаяние не нужно, только твоя любовь.",
-        "Die Reue überwältigt meine Seele. — Раскаяние переполняет мою душу."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10323,10 +9231,6 @@
       "synonyms": [
         "соперничество"
       ],
-      "collocations": [
-        "Ihre Rivalität spielt mir in die Hände. — Их соперничество играет мне на руку.",
-        "Unsere Rivalität wird tödlich enden. — Наше соперничество закончится смертью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10354,9 +9258,6 @@
       ],
       "synonyms": [
         "покой"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Ruhe nie. — В тронном зале постоянно звучит слово «покой»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10387,10 +9288,6 @@
       "synonyms": [
         "позор"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald die Schande erwähnt wird. — Шут насмехается, едва кто-то произносит «позор».",
-        "Diese Schande ist Cornwall's, nicht meine. — Этот позор Корнуолла, не мой."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -10419,10 +9316,6 @@
       ],
       "synonyms": [
         "битва"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Schlacht verteilt wird. — Корделия внимательно следит, кому достанется «битва».",
-        "Diese Schlacht entscheidet über das Schicksal des Königreichs. — Эта битва решает судьбу королевства."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10453,10 +9346,6 @@
       "synonyms": [
         "вина"
       ],
-      "collocations": [
-        "Während des Sturms wirkt die Schuld noch bedrückender. — Во время бури само «вина» звучит ещё тяжелее.",
-        "Die Schuld erdrückt mich am Ende. — Вина давит меня в конце."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -10485,9 +9374,6 @@
       ],
       "synonyms": [
         "сестра"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Schwester ein ständiges Thema. — Для придворных «сестра» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10520,9 +9406,6 @@
       "synonyms": [
         "слабость"
       ],
-      "collocations": [
-        "Meine Schwäche erlaubt das Böse zu wachsen. — Моя слабость позволяет злу расти."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10550,10 +9433,6 @@
       ],
       "synonyms": [
         "душа"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Seele zur Sprache kommt. — Сердце Лира тяжелеет: «душа» звучит слишком близко.",
-        "Meine Seele ist rein vor Gott. — Моя душа чиста перед Богом."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10586,9 +9465,6 @@
       "synonyms": [
         "тоска"
       ],
-      "collocations": [
-        "Die Sehnsucht nach Versöhnung erfüllt mein Herz. — Тоска по примирению наполняет моё сердце."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10616,9 +9492,6 @@
       ],
       "synonyms": [
         "солнце"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Sonne nie. — В тронном зале постоянно звучит слово «солнце»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10648,10 +9521,6 @@
       ],
       "synonyms": [
         "забота"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Sorge erwähnt wird. — Шут насмехается, едва кто-то произносит «забота».",
-        "Die Sorge um meinen Vater lässt mich nicht schlafen. — Забота об отце не даёт мне спать."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10684,9 +9553,6 @@
       "synonyms": [
         "стойкость"
       ],
-      "collocations": [
-        "Mit Standhaftigkeit ertrage ich die Schmach. — Со стойкостью я переношу позор."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10715,14 +9581,6 @@
       "synonyms": [
         "кара",
         "наказание"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Strafe verteilt wird. — Корделия внимательно следит, кому достанется «наказание».",
-        "Diese Strafe ist der Preis für meine Ehrlichkeit. — Это наказание - цена моей честности.",
-        "Diese Strafe nehme ich mit Würde an. — Это наказание я принимаю с достоинством.",
-        "Diese Strafe erdulde ich für meinen König. — Это наказание я терплю ради короля.",
-        "Die Strafe für Widerspruch ist hart. — Наказание за возражение сурово.",
-        "Dies ist die gerechte Strafe für meine Grausamkeit. — Это справедливая кара за мою жестокость."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10755,9 +9613,6 @@
       "synonyms": [
         "стратегия"
       ],
-      "collocations": [
-        "Unsere Strategie wird ihn brechen. — Наша стратегия сломает его."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10785,9 +9640,6 @@
       ],
       "synonyms": [
         "поступок"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Tat noch bedrückender. — Во время бури само «поступок» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10817,9 +9669,6 @@
       ],
       "synonyms": [
         "дочь"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Tochter ein ständiges Thema. — Для придворных «дочь» — постоянная тема."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10851,12 +9700,6 @@
         "печаль",
         "скорбь"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Trauer nie. — В тронном зале постоянно звучит слово «печаль».",
-        "Die Trauer überwältigt meine Seele. — Скорбь переполняет мою душу.",
-        "Die Trauer ist zu schwer zu ertragen. — Скорбь слишком тяжела, чтобы вынести.",
-        "Die Trauer um Корделия macht mich stumm. — Печаль о Корделии делает меня немым."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -10886,11 +9729,6 @@
       "synonyms": [
         "верность"
       ],
-      "collocations": [
-        "Der Narr spottet, sobald die Treue erwähnt wird. — Шут насмехается, едва кто-то произносит «верность».",
-        "Meine Treue gilt der Wahrheit und der echten Liebe. — Моя верность принадлежит правде и истинной любви.",
-        "Die Treue zu meinem König ist unerschütterlich. — Верность моему королю непоколебима."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -10919,10 +9757,6 @@
       ],
       "synonyms": [
         "слеза"
-      ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Träne zur Sprache kommt. — Сердце Лира тяжелеет: «слеза» звучит слишком близко.",
-        "Keine Träne will ich für diese Undankbaren vergießen! — Ни одной слезы я не пролью за этих неблагодарных!"
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -10955,9 +9789,6 @@
       "synonyms": [
         "слёзы"
       ],
-      "collocations": [
-        "Unsere Tränen waschen den Schmerz fort. — Наши слёзы смывают боль."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -10988,9 +9819,6 @@
       "synonyms": [
         "добродетель"
       ],
-      "collocations": [
-        "Die Tugend wird mein Leitstern sein. — Добродетель будет моей путеводной звездой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11020,9 +9848,6 @@
       ],
       "synonyms": [
         "тирания"
-      ],
-      "collocations": [
-        "Meine Tyrannei erstickt jeden Widerstand. — Моя тирания душит любое сопротивление."
       ],
       "visual_hint": "📚"
     },
@@ -11058,10 +9883,6 @@
         "обман",
         "der Betrug — тоже «обман»"
       ],
-      "collocations": [
-        "Die Täuschung ist vollkommen. — Обман совершенен.",
-        "Edgars liebevolle Täuschung rettet mich. — Любящий обман Эдгара спасает меня."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11089,9 +9910,6 @@
       ],
       "synonyms": [
         "дверь"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Tür verteilt wird. — Корделия внимательно следит, кому достанется «дверь»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11123,9 +9941,6 @@
       ],
       "synonyms": [
         "неблагодарность"
-      ],
-      "collocations": [
-        "Die Undankbarkeit ist schärfer als der Zahn einer Schlange! — Неблагодарность острее змеиного зуба!"
       ],
       "visual_hint": "📚"
     },
@@ -11160,10 +9975,6 @@
       "synonyms": [
         "несправедливость"
       ],
-      "collocations": [
-        "Diese Ungerechtigkeit werde ich nicht akzeptieren. — Эту несправедливость я не приму.",
-        "Ich begehe große Ungerechtigkeit. — Я совершаю большую несправедливость."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11193,9 +10004,6 @@
       ],
       "synonyms": [
         "угнетение"
-      ],
-      "collocations": [
-        "Die Unterdrückung ist mein Herrschaftsmittel. — Угнетение - моё средство правления."
       ],
       "visual_hint": "📚"
     },
@@ -11227,9 +10035,6 @@
       "synonyms": [
         "презрение"
       ],
-      "collocations": [
-        "Meine Verachtung für ihn wächst täglich. — Моё презрение к нему растёт ежедневно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11259,9 +10064,6 @@
       ],
       "synonyms": [
         "ответственность"
-      ],
-      "collocations": [
-        "Die Verantwortung für alle wiegt schwer. — Ответственность за всех тяжела."
       ],
       "visual_hint": "📚"
     },
@@ -11294,9 +10096,6 @@
         "изгнание",
         "das Exil — тоже «изгнание»"
       ],
-      "collocations": [
-        "Die Verbannung ist der Preis für meine Ehrlichkeit. — Изгнание - цена моей честности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11326,9 +10125,6 @@
       ],
       "synonyms": [
         "преследование"
-      ],
-      "collocations": [
-        "Die Verfolgung des blinden Grafen beginnt. — Преследование слепого графа начинается."
       ],
       "visual_hint": "📚"
     },
@@ -11360,9 +10156,6 @@
       "synonyms": [
         "прощение"
       ],
-      "collocations": [
-        "Die Vergebung ist der Schlüssel zum Frieden. — Прощение - ключ к покою."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11393,9 +10186,6 @@
       "synonyms": [
         "возмездие"
       ],
-      "collocations": [
-        "Die Vergeltung ereilt mich unerwartet. — Возмездие настигает меня неожиданно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11425,9 +10215,6 @@
       ],
       "synonyms": [
         "бренность"
-      ],
-      "collocations": [
-        "Die Vergänglichkeit der Macht ist offenbar. — Бренность власти очевидна."
       ],
       "visual_hint": "📚"
     },
@@ -11463,10 +10250,6 @@
         "маскировка",
         "переодевание"
       ],
-      "collocations": [
-        "Diese Verkleidung ist meine einzige Rettung. — Эта маскировка - моё единственное спасение.",
-        "In Verkleidung diene ich meinem König weiter. — В переодевании я продолжаю служить королю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11494,9 +10277,6 @@
       ],
       "synonyms": [
         "разум"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Vernunft noch bedrückender. — Во время бури само «разум» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11527,9 +10307,6 @@
       "synonyms": [
         "искушение"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Versuchung zur Sprache kommt. — Сердце Лира тяжелеет: «искушение» звучит слишком близко."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -11558,10 +10335,6 @@
       ],
       "synonyms": [
         "примирение"
-      ],
-      "collocations": [
-        "Für die Höflinge bleibt die Versöhnung ein ständiges Thema. — Для придворных «примирение» — постоянная тема.",
-        "Die Versöhnung kommt zu spät. — Примирение приходит слишком поздно."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11592,10 +10365,6 @@
       "synonyms": [
         "превращение"
       ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Verwandlung nie. — В тронном зале постоянно звучит слово «превращение».",
-        "Eine Verwandlung beginnt in meiner Seele. — Превращение начинается в моей душе."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -11624,13 +10393,6 @@
       ],
       "synonyms": [
         "отчаяние"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Verzweiflung erwähnt wird. — Шут насмехается, едва кто-то произносит «отчаяние».",
-        "Die Verzweiflung packt mein altes Herz! — Отчаяние охватывает моё старое сердце!",
-        "Seine Verzweiflung bricht mir das Herz. — Его отчаяние разбивает мне сердце.",
-        "Die Verzweiflung treibt mich zum Abgrund. — Отчаяние гонит меня к пропасти.",
-        "Die Verzweiflung führt mich zum Tod. — Отчаяние ведёт меня к смерти."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11663,9 +10425,6 @@
       "synonyms": [
         "предчувствие"
       ],
-      "collocations": [
-        "Eine dunkle Vorahnung erfüllt mein Herz. — Тёмное предчувствие наполняет моё сердце."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11696,9 +10455,6 @@
       "synonyms": [
         "стража"
       ],
-      "collocations": [
-        "Ich halte Wache über seinen Schlaf. — Я держу стражу над его сном."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11726,12 +10482,6 @@
       ],
       "synonyms": [
         "правда"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Wahrheit verteilt wird. — Корделия внимательно следит, кому достанется «правда».",
-        "Die Wahrheit war immer in deinen Worten, Kind. — Правда всегда была в твоих словах, дитя.",
-        "Die Wahrheit war vor meinen Augen verborgen. — Правда была скрыта от моих глаз.",
-        "Die Wahrheit verpacke ich in lustige Lieder. — Правду я заворачиваю в весёлые песни."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11763,9 +10513,6 @@
       ],
       "synonyms": [
         "предупреждение"
-      ],
-      "collocations": [
-        "Meine Warnung kommt als Rätsel verkleidet. — Моё предупреждение приходит замаскированным под загадку."
       ],
       "visual_hint": "📚"
     },
@@ -11804,12 +10551,6 @@
       "synonyms": [
         "мудрость"
       ],
-      "collocations": [
-        "Mit Weisheit will ich das Land führen. — С мудростью я хочу вести страну.",
-        "Die Weisheit kommt zu spät zu mir. — Мудрость приходит ко мне слишком поздно.",
-        "Durch Leiden habe ich Weisheit erlangt. — Через страдания я обрёл мудрость.",
-        "Hinter meinen Späßen verbirgt sich Weisheit. — За моими шутками скрывается мудрость."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11838,9 +10579,6 @@
       "synonyms": [
         "мир",
         "der Friede — тоже «мир»"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Welt noch bedrückender. — Во время бури само «мир» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -11873,9 +10611,6 @@
         "природа",
         "die Natur — тоже «природа»"
       ],
-      "collocations": [
-        "Für die Höflinge bleibt die Wildnis ein ständiges Thema. — Для придворных «дикая природа» — постоянная тема."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -11907,9 +10642,6 @@
       "synonyms": [
         "произвол"
       ],
-      "collocations": [
-        "Meine Willkür ist das einzige Gesetz. — Мой произвол - единственный закон."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -11939,9 +10671,6 @@
       ],
       "synonyms": [
         "вдова"
-      ],
-      "collocations": [
-        "Als Witwe bin ich endlich frei. — Как вдова я наконец свободна."
       ],
       "visual_hint": "📚"
     },
@@ -11973,9 +10702,6 @@
       "synonyms": [
         "рана"
       ],
-      "collocations": [
-        "Die Wunde brennt wie Feuer in meinem Leib. — Рана горит как огонь в моём теле."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12003,9 +10729,6 @@
       ],
       "synonyms": [
         "ярость"
-      ],
-      "collocations": [
-        "Im Thronsaal verstummen die Gespräche über die Wut nie. — В тронном зале постоянно звучит слово «ярость»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -12036,10 +10759,6 @@
       "synonyms": [
         "достоинство"
       ],
-      "collocations": [
-        "Lears Herz wird schwer, wenn die Würde zur Sprache kommt. — Сердце Лира тяжелеет: «достоинство» звучит слишком близко.",
-        "Mit Würde trage ich mein Schicksal. — С достоинством я несу свою судьбу."
-      ],
       "visual_hint": "📚",
       "gender": "feminine"
     },
@@ -12068,9 +10787,6 @@
       ],
       "synonyms": [
         "время"
-      ],
-      "collocations": [
-        "Der Narr spottet, sobald die Zeit erwähnt wird. — Шут насмехается, едва кто-то произносит «время»."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -12106,10 +10822,6 @@
       "synonyms": [
         "церемония"
       ],
-      "collocations": [
-        "Die Zeremonie der Teilung beginnt jetzt. — Церемония раздела начинается сейчас.",
-        "Die Zeremonie beginnt im prächtigen Thronsaal. — Церемония начинается в великолепном тронном зале."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12141,9 +10853,6 @@
         "убежище",
         "das Asyl — тоже «убежище»"
       ],
-      "collocations": [
-        "Ich suche Zuflucht für uns beide. — Я ищу убежище для нас обоих."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12171,10 +10880,6 @@
       ],
       "synonyms": [
         "будущее"
-      ],
-      "collocations": [
-        "Cordelia merkt sich genau, wie die Zukunft verteilt wird. — Корделия внимательно следит, кому достанется «будущее».",
-        "Die Zukunft des Königreichs liegt in unseren Händen. — Будущее королевства в наших руках."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -12204,9 +10909,6 @@
       ],
       "synonyms": [
         "язык"
-      ],
-      "collocations": [
-        "Während des Sturms wirkt die Zunge noch bedrückender. — Во время бури само «язык» звучит ещё тяжелее."
       ],
       "visual_hint": "📚",
       "gender": "feminine"
@@ -12239,9 +10941,6 @@
       "synonyms": [
         "раздор"
       ],
-      "collocations": [
-        "Die Zwietracht zerstört unsere Ehe. — Раздор разрушает наш брак."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12272,9 +10971,6 @@
       "synonyms": [
         "удивление"
       ],
-      "collocations": [
-        "Die Überraschung des Angriffs schockiert mich. — Неожиданность нападения шокирует меня."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12302,11 +10998,6 @@
       ],
       "synonyms": [
         "служить"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Dienen ist. — Во время бури становится понятно, насколько важно служить.",
-        "Ich diene ohne Gewissen oder Ehre. — Я служу без совести и чести.",
-        "Ich diene dem König seit vielen Jahren. — Я служу королю много лет."
       ],
       "visual_hint": "📚"
     },
@@ -12336,9 +11027,6 @@
       "synonyms": [
         "угрожать",
         "bedrohen — тоже «угрожать»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Drohen alle verändert. — Шут чувствует, как умение угрожать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -12372,9 +11060,6 @@
         "erdulden — тоже «терпеть»",
         "ertragen — тоже «терпеть»"
       ],
-      "collocations": [
-        "Ich dulde ihre Grausamkeit zu lange. — Я слишком долго терплю её жестокость."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12404,10 +11089,6 @@
         "выдерживать",
         "aushalten — тоже «выдерживать»",
         "ausharren — тоже «выдерживать»"
-      ],
-      "collocations": [
-        "Das Durchhalten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело выдерживать.",
-        "Gemeinsam werden wir durchhalten. — Вместе мы выдержим."
       ],
       "visual_hint": "📚"
     },
@@ -12439,9 +11120,6 @@
       "synonyms": [
         "благородный"
       ],
-      "collocations": [
-        "Ich strebe nach edlen Taten. — Я стремлюсь к благородным поступкам."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12469,9 +11147,6 @@
       ],
       "synonyms": [
         "чтить"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Ehren auch ohne Stolz möglich ist. — Корделия показывает, что чтить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -12503,9 +11178,6 @@
       "synonyms": [
         "торопиться"
       ],
-      "collocations": [
-        "Ich eile, um ihre Wünsche zu erfüllen. — Я тороплюсь исполнить её желания."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12536,9 +11208,6 @@
       "synonyms": [
         "вмешиваться"
       ],
-      "collocations": [
-        "Ich greife ein, um das Schlimmste zu verhindern. — Я вмешиваюсь, чтобы предотвратить худшее."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12568,9 +11237,6 @@
         "запирать",
         "verschließen — тоже «запирать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Einsperren ist. — Во время бури становится понятно, насколько важно запирать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12598,9 +11264,6 @@
       ],
       "synonyms": [
         "обнаруживать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Entdecken alle verändert. — Шут чувствует, как умение обнаруживать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -12631,9 +11294,6 @@
         "лишать",
         "собственности"
       ],
-      "collocations": [
-        "Das Enteignen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело лишать собственности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12661,9 +11321,6 @@
       ],
       "synonyms": [
         "убегать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Entfliehen auch ohne Stolz möglich ist. — Корделия показывает, что убегать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -12698,10 +11355,6 @@
         "разоблачать",
         "раскрывать"
       ],
-      "collocations": [
-        "Ich enthülle meine wahre Identität. — Я разоблачаю свою истинную личность.",
-        "Spielerisch enthülle ich seine Fehler. — Играючи я раскрываю его ошибки."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12729,9 +11382,6 @@
       ],
       "synonyms": [
         "решать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Entscheiden ist. — Во время бури становится понятно, насколько важно решать."
       ],
       "visual_hint": "📚"
     },
@@ -12761,9 +11411,6 @@
       "synonyms": [
         "извинять"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Entschuldigen alle verändert. — Шут чувствует, как умение извинять меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12791,9 +11438,6 @@
       ],
       "synonyms": [
         "возникать"
-      ],
-      "collocations": [
-        "Das Entstehen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело возникать."
       ],
       "visual_hint": "📚"
     },
@@ -12825,9 +11469,6 @@
         "с",
         "трона"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Entthronen ist. — Во время бури становится понятно, насколько важно свергать с трона."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12855,9 +11496,6 @@
       ],
       "synonyms": [
         "разочаровывать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Enttäuschen auch ohne Stolz möglich ist. — Корделия показывает, что разочаровывать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -12894,11 +11532,6 @@
       "synonyms": [
         "беспощадный"
       ],
-      "collocations": [
-        "Erbarmungslos verfolge ich mein Ziel. — Беспощадно я преследую свою цель.",
-        "Ich bin erbarmungslos in meiner Rache. — Я беспощадна в своей мести.",
-        "Erbarmungslos werfe ich ihn hinaus. — Беспощадно я выбрасываю его."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12927,11 +11560,6 @@
       "synonyms": [
         "наследовать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Erben alle verändert. — Шут чувствует, как умение наследовать меняет всех.",
-        "Nun erbe ich alles, was Edgar zustand. — Теперь я наследую всё, что полагалось Эдгару.",
-        "Nun erbe ich Titel und Verantwortung. — Теперь я наследую титул и ответственность."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -12959,10 +11587,6 @@
       ],
       "synonyms": [
         "слепнуть"
-      ],
-      "collocations": [
-        "Das Erblinden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело слепнуть.",
-        "Ich erblinde durch ihre Grausamkeit. — Я слепну от их жестокости."
       ],
       "visual_hint": "📚"
     },
@@ -12993,9 +11617,6 @@
       ],
       "synonyms": [
         "жалкий"
-      ],
-      "collocations": [
-        "Erbärmlich ende ich wie ich gelebt habe. — Жалко я заканчиваю, как и жил."
       ],
       "visual_hint": "📚"
     },
@@ -13029,9 +11650,6 @@
         "dulden — тоже «терпеть»",
         "ertragen — тоже «терпеть»"
       ],
-      "collocations": [
-        "Ich erdulde die Schande ohne Klage. — Я терплю позор без жалоб."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13060,9 +11678,6 @@
       "synonyms": [
         "происходить",
         "geschehen — тоже «происходить»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Ereignen auch ohne Stolz möglich ist. — Корделия показывает, что происходить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -13094,9 +11709,6 @@
         "erkennen — тоже «узнавать»",
         "wiedererkennen — тоже «узнавать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Erfahren ist. — Во время бури становится понятно, насколько важно узнавать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13125,9 +11737,6 @@
       "synonyms": [
         "исполнять",
         "befolgen — тоже «исполнять»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Erfüllen alle verändert. — Шут чувствует, как умение исполнять меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -13159,9 +11768,6 @@
       "synonyms": [
         "покорный"
       ],
-      "collocations": [
-        "Ergeben folge ich jedem Befehl. — Покорно я следую каждому приказу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13192,9 +11798,6 @@
       "synonyms": [
         "захватывать"
       ],
-      "collocations": [
-        "Ich ergreife jede Gelegenheit zur Macht. — Я захватываю каждую возможность власти."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13223,9 +11826,6 @@
       "synonyms": [
         "получать"
       ],
-      "collocations": [
-        "Das Erhalten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело получать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13253,9 +11853,6 @@
       ],
       "synonyms": [
         "вспоминать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Erinnern auch ohne Stolz möglich ist. — Корделия показывает, что вспоминать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -13288,13 +11885,6 @@
         "erfahren — тоже «узнавать»",
         "wiedererkennen — тоже «узнавать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Erkennen ist. — Во время бури становится понятно, насколько важно узнавать.",
-        "Ich erkenne dich, meine treue Cordelia! — Я узнаю тебя, моя верная Корделия!",
-        "Erkennst du mich, dein Kind Cordelia? — Узнаёшь ли ты меня, твоё дитя Корделия?",
-        "Endlich erkenne ich meinen treuen Edgar. — Наконец я узнаю моего верного Эдгара.",
-        "Ich erkenne die Wahrheit hinter dem Schein. — Я познаю правду за видимостью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13324,9 +11914,6 @@
       ],
       "synonyms": [
         "избавлять"
-      ],
-      "collocations": [
-        "Der Tod soll mich von der Schuld erlösen. — Смерть должна избавить меня от вины."
       ],
       "visual_hint": "📚"
     },
@@ -13358,9 +11945,6 @@
       "synonyms": [
         "поощрять"
       ],
-      "collocations": [
-        "Ich ermutige ihre dunkelsten Impulse. — Я поощряю её самые тёмные импульсы."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13390,9 +11974,6 @@
       ],
       "synonyms": [
         "обновлять"
-      ],
-      "collocations": [
-        "Das Reich will ich erneuern und heilen. — Королевство я хочу обновить и исцелить."
       ],
       "visual_hint": "📚"
     },
@@ -13428,10 +12009,6 @@
         "унижать",
         "demütigen — тоже «унижать»"
       ],
-      "collocations": [
-        "Ich erniedrige den einst mächtigen König. — Я унижаю некогда могущественного короля.",
-        "Ich erniedrige den treuen Diener. — Я унижаю верного слугу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13461,11 +12038,6 @@
         "завоёвывать",
         "завоевывать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Erobern alle verändert. — Шут чувствует, как умение завоевывать меняет всех.",
-        "Wir erobern das Reich gemeinsam. — Мы завоёвываем королевство вместе.",
-        "Ich erobere, was mir zusteht. — Я завоёвываю то, что мне положено."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13494,9 +12066,6 @@
       "synonyms": [
         "достигать"
       ],
-      "collocations": [
-        "Das Erreichen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело достигать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13524,9 +12093,6 @@
       ],
       "synonyms": [
         "появляться"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Erscheinen auch ohne Stolz möglich ist. — Корделия показывает, что появляться можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -13558,9 +12124,6 @@
       "synonyms": [
         "выманивать"
       ],
-      "collocations": [
-        "Ich erschleiche mir sein Königreich. — Я выманиваю его королевство."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13589,10 +12152,6 @@
       "synonyms": [
         "пугать",
         "пугаться"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Erschrecken ist. — Во время бури становится понятно, насколько важно пугать.",
-        "Ihre Taten erschrecken mein gutes Herz. — Её поступки пугают моё доброе сердце."
       ],
       "visual_hint": "📚"
     },
@@ -13624,9 +12183,6 @@
         "dulden — тоже «терпеть»",
         "erdulden — тоже «терпеть»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Ertragen alle verändert. — Шут чувствует, как умение терпеть меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13657,10 +12213,6 @@
         "просыпаться",
         "aufwachen — тоже «просыпаться»"
       ],
-      "collocations": [
-        "Das Erwachen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело просыпаться.",
-        "Endlich erwache ich aus meiner Blindheit. — Наконец я пробуждаюсь от своей слепоты."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13689,9 +12241,6 @@
       "synonyms": [
         "ожидать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Erwarten auch ohne Stolz möglich ist. — Корделия показывает, что ожидать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13719,9 +12268,6 @@
       ],
       "synonyms": [
         "рассказывать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Erzählen ist. — Во время бури становится понятно, насколько важно рассказывать."
       ],
       "visual_hint": "📚"
     },
@@ -13758,11 +12304,6 @@
       "synonyms": [
         "вечный"
       ],
-      "collocations": [
-        "Unsere Liebe wird ewig dauern, mein Kind. — Наша любовь будет вечной, дитя моё.",
-        "Unsere Liebe ist ewig, Vater. — Наша любовь вечна, отец.",
-        "Meine Treue ist ewig, über den Tod hinaus. — Моя верность вечна, за пределами смерти."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13792,11 +12333,6 @@
         "падать",
         "stürzen — тоже «падать»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Fallen alle verändert. — Шут чувствует, как умение падать меняет всех.",
-        "Ich falle wie der Feigling, der ich bin. — Я падаю как трус, которым являюсь.",
-        "Ich falle von seinem gerechten Schwert. — Я падаю от его справедливого меча."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13825,9 +12361,6 @@
       "synonyms": [
         "ловить"
       ],
-      "collocations": [
-        "Das Fangen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ловить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13855,9 +12388,6 @@
       ],
       "synonyms": [
         "отсутствовать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Fehlen auch ohne Stolz möglich ist. — Корделия показывает, что отсутствовать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -13889,9 +12419,6 @@
       "synonyms": [
         "торжественный"
       ],
-      "collocations": [
-        "Dieser feierliche Moment wird zur Tragödie. — Этот торжественный момент становится трагедией."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13921,9 +12448,6 @@
       ],
       "synonyms": [
         "трусливый"
-      ],
-      "collocations": [
-        "Feige verstecke ich mich hinter meiner Herrin. — Трусливо я прячусь за своей госпожой."
       ],
       "visual_hint": "📚"
     },
@@ -13955,9 +12479,6 @@
       "synonyms": [
         "сковывать"
       ],
-      "collocations": [
-        "Sie fesseln mich wie einen gemeinen Dieb. — Они сковывают меня как обычного вора."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -13985,9 +12506,6 @@
       ],
       "synonyms": [
         "находить"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Finden ist. — Во время бури становится понятно, насколько важно находить."
       ],
       "visual_hint": "📚"
     },
@@ -14017,10 +12535,6 @@
       "synonyms": [
         "бежать",
         "rennen — тоже «бежать»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Fliehen alle verändert. — Шут чувствует, как умение бежать меняет всех.",
-        "Ich muss vor falschen Anschuldigungen fliehen. — Я должен бежать от ложных обвинений."
       ],
       "visual_hint": "📚"
     },
@@ -14052,9 +12566,6 @@
         "verfluchen — тоже «проклинать»",
         "verwünschen — тоже «проклинать»"
       ],
-      "collocations": [
-        "Das Fluchen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело проклинать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14082,10 +12593,6 @@
       ],
       "synonyms": [
         "следовать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Folgen auch ohne Stolz möglich ist. — Корделия показывает, что следовать можно и без гордыни.",
-        "Bald folge ich meinem König ins Jenseits. — Скоро я последую за королём в иной мир."
       ],
       "visual_hint": "📚"
     },
@@ -14120,10 +12627,6 @@
       "synonyms": [
         "пытать"
       ],
-      "collocations": [
-        "Ich foltere ihn mit kalten Worten. — Я пытаю его холодными словами.",
-        "Mit Lust foltere ich den alten Mann. — С наслаждением я пытаю старика."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14154,9 +12657,6 @@
       "synonyms": [
         "уходить"
       ],
-      "collocations": [
-        "Ich gehe fort, wenn keiner es bemerkt. — Я ухожу, когда никто не замечает."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14184,9 +12684,6 @@
       ],
       "synonyms": [
         "спрашивать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Fragen ist. — Во время бури становится понятно, насколько важно спрашивать."
       ],
       "visual_hint": "📚"
     },
@@ -14218,9 +12715,6 @@
       "synonyms": [
         "дерзкий"
       ],
-      "collocations": [
-        "Frech widerspreche ich dem alten Mann. — Дерзко я возражаю старику."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14250,9 +12744,6 @@
       ],
       "synonyms": [
         "чужой"
-      ],
-      "collocations": [
-        "Ich bin jetzt fremd in meinem eigenen Land. — Я теперь чужая в своей собственной стране."
       ],
       "visual_hint": "📚"
     },
@@ -14289,11 +12780,6 @@
       "synonyms": [
         "мёрзнуть"
       ],
-      "collocations": [
-        "Wir alle frieren in dieser kalten Welt. — Мы все мёрзнем в этом холодном мире.",
-        "Wir frieren gemeinsam in dieser kalten Nacht. — Мы мёрзнем вместе в эту холодную ночь.",
-        "Wir frieren gemeinsam in der kalten Nacht. — Мы мёрзнем вместе в холодную ночь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14324,9 +12810,6 @@
       "synonyms": [
         "подделывать"
       ],
-      "collocations": [
-        "Ich fälsche Edgars Brief perfekt. — Я идеально подделываю письмо Эдгара."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14354,9 +12837,6 @@
       ],
       "synonyms": [
         "чувствовать"
-      ],
-      "collocations": [
-        "Das Fühlen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело чувствовать."
       ],
       "visual_hint": "📚"
     },
@@ -14387,10 +12867,6 @@
         "вести",
         "verhalten — тоже «вести»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Führen alle verändert. — Шут чувствует, как умение вести меняет всех.",
-        "Ich führe ihn sicher durch die Dunkelheit. — Я веду его безопасно сквозь тьму."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14419,9 +12895,6 @@
       "synonyms": [
         "бояться"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Fürchten auch ohne Stolz möglich ist. — Корделия показывает, что бояться можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14449,9 +12922,6 @@
       ],
       "synonyms": [
         "давать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Geben ist. — Во время бури становится понятно, насколько важно давать."
       ],
       "visual_hint": "📚"
     },
@@ -14483,9 +12953,6 @@
       "synonyms": [
         "пленный"
       ],
-      "collocations": [
-        "Obwohl gefangen, bin ich frei in meinem Herzen. — Хотя я в плену, в сердце я свободна."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14515,10 +12982,6 @@
         "повиноваться",
         "подчиняться"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Gehorchen alle verändert. — Шут чувствует, как умение подчиняться меняет всех.",
-        "Ich kann der Lüge nicht gehorchen. — Я не могу повиноваться лжи."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14546,9 +13009,6 @@
       ],
       "synonyms": [
         "принадлежать"
-      ],
-      "collocations": [
-        "Das Gehören fällt Lear unerwartet schwer. — Лиру неожиданно тяжело принадлежать."
       ],
       "visual_hint": "📚"
     },
@@ -14580,9 +13040,6 @@
       "synonyms": [
         "наслаждаться"
       ],
-      "collocations": [
-        "Ich genieße jeden Schrei des Schmerzes. — Я наслаждаюсь каждым криком боли."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14613,9 +13070,6 @@
       "synonyms": [
         "справедливый"
       ],
-      "collocations": [
-        "Ich kämpfe für das, was gerecht ist. — Я борюсь за то, что справедливо."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14645,9 +13099,6 @@
         "происходить",
         "ereignen — тоже «происходить»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Geschehen auch ohne Stolz möglich ist. — Корделия показывает, что происходить можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14676,10 +13127,6 @@
       "synonyms": [
         "признаваться"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Gestehen ist. — Во время бури становится понятно, насколько важно признаваться.",
-        "Ich gestehe alle meine Verbrechen. — Я признаюсь во всех преступлениях."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14707,10 +13154,6 @@
       ],
       "synonyms": [
         "выигрывать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Gewinnen alle verändert. — Шут чувствует, как умение выигрывать меняет всех.",
-        "Ich gewinne alles durch List. — Я выигрываю всё хитростью."
       ],
       "visual_hint": "📚"
     },
@@ -14742,9 +13185,6 @@
       "synonyms": [
         "жадный"
       ],
-      "collocations": [
-        "Gierig greife ich nach jedem Stück Macht. — Жадно я хватаюсь за каждый кусок власти."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14772,10 +13212,6 @@
       ],
       "synonyms": [
         "верить"
-      ],
-      "collocations": [
-        "Das Glauben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело верить.",
-        "Ich glaube Edmunds Lügen sofort. — Я сразу верю лжи Эдмунда."
       ],
       "visual_hint": "📚"
     },
@@ -14807,9 +13243,6 @@
       "synonyms": [
         "безжалостный"
       ],
-      "collocations": [
-        "Ich bin gnadenlos wie der Winter. — Я безжалостна как зима."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14839,9 +13272,6 @@
       ],
       "synonyms": [
         "жестокий"
-      ],
-      "collocations": [
-        "Ich bin grausam zu dem, der mir alles gab. — Я жестока к тому, кто дал мне всё."
       ],
       "visual_hint": "📚"
     },
@@ -14875,9 +13305,6 @@
         "nachdenken — тоже «размышлять»",
         "sinnen — тоже «размышлять»"
       ],
-      "collocations": [
-        "Nachts grüble ich über richtig und falsch. — Ночами я размышляю о правильном и неправильном."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14905,9 +13332,6 @@
       ],
       "synonyms": [
         "иметь"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Haben auch ohne Stolz möglich ist. — Корделия показывает, что иметь можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -14937,9 +13361,6 @@
       "synonyms": [
         "держать"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Halten ist. — Во время бури становится понятно, насколько важно держать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14968,9 +13389,6 @@
       "synonyms": [
         "действовать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Handeln alle verändert. — Шут чувствует, как умение действовать меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -14998,11 +13416,6 @@
       ],
       "synonyms": [
         "ненавидеть"
-      ],
-      "collocations": [
-        "Das Hassen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ненавидеть.",
-        "Ich hasse meine Schwester mehr als je zuvor. — Я ненавижу сестру больше, чем когда-либо.",
-        "Ich hasse seine Schwäche und Güte. — Я ненавижу его слабость и доброту."
       ],
       "visual_hint": "📚"
     },
@@ -15034,9 +13447,6 @@
       "synonyms": [
         "спешить"
       ],
-      "collocations": [
-        "Ich haste von einem Ort zum anderen. — Я спешу с места на место."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15066,9 +13476,6 @@
       ],
       "synonyms": [
         "исцелять"
-      ],
-      "collocations": [
-        "Meine Liebe wird deine Wunden heilen. — Моя любовь исцелит твои раны."
       ],
       "visual_hint": "📚"
     },
@@ -15100,9 +13507,6 @@
       "synonyms": [
         "тайно"
       ],
-      "collocations": [
-        "Ich handle heimlich gegen die neuen Herrscher. — Я действую тайно против новых правителей."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15130,9 +13534,6 @@
       ],
       "synonyms": [
         "жениться"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Heiraten auch ohne Stolz möglich ist. — Корделия показывает, что жениться можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -15162,10 +13563,6 @@
       "synonyms": [
         "помогать"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Helfen ist. — Во время бури становится понятно, насколько важно помогать.",
-        "Heimlich helfe ich dem verstoßenen König. — Тайно я помогаю изгнанному королю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15194,11 +13591,6 @@
       "synonyms": [
         "править",
         "regieren — тоже «править»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Herrschen alle verändert. — Шут чувствует, как умение править меняет всех.",
-        "Ich habe lange genug geherrscht. — Я правил достаточно долго.",
-        "Jetzt herrsche ich über meine Länder. — Теперь я правлю своими землями."
       ],
       "visual_hint": "📚"
     },
@@ -15230,9 +13622,6 @@
       "synonyms": [
         "травить"
       ],
-      "collocations": [
-        "Ich hetze ihn bis zum Ende. — Я травлю его до конца."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15262,9 +13651,6 @@
       ],
       "synonyms": [
         "лицемерить"
-      ],
-      "collocations": [
-        "Ich muss vor meinem Vater heucheln. — Я должна лицемерить перед отцом."
       ],
       "visual_hint": "📚"
     },
@@ -15296,9 +13682,6 @@
       "synonyms": [
         "подвергать",
         "сомнению"
-      ],
-      "collocations": [
-        "Ich beginne ihre Taten zu hinterfragen. — Я начинаю подвергать сомнению её поступки."
       ],
       "visual_hint": "📚"
     },
@@ -15332,9 +13715,6 @@
         "betrügen — тоже «обманывать»",
         "täuschen — тоже «обманывать»"
       ],
-      "collocations": [
-        "Ich hintergehe jeden, der mir traut. — Я обманываю каждого, кто мне доверяет."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15363,9 +13743,6 @@
       "synonyms": [
         "надеяться"
       ],
-      "collocations": [
-        "Das Hoffen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело надеяться."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15393,9 +13770,6 @@
       ],
       "synonyms": [
         "слышать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Hören auch ohne Stolz möglich ist. — Корделия показывает, что слышать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -15427,9 +13801,6 @@
       "synonyms": [
         "интриговать"
       ],
-      "collocations": [
-        "Ich intrigiere gegen meinen Bruder. — Я интригую против брата."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15457,9 +13828,6 @@
       ],
       "synonyms": [
         "ошибаться"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Irren ist. — Во время бури становится понятно, насколько важно ошибаться."
       ],
       "visual_hint": "📚"
     },
@@ -15495,10 +13863,6 @@
         "гнаться",
         "гнать"
       ],
-      "collocations": [
-        "Wie ein Hund jage ich meine Beute. — Как собака я гонюсь за добычей.",
-        "Ich jage meinen Sohn fort wie einen Verbrecher. — Я гоню сына прочь как преступника."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15528,9 +13892,6 @@
       ],
       "synonyms": [
         "жонглировать"
-      ],
-      "collocations": [
-        "Ich jongliere mit zwei gefährlichen Frauen. — Я жонглирую двумя опасными женщинами."
       ],
       "visual_hint": "📚"
     },
@@ -15562,9 +13923,6 @@
         "der Adel — тоже «знать»",
         "wissen — тоже «знать»"
       ],
-      "collocations": [
-        "Das Kennen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело знать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15592,9 +13950,6 @@
       ],
       "synonyms": [
         "жаловаться"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Klagen auch ohne Stolz möglich ist. — Корделия показывает, что жаловаться можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -15628,9 +13983,6 @@
         "видеть",
         "sehen — тоже «видеть»"
       ],
-      "collocations": [
-        "Zum ersten Mal sehe ich klar. — Впервые я вижу ясно."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15660,9 +14012,6 @@
       ],
       "synonyms": [
         "звучать"
-      ],
-      "collocations": [
-        "Meine Worte klingen lustig, doch sind traurig. — Мои слова звучат весело, но печальны."
       ],
       "visual_hint": "📚"
     },
@@ -15694,9 +14043,6 @@
       "synonyms": [
         "умный"
       ],
-      "collocations": [
-        "Ich bin klüger als alle bei Hofe. — Я умнее всех при дворе."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15727,9 +14073,6 @@
       "synonyms": [
         "порабощать"
       ],
-      "collocations": [
-        "Ich knechte alle, die mir unterstehen. — Я порабощаю всех, кто мне подчинён."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15757,9 +14100,6 @@
       ],
       "synonyms": [
         "приходить"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Kommen ist. — Во время бури становится понятно, насколько важно приходить."
       ],
       "visual_hint": "📚"
     },
@@ -15791,9 +14131,6 @@
       "synonyms": [
         "противостоять"
       ],
-      "collocations": [
-        "Ich konfrontiere sie mit ihrer Grausamkeit. — Я противостою ей с её жестокостью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15821,9 +14158,6 @@
       ],
       "synonyms": [
         "короновать"
-      ],
-      "collocations": [
-        "Das Krönen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело короновать."
       ],
       "visual_hint": "📚"
     },
@@ -15855,11 +14189,6 @@
         "bekämpfen — тоже «бороться»",
         "сражаться"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Kämpfen alle verändert. — Шут чувствует, как умение бороться меняет всех.",
-        "Ich kämpfe gegen alle seine Feinde. — Я сражаюсь против всех его врагов.",
-        "Ich kämpfe um das, was ich begehre. — Я борюсь за то, чего желаю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15887,9 +14216,6 @@
       ],
       "synonyms": [
         "мочь"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Können alle verändert. — Шут чувствует, как умение мочь меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -15919,9 +14245,6 @@
       "synonyms": [
         "смеяться"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Lachen auch ohne Stolz möglich ist. — Корделия показывает, что смеяться можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -15949,9 +14272,6 @@
       ],
       "synonyms": [
         "позволять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Lassen ist. — Во время бури становится понятно, насколько важно позволять."
       ],
       "visual_hint": "📚"
     },
@@ -15983,9 +14303,6 @@
       "synonyms": [
         "подслушивать"
       ],
-      "collocations": [
-        "Heimlich lausche ich allen Gesprächen. — Тайно я подслушиваю все разговоры."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16014,9 +14331,6 @@
       "synonyms": [
         "жить",
         "wohnen — тоже «жить»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Leben alle verändert. — Шут чувствует, как умение жить меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -16048,9 +14362,6 @@
       "synonyms": [
         "законный"
       ],
-      "collocations": [
-        "Ich bin der legitime Sohn des Grafen. — Я законный сын графа."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16081,9 +14392,6 @@
       "synonyms": [
         "легковерный"
       ],
-      "collocations": [
-        "Ich bin zu leichtgläubig für diese Welt. — Я слишком легковерен для этого мира."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16111,14 +14419,6 @@
       ],
       "synonyms": [
         "страдать"
-      ],
-      "collocations": [
-        "Das Leiden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело страдать.",
-        "Wer nicht gelitten hat, kennt das Leben nicht. — Кто не страдал, не знает жизни.",
-        "Der König leidet mehr als ich jemals gelitten habe. — Король страдает больше, чем я когда-либо страдал.",
-        "Er muss furchtbar leiden ohne mich. — Он должно быть ужасно страдает без меня.",
-        "Ich leide furchtbare Qualen. — Я страдаю от ужасных мук.",
-        "Zum ersten Mal leide ich selbst. — Впервые я сам страдаю."
       ],
       "visual_hint": "📚"
     },
@@ -16150,9 +14450,6 @@
       "synonyms": [
         "направлять"
       ],
-      "collocations": [
-        "Ich lenke das Land in eine bessere Zukunft. — Я направляю страну в лучшее будущее."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16181,9 +14478,6 @@
       "synonyms": [
         "отрицать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Leugnen auch ohne Stolz möglich ist. — Корделия показывает, что отрицать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16211,9 +14505,6 @@
       ],
       "synonyms": [
         "любить"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Lieben ist. — Во время бури становится понятно, насколько важно любить."
       ],
       "visual_hint": "📚"
     },
@@ -16245,9 +14536,6 @@
       "synonyms": [
         "заманивать"
       ],
-      "collocations": [
-        "Ich locke ihn mit Versprechungen. — Я заманиваю его обещаниями."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16277,10 +14565,6 @@
         "лгать",
         "belügen — тоже «лгать»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Lügen alle verändert. — Шут чувствует, как умение лгать меняет всех.",
-        "Ich lüge ohne mit der Wimper zu zucken. — Я лгу не моргнув глазом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16309,9 +14593,6 @@
       "synonyms": [
         "делать",
         "tun — тоже «делать»"
-      ],
-      "collocations": [
-        "Das Machen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело делать."
       ],
       "visual_hint": "📚"
     },
@@ -16343,9 +14624,6 @@
       "synonyms": [
         "манипулировать"
       ],
-      "collocations": [
-        "Ich manipuliere meinen Vater geschickt. — Я ловко манипулирую отцом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16375,9 +14653,6 @@
       ],
       "synonyms": [
         "мягкий"
-      ],
-      "collocations": [
-        "Meine milde Art wird als Schwäche gesehen. — Моя мягкость воспринимается как слабость."
       ],
       "visual_hint": "📚"
     },
@@ -16409,9 +14684,6 @@
       "synonyms": [
         "пренебрегать"
       ],
-      "collocations": [
-        "Ich missachte seinen früheren Rang. — Я пренебрегаю его прежним рангом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16439,9 +14711,6 @@
       ],
       "synonyms": [
         "злоупотреблять"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Missbrauchen auch ohne Stolz möglich ist. — Корделия показывает, что злоупотреблять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -16473,9 +14742,6 @@
       "synonyms": [
         "жестоко",
         "обращаться"
-      ],
-      "collocations": [
-        "Ich misshandle den alten Mann. — Я жестоко обращаюсь со стариком."
       ],
       "visual_hint": "📚"
     },
@@ -16509,10 +14775,6 @@
         "trauen — тоже «доверять»",
         "vertrauen — тоже «доверять»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Misstrauen ist. — Во время бури становится понятно, насколько важно не доверять.",
-        "Ich misstraue jedem ihrer Worte. — Я не доверяю ни одному её слову."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16541,10 +14803,6 @@
       "synonyms": [
         "убивать",
         "töten — тоже «убивать»"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Morden alle verändert. — Шут чувствует, как умение убивать меняет всех.",
-        "Ich bin bereit zu morden für meine Lust. — Я готова убивать ради своей страсти."
       ],
       "visual_hint": "📚"
     },
@@ -16576,9 +14834,6 @@
       "synonyms": [
         "бормотать"
       ],
-      "collocations": [
-        "Ich murmle Unsinn, um verrückt zu wirken. — Я бормочу чепуху, чтобы казаться сумасшедшим."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16609,9 +14864,6 @@
       "synonyms": [
         "храбрый"
       ],
-      "collocations": [
-        "Sei mutig, mein Herz, für die gerechte Sache. — Будь храбрым, моё сердце, ради правого дела."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16640,9 +14892,6 @@
       "synonyms": [
         "должен",
         "sollen — тоже «должен»"
-      ],
-      "collocations": [
-        "Das Müssen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело должен."
       ],
       "visual_hint": "📚"
     },
@@ -16676,9 +14925,6 @@
         "grübeln — тоже «размышлять»",
         "sinnen — тоже «размышлять»"
       ],
-      "collocations": [
-        "Ich denke nach über des Lebens Sinn. — Я размышляю о смысле жизни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16708,9 +14954,6 @@
       ],
       "synonyms": [
         "уступать"
-      ],
-      "collocations": [
-        "Zu oft gebe ich ihrem Willen nach. — Слишком часто я уступаю её воле."
       ],
       "visual_hint": "📚"
     },
@@ -16745,10 +14988,6 @@
       "synonyms": [
         "голый"
       ],
-      "collocations": [
-        "Nackt kam ich auf die Welt, nackt gehe ich! — Голым я пришёл в мир, голым и уйду!",
-        "Fast nackt wandere ich durch die Wildnis. — Почти голый, я брожу по дикой местности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16779,9 +15018,6 @@
       "synonyms": [
         "дразнить"
       ],
-      "collocations": [
-        "Ich necke den König mit der Wahrheit. — Я дразню короля правдой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16809,9 +15045,6 @@
       ],
       "synonyms": [
         "брать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Nehmen auch ohne Stolz möglich ist. — Корделия показывает, что брать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -16843,9 +15076,6 @@
       "synonyms": [
         "новый"
       ],
-      "collocations": [
-        "Eine neue Ära beginnt für unser Land. — Новая эра начинается для нашей страны."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16875,9 +15105,6 @@
       ],
       "synonyms": [
         "жертвовать"
-      ],
-      "collocations": [
-        "Ich opfere ihn für meine Ambitionen. — Я жертвую им ради своих амбиций."
       ],
       "visual_hint": "📚"
     },
@@ -16909,9 +15136,6 @@
       "synonyms": [
         "пассивный"
       ],
-      "collocations": [
-        "Passiv schaue ich dem Unrecht zu. — Пассивно я наблюдаю за несправедливостью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -16941,9 +15165,6 @@
       ],
       "synonyms": [
         "свистеть"
-      ],
-      "collocations": [
-        "Ich pfeife gegen die Dunkelheit an. — Я свищу против темноты."
       ],
       "visual_hint": "📚"
     },
@@ -16975,9 +15196,6 @@
       "synonyms": [
         "планировать"
       ],
-      "collocations": [
-        "Wir planen den Untergang des alten Königs. — Мы планируем падение старого короля."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17008,9 +15226,6 @@
       "synonyms": [
         "великолепный"
       ],
-      "collocations": [
-        "Ein prächtiger Tag für eine verhängnisvolle Entscheidung. — Великолепный день для рокового решения."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17039,9 +15254,6 @@
       "synonyms": [
         "проверять"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Prüfen ist. — Во время бури становится понятно, насколько важно проверять."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17069,11 +15281,6 @@
       ],
       "synonyms": [
         "мучить"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Quälen alle verändert. — Шут чувствует, как умение мучить меняет всех.",
-        "Es bereitet mir Freude, ihn zu quälen. — Мне доставляет радость мучить его.",
-        "Es macht mir Freude, ihn zu quälen. — Мне доставляет радость мучить его."
       ],
       "visual_hint": "📚"
     },
@@ -17105,9 +15312,6 @@
       "synonyms": [
         "советовать"
       ],
-      "collocations": [
-        "Als Кай rate ich ihm zur Vorsicht. — Как Кай я советую ему осторожность."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17135,9 +15339,6 @@
       ],
       "synonyms": [
         "грабить"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Rauben auch ohne Stolz möglich ist. — Корделия показывает, что грабить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -17172,10 +15373,6 @@
       "synonyms": [
         "праведный"
       ],
-      "collocations": [
-        "Ich will rechtschaffen leben und handeln. — Я хочу жить и действовать праведно.",
-        "Ich bin ein rechtschaffener Mann. — Я праведный человек."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17205,9 +15402,6 @@
         "говорить",
         "sagen — тоже «говорить»",
         "sprechen — тоже «говорить»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Reden ist. — Во время бури становится понятно, насколько важно говорить."
       ],
       "visual_hint": "📚"
     },
@@ -17239,11 +15433,6 @@
         "herrschen — тоже «править»",
         "управлять"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Regieren alle verändert. — Шут чувствует, как умение управлять меняет всех.",
-        "Mit Weisheit werde ich regieren. — С мудростью я буду править.",
-        "Ich werde mit eiserner Hand regieren. — Я буду управлять железной рукой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17272,9 +15461,6 @@
       "synonyms": [
         "путешествовать"
       ],
-      "collocations": [
-        "Das Reisen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело путешествовать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17302,9 +15488,6 @@
       ],
       "synonyms": [
         "рвать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Reißen auch ohne Stolz möglich ist. — Корделия показывает, что рвать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -17335,9 +15518,6 @@
         "бежать",
         "fliehen — тоже «бежать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Rennen ist. — Во время бури становится понятно, насколько важно бежать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17365,11 +15545,6 @@
       ],
       "synonyms": [
         "спасать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Retten alle verändert. — Шут чувствует, как умение спасать меняет всех.",
-        "Mit List will ich meinen Vater retten. — Хитростью я хочу спасти отца.",
-        "Ich muss meinen Vater vor seinen grausamen Töchtern retten. — Я должна спасти отца от его жестоких дочерей."
       ],
       "visual_hint": "📚"
     },
@@ -17399,10 +15574,6 @@
       "synonyms": [
         "судить",
         "urteilen — тоже «судить»"
-      ],
-      "collocations": [
-        "Das Richten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело судить.",
-        "Gerecht will ich über die Verbrecher richten. — Справедливо я хочу судить преступников."
       ],
       "visual_hint": "📚"
     },
@@ -17434,9 +15605,6 @@
       "synonyms": [
         "рисковать"
       ],
-      "collocations": [
-        "Ich riskiere alles für den alten König. — Я рискую всем ради старого короля."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17467,9 +15635,6 @@
       "synonyms": [
         "соперничать"
       ],
-      "collocations": [
-        "Ich rivalisiere mit meiner Schwester um Edmund. — Я соперничаю с сестрой за Эдмунда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17498,9 +15663,6 @@
       "synonyms": [
         "звать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Rufen auch ohne Stolz möglich ist. — Корделия показывает, что звать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17528,9 +15690,6 @@
       ],
       "synonyms": [
         "мстить"
-      ],
-      "collocations": [
-        "Das Rächen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело мстить."
       ],
       "visual_hint": "📚"
     },
@@ -17565,10 +15724,6 @@
       "synonyms": [
         "загадочный"
       ],
-      "collocations": [
-        "Meine Worte bleiben rätselhaft und wahr. — Мои слова остаются загадочными и правдивыми.",
-        "Mein Ende bleibt rätselhaft und stumm. — Мой конец остаётся загадочным и немым."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17598,9 +15753,6 @@
       ],
       "synonyms": [
         "хрипеть"
-      ],
-      "collocations": [
-        "Röchelnd hauche ich mein Leben aus. — Хрипя, я испускаю дух."
       ],
       "visual_hint": "📚"
     },
@@ -17632,9 +15784,6 @@
         "reden — тоже «говорить»",
         "sprechen — тоже «говорить»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Sagen ist. — Во время бури становится понятно, насколько важно говорить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17665,9 +15814,6 @@
       "synonyms": [
         "нежный"
       ],
-      "collocations": [
-        "Sei sanft zu dir selbst, lieber Vater. — Будь нежен к себе, дорогой отец."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17695,9 +15841,6 @@
       ],
       "synonyms": [
         "создавать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Schaffen alle verändert. — Шут чувствует, как умение создавать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -17730,9 +15873,6 @@
         "erdulden — тоже «терпеть»",
         "неудачу"
       ],
-      "collocations": [
-        "Das Scheitern fällt Lear unerwartet schwer. — Лиру неожиданно тяжело терпеть неудачу."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17760,9 +15900,6 @@
       ],
       "synonyms": [
         "дарить"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Schenken auch ohne Stolz möglich ist. — Корделия показывает, что дарить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -17794,9 +15931,6 @@
       "synonyms": [
         "шутить"
       ],
-      "collocations": [
-        "Ich scherze, um den Schmerz zu verbergen. — Я шучу, чтобы скрыть боль."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17824,9 +15958,6 @@
       ],
       "synonyms": [
         "посылать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Schicken ist. — Во время бури становится понятно, насколько важно посылать."
       ],
       "visual_hint": "📚"
     },
@@ -17856,9 +15987,6 @@
       "synonyms": [
         "спать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Schlafen alle verändert. — Шут чувствует, как умение спать меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17887,9 +16015,6 @@
       "synonyms": [
         "бить"
       ],
-      "collocations": [
-        "Das Schlagen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело бить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17917,10 +16042,6 @@
       ],
       "synonyms": [
         "льстить"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Schmeicheln auch ohne Stolz möglich ist. — Корделия показывает, что льстить можно и без гордыни.",
-        "Mit süßen Worten schmeichle ich ihm. — Сладкими словами я льщу ему."
       ],
       "visual_hint": "📚"
     },
@@ -17952,9 +16073,6 @@
       "synonyms": [
         "ковать"
       ],
-      "collocations": [
-        "Ich schmiede Pläne gegen alle Feinde. — Я кую планы против всех врагов."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -17985,9 +16103,6 @@
       "synonyms": [
         "вынюхивать"
       ],
-      "collocations": [
-        "Überall schnüffle ich nach Geheimnissen. — Везде я вынюхиваю секреты."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18015,9 +16130,6 @@
       ],
       "synonyms": [
         "писать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Schreiben ist. — Во время бури становится понятно, насколько важно писать."
       ],
       "visual_hint": "📚"
     },
@@ -18052,10 +16164,6 @@
       "synonyms": [
         "кричать"
       ],
-      "collocations": [
-        "Ich schreie in den Wind meine Wut hinaus! — Я кричу в ветер свою ярость!",
-        "Ich schreie vor unerträglichem Schmerz. — Я кричу от невыносимой боли."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18086,9 +16194,6 @@
       "synonyms": [
         "виновный"
       ],
-      "collocations": [
-        "Ich bin schuldig vor meiner Tochter. — Я виновен перед своей дочерью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18116,9 +16221,6 @@
       ],
       "synonyms": [
         "молчать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Schweigen alle verändert. — Шут чувствует, как умение молчать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -18150,9 +16252,6 @@
       "synonyms": [
         "ослаблять"
       ],
-      "collocations": [
-        "Die Verletzung schwächt meinen starken Körper. — Ранение ослабляет моё сильное тело."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18180,10 +16279,6 @@
       ],
       "synonyms": [
         "клясться"
-      ],
-      "collocations": [
-        "Das Schwören fällt Lear unerwartet schwer. — Лиру неожиданно тяжело клясться.",
-        "Ich schwöre, dass ich Euch mehr liebe als mein Leben. — Я клянусь, что люблю вас больше жизни."
       ],
       "visual_hint": "📚"
     },
@@ -18217,9 +16312,6 @@
         "beschützen — тоже «защищать»",
         "verteidigen — тоже «защищать»"
       ],
-      "collocations": [
-        "Ich will den wahnsinnigen König schützen. — Я хочу защитить безумного короля."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18249,9 +16341,6 @@
         "видеть",
         "klar sehen — тоже «видеть»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Sehen auch ohne Stolz möglich ist. — Корделия показывает, что видеть можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18279,9 +16368,6 @@
       ],
       "synonyms": [
         "быть"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Sein ist. — Во время бури становится понятно, насколько важно быть."
       ],
       "visual_hint": "📚"
     },
@@ -18312,9 +16398,6 @@
       ],
       "synonyms": [
         "растворяться"
-      ],
-      "collocations": [
-        "Ich löse mich auf wie Nebel im Wind. — Я растворяюсь как туман на ветру."
       ],
       "visual_hint": "📚"
     },
@@ -18347,9 +16430,6 @@
         "защищаться",
         "wehren — тоже «защищаться»"
       ],
-      "collocations": [
-        "Ich wehre mich gegen ihre Tyrannei. — Я защищаюсь от её тирании."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18378,11 +16458,6 @@
       "synonyms": [
         "побеждать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Siegen alle verändert. — Шут чувствует, как умение побеждать меняет всех.",
-        "Die Wahrheit wird über die Lüge siegen. — Правда победит ложь.",
-        "Die Liebe wird über den Hass siegen. — Любовь победит ненависть."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18410,10 +16485,6 @@
       ],
       "synonyms": [
         "петь"
-      ],
-      "collocations": [
-        "Das Singen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело петь.",
-        "Ich singe, um seine Angst zu lindern. — Я пою, чтобы облегчить его страх."
       ],
       "visual_hint": "📚"
     },
@@ -18445,9 +16516,6 @@
         "grübeln — тоже «размышлять»",
         "nachdenken — тоже «размышлять»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Sinnen auch ohne Stolz möglich ist. — Корделия показывает, что размышлять можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18475,9 +16543,6 @@
       ],
       "synonyms": [
         "сидеть"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Sitzen ist. — Во время бури становится понятно, насколько важно сидеть."
       ],
       "visual_hint": "📚"
     },
@@ -18508,9 +16573,6 @@
         "должен",
         "müssen — тоже «должен»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Sollen alle verändert. — Шут чувствует, как умение должен меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18538,9 +16600,6 @@
       ],
       "synonyms": [
         "заботиться"
-      ],
-      "collocations": [
-        "Das Sorgen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело заботиться."
       ],
       "visual_hint": "📚"
     },
@@ -18570,9 +16629,6 @@
       "synonyms": [
         "экономить"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Sparen auch ohne Stolz möglich ist. — Корделия показывает, что экономить можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18600,10 +16656,6 @@
       ],
       "synonyms": [
         "играть"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Spielen ist. — Во время бури становится понятно, насколько важно играть.",
-        "Ich spiele mit ihren Gefühlen. — Я играю с их чувствами."
       ],
       "visual_hint": "📚"
     },
@@ -18634,9 +16686,6 @@
       ],
       "synonyms": [
         "шпионить"
-      ],
-      "collocations": [
-        "Ich spioniere für meine böse Herrin. — Я шпионю для моей злой госпожи."
       ],
       "visual_hint": "📚"
     },
@@ -18669,9 +16718,6 @@
         "насмехаться",
         "verhöhnen — тоже «насмехаться»"
       ],
-      "collocations": [
-        "Ich spotte über die Torheit der Mächtigen. — Я насмехаюсь над глупостью сильных."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18702,9 +16748,6 @@
         "reden — тоже «говорить»",
         "sagen — тоже «говорить»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Sprechen alle verändert. — Шут чувствует, как умение говорить меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18732,10 +16775,6 @@
       ],
       "synonyms": [
         "прыгать"
-      ],
-      "collocations": [
-        "Das Springen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прыгать.",
-        "Ich will von den Klippen springen. — Я хочу прыгнуть со скал."
       ],
       "visual_hint": "📚"
     },
@@ -18767,9 +16806,6 @@
       "synonyms": [
         "бесследно"
       ],
-      "collocations": [
-        "Spurlos gehe ich aus dieser Welt. — Бесследно я ухожу из этого мира."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18797,9 +16833,6 @@
       ],
       "synonyms": [
         "стоять"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Stehen auch ohne Stolz möglich ist. — Корделия показывает, что стоять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -18829,9 +16862,6 @@
       "synonyms": [
         "красть"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Stehlen ist. — Во время бури становится понятно, насколько важно красть."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18859,14 +16889,6 @@
       ],
       "synonyms": [
         "умирать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Sterben alle verändert. — Шут чувствует, как умение умирать меняет всех.",
-        "Lass mich an deiner Seite sterben, Cordelia. — Позволь мне умереть рядом с тобой, Корделия.",
-        "Wenn ich sterben muss, sterbe ich mit reinem Herzen. — Если я должна умереть, я умру с чистым сердцем.",
-        "Ich sterbe ohne Reue für meine Taten. — Я умираю без раскаяния за свои дела.",
-        "Ich sterbe vor Freude und Kummer. — Я умираю от радости и горя.",
-        "Ich sterbe durch meine eigene Hand. — Я умираю от своей собственной руки."
       ],
       "visual_hint": "📚"
     },
@@ -18898,10 +16920,6 @@
         "bestrafen — тоже «наказывать»",
         "züchtigen — тоже «наказывать»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Strafen auch ohne Stolz möglich ist. — Корделия показывает, что наказывать можно и без гордыни.",
-        "Die Schuldigen müssen bestraft werden. — Виновные должны быть наказаны."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18932,9 +16950,6 @@
       "synonyms": [
         "стремиться"
       ],
-      "collocations": [
-        "Ich strebe nach absoluter Kontrolle. — Я стремлюсь к абсолютному контролю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18964,10 +16979,6 @@
         "спорить",
         "ссориться"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Streiten ist. — Во время бури становится понятно, насколько важно спорить.",
-        "Ich streite mit meinem schwachen Mann. — Я ссорюсь со своим слабым мужем."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -18995,9 +17006,6 @@
       ],
       "synonyms": [
         "мешать"
-      ],
-      "collocations": [
-        "Das Stören fällt Lear unerwartet schwer. — Лиру неожиданно тяжело мешать."
       ],
       "visual_hint": "📚"
     },
@@ -19028,10 +17036,6 @@
         "падать",
         "fallen — тоже «падать»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Stürzen alle verändert. — Шут чувствует, как умение падать меняет всех.",
-        "Ich glaube, von hohen Klippen zu stürzen. — Я верю, что падаю с высоких скал."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19059,9 +17063,6 @@
       ],
       "synonyms": [
         "искать"
-      ],
-      "collocations": [
-        "Das Suchen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело искать."
       ],
       "visual_hint": "📚"
     },
@@ -19093,9 +17094,6 @@
       "synonyms": [
         "напевать"
       ],
-      "collocations": [
-        "Leise summe ich alte Melodien. — Тихо я напеваю старые мелодии."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19123,9 +17121,6 @@
       ],
       "synonyms": [
         "танцевать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Tanzen auch ohne Stolz möglich ist. — Корделия показывает, что танцевать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -19157,9 +17152,6 @@
       "synonyms": [
         "отважный"
       ],
-      "collocations": [
-        "Ich bleibe tapfer für dich, Vater. — Я остаюсь отважной ради тебя, отец."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19187,10 +17179,6 @@
       ],
       "synonyms": [
         "делить"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Teilen alle verändert. — Шут чувствует, как умение делить меняет всех.",
-        "Wir teilen das Reich zwischen uns. — Мы делим королевство между собой."
       ],
       "visual_hint": "📚"
     },
@@ -19220,10 +17208,6 @@
       "synonyms": [
         "бушевать"
       ],
-      "collocations": [
-        "Das Toben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело бушевать.",
-        "Lasst die Winde toben und die Blitze fallen! — Пусть ветры бушуют и молнии падают!"
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19251,9 +17235,6 @@
       ],
       "synonyms": [
         "нести"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Tragen ist. — Во время бури становится понятно, насколько важно нести."
       ],
       "visual_hint": "📚"
     },
@@ -19285,9 +17266,6 @@
         "misstrauen — тоже «доверять»",
         "vertrauen — тоже «доверять»"
       ],
-      "collocations": [
-        "Das Trauen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело доверять."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19316,9 +17294,6 @@
       "synonyms": [
         "горевать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Trauern auch ohne Stolz möglich ist. — Корделия показывает, что горевать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19346,9 +17321,6 @@
       ],
       "synonyms": [
         "разделять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Trennen ist. — Во время бури становится понятно, насколько важно разделять."
       ],
       "visual_hint": "📚"
     },
@@ -19383,10 +17355,6 @@
       "synonyms": [
         "верный"
       ],
-      "collocations": [
-        "Treu bleibe ich trotz der Verkleidung. — Верным остаюсь несмотря на переодевание.",
-        "Ich bleibe treu, wenn alle anderen fliehen. — Я остаюсь верным, когда все остальные бегут."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19417,9 +17385,6 @@
       "synonyms": [
         "торжествовать"
       ],
-      "collocations": [
-        "Ich triumphiere über meinen Bruder. — Я торжествую над братом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19447,9 +17412,6 @@
       ],
       "synonyms": [
         "мечтать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Träumen alle verändert. — Шут чувствует, как умение мечтать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -19479,12 +17441,6 @@
       "synonyms": [
         "утешать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Trösten alle verändert. — Шут чувствует, как умение утешать меняет всех.",
-        "Als Fremder tröste ich meinen eigenen Vater. — Как чужой, я утешаю собственного отца.",
-        "Lass mich dich trösten in dieser dunklen Stunde. — Позволь мне утешить тебя в этот тёмный час.",
-        "Mit Worten tröste ich den wahnsinnigen König. — Словами я утешаю безумного короля."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19513,9 +17469,6 @@
       "synonyms": [
         "делать",
         "machen — тоже «делать»"
-      ],
-      "collocations": [
-        "Das Tun fällt Lear unerwartet schwer. — Лиру неожиданно тяжело делать."
       ],
       "visual_hint": "📚"
     },
@@ -19547,12 +17500,6 @@
         "betrügen — тоже «обманывать»",
         "hintergehen — тоже «обманывать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Täuschen ist. — Во время бури становится понятно, насколько важно обманывать.",
-        "Ich täusche ihn, um sein Leben zu retten. — Я обманываю его, чтобы спасти его жизнь.",
-        "Edmund täuscht mich mit falschen Beweisen. — Эдмунд обманывает меня ложными доказательствами.",
-        "Ich täusche meinen alten Vater leicht. — Я легко обманываю старого отца."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19581,9 +17528,6 @@
       "synonyms": [
         "убивать",
         "morden — тоже «убивать»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Töten auch ohne Stolz möglich ist. — Корделия показывает, что убивать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -19614,9 +17558,6 @@
       ],
       "synonyms": [
         "коварный"
-      ],
-      "collocations": [
-        "Tückisch plane ich meinen nächsten Schritt. — Коварно я планирую свой следующий шаг."
       ],
       "visual_hint": "📚"
     },
@@ -19651,10 +17592,6 @@
       "synonyms": [
         "обнимать"
       ],
-      "collocations": [
-        "Lass mich dich umarmen und deine Tränen trocknen. — Позволь мне обнять тебя и вытереть твои слёзы.",
-        "Ein letztes Mal umarme ich meinen Sohn. — В последний раз я обнимаю сына."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19685,9 +17622,6 @@
         "wiederkehren — тоже «возвращаться»",
         "zurückkehren — тоже «возвращаться»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Umkehren alle verändert. — Шут чувствует, как умение возвращаться меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19715,9 +17649,6 @@
       ],
       "synonyms": [
         "окружать"
-      ],
-      "collocations": [
-        "Das Umringen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело окружать."
       ],
       "visual_hint": "📚"
     },
@@ -19749,9 +17680,6 @@
       "synonyms": [
         "внебрачный"
       ],
-      "collocations": [
-        "Meine uneheliche Geburt ist mein Fluch. — Моё внебрачное рождение - мой проклятие."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19781,9 +17709,6 @@
       ],
       "synonyms": [
         "неузнанный"
-      ],
-      "collocations": [
-        "Unerkannt bleibe ich an seiner Seite. — Неузнанным я остаюсь рядом с ним."
       ],
       "visual_hint": "📚"
     },
@@ -19815,9 +17740,6 @@
       "synonyms": [
         "неуверенный"
       ],
-      "collocations": [
-        "Ich werde unsicher in meinem Schweigen. — Я становлюсь неуверенным в своём молчании."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19845,9 +17767,6 @@
       ],
       "synonyms": [
         "прерывать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Unterbrechen auch ohne Stolz möglich ist. — Корделия показывает, что прерывать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -19877,10 +17796,6 @@
       "synonyms": [
         "подавлять"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Unterdrücken ist. — Во время бури становится понятно, насколько важно подавлять.",
-        "Ich unterdrücke jeden freien Gedanken. — Я подавляю любую свободную мысль."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19908,9 +17823,6 @@
       ],
       "synonyms": [
         "погибать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Untergehen alle verändert. — Шут чувствует, как умение погибать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -19943,9 +17855,6 @@
         "проигрывать",
         "verlieren — тоже «проигрывать»"
       ],
-      "collocations": [
-        "Ich unterliege dem edlen Edgar. — Я проигрываю благородному Эдгару."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -19973,9 +17882,6 @@
       ],
       "synonyms": [
         "различать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Unterscheiden auch ohne Stolz möglich ist. — Корделия показывает, что различать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -20005,9 +17911,6 @@
       "synonyms": [
         "недооценивать"
       ],
-      "collocations": [
-        "Das Unterschätzen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело недооценивать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20036,10 +17939,6 @@
       "synonyms": [
         "поддерживать"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Unterstützen ist. — Во время бури становится понятно, насколько важно поддерживать.",
-        "Ich unterstütze ihre Unmenschlichkeit. — Я поддерживаю её бесчеловечность."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20067,10 +17966,6 @@
       ],
       "synonyms": [
         "подчинять"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Unterwerfen alle verändert. — Шут чувствует, как умение подчинять меняет всех.",
-        "Alle müssen sich mir unterwerfen. — Все должны мне подчиниться."
       ],
       "visual_hint": "📚"
     },
@@ -20102,9 +17997,6 @@
       "synonyms": [
         "раболепный"
       ],
-      "collocations": [
-        "Unterwürfig krieche ich vor meiner Herrin. — Раболепно я пресмыкаюсь перед госпожой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20133,9 +18025,6 @@
       "synonyms": [
         "судить",
         "richten — тоже «судить»"
-      ],
-      "collocations": [
-        "Das Urteilen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело судить."
       ],
       "visual_hint": "📚"
     },
@@ -20166,9 +18055,6 @@
       ],
       "synonyms": [
         "презирать"
-      ],
-      "collocations": [
-        "Ich verachte seine Schwäche und sein Alter. — Я презираю его слабость и старость."
       ],
       "visual_hint": "📚"
     },
@@ -20201,10 +18087,6 @@
         "verstoßen — тоже «изгонять»",
         "vertreiben — тоже «изгонять»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verbannen auch ohne Stolz möglich ist. — Корделия показывает, что изгонять можно и без гордыни.",
-        "Mein Vater will mich aus dem Land verbannen. — Мой отец хочет изгнать меня из страны."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20235,9 +18117,6 @@
       "synonyms": [
         "изгнанный"
       ],
-      "collocations": [
-        "Verbannt aus dem Land, das ich liebe. — Изгнан из страны, которую люблю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20267,9 +18146,6 @@
         "скрывать",
         "verheimlichen — тоже «скрывать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verbergen ist. — Во время бури становится понятно, насколько важно скрывать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20297,9 +18173,6 @@
       ],
       "synonyms": [
         "запрещать"
-      ],
-      "collocations": [
-        "Das Verbieten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело запрещать."
       ],
       "visual_hint": "📚"
     },
@@ -20329,9 +18202,6 @@
       "synonyms": [
         "соединять"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verbinden alle verändert. — Шут чувствует, как умение соединять меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20359,9 +18229,6 @@
       ],
       "synonyms": [
         "сжигать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verbrennen auch ohne Stolz möglich ist. — Корделия показывает, что сжигать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -20393,9 +18260,6 @@
       "synonyms": [
         "объединяться"
       ],
-      "collocations": [
-        "Ich verbünde mich mit den bösen Schwestern. — Я объединяюсь со злыми сёстрами."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20424,9 +18288,6 @@
       "synonyms": [
         "портить"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verderben alle verändert. — Шут чувствует, как умение портить меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20454,9 +18315,6 @@
       ],
       "synonyms": [
         "заслуживать"
-      ],
-      "collocations": [
-        "Das Verdienen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело заслуживать."
       ],
       "visual_hint": "📚"
     },
@@ -20488,9 +18346,6 @@
       "synonyms": [
         "вытеснять"
       ],
-      "collocations": [
-        "Ich verdränge den rechtmäßigen Erben. — Я вытесняю законного наследника."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20519,10 +18374,6 @@
       "synonyms": [
         "подозревать",
         "argwöhnen — тоже «подозревать»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verdächtigen ist. — Во время бури становится понятно, насколько важно подозревать.",
-        "Ich verdächtige meinen guten Sohn Edgar. — Я подозреваю моего доброго сына Эдгара."
       ],
       "visual_hint": "📚"
     },
@@ -20554,9 +18405,6 @@
       "synonyms": [
         "договариваться"
       ],
-      "collocations": [
-        "Wir vereinbaren gemeinsame Grausamkeit. — Мы договариваемся о совместной жестокости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20584,9 +18432,6 @@
       ],
       "synonyms": [
         "объединять"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Vereinen auch ohne Stolz möglich ist. — Корделия показывает, что объединять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -20621,9 +18466,6 @@
       "synonyms": [
         "издыхать"
       ],
-      "collocations": [
-        "Wie ein Tier verende ich elend. — Как зверь я издыхаю жалко."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20653,12 +18495,6 @@
         "проклинать",
         "fluchen — тоже «проклинать»",
         "verwünschen — тоже «проклинать»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verfluchen ist. — Во время бури становится понятно, насколько важно проклинать.",
-        "Ich verfluche dich bei allen Sternen! — Я проклинаю тебя всеми звёздами!",
-        "Sterbend verfluche ich meine Mörder. — Умирая, я проклинаю своих убийц.",
-        "Im Zorn verfluche ich Edgar. — В гневе я проклинаю Эдгара."
       ],
       "visual_hint": "📚"
     },
@@ -20690,9 +18526,6 @@
       "synonyms": [
         "проклятый"
       ],
-      "collocations": [
-        "Verflucht sei unser böses Blut! — Проклята наша злая кровь!"
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20720,11 +18553,6 @@
       ],
       "synonyms": [
         "преследовать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Verfolgen alle verändert. — Шут чувствует, как умение преследовать меняет всех.",
-        "Gnadenlos verfolge ich den alten Mann. — Безжалостно я преследую старика.",
-        "Die Soldaten verfolgen mich wie einen Verbrecher. — Солдаты преследуют меня как преступника."
       ],
       "visual_hint": "📚"
     },
@@ -20759,10 +18587,6 @@
       "synonyms": [
         "соблазнять"
       ],
-      "collocations": [
-        "Ich verführe beide Schwestern gleichzeitig. — Я соблазняю обеих сестёр одновременно.",
-        "Ich will Edmund verführen und besitzen. — Я хочу соблазнить и завладеть Эдмундом."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20792,11 +18616,6 @@
         "прощать",
         "verzeihen — тоже «прощать»"
       ],
-      "collocations": [
-        "Das Vergeben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прощать.",
-        "Kannst du einem törichten alten Mann vergeben? — Можешь ли ты простить глупого старика?",
-        "Edgar vergibt mir meine Blindheit. — Эдгар прощает мне мою слепоту."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20825,9 +18644,6 @@
       "synonyms": [
         "забывать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Vergessen auch ohne Stolz möglich ist. — Корделия показывает, что забывать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20855,10 +18671,6 @@
       ],
       "synonyms": [
         "отравлять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Vergiften ist. — Во время бури становится понятно, насколько важно отравлять.",
-        "Ich vergifte erst meine Schwester, dann mich selbst. — Я отравляю сначала сестру, потом себя."
       ],
       "visual_hint": "📚"
     },
@@ -20890,9 +18702,6 @@
       "synonyms": [
         "отравленный"
       ],
-      "collocations": [
-        "Ich bin von meiner eigenen Schwester vergiftet. — Я отравлена собственной сестрой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20923,9 +18732,6 @@
       "synonyms": [
         "преходящий"
       ],
-      "collocations": [
-        "Alles ist vergänglich, nur die Torheit bleibt. — Всё преходяще, только глупость остаётся."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -20953,9 +18759,6 @@
       ],
       "synonyms": [
         "арестовывать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Verhaften alle verändert. — Шут чувствует, как умение арестовывать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -20987,9 +18790,6 @@
         "führen — тоже «вести»",
         "себя"
       ],
-      "collocations": [
-        "Das Verhalten fällt Lear unerwartet schwer. — Лиру неожиданно тяжело вести себя."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21018,9 +18818,6 @@
       "synonyms": [
         "скрывать",
         "verbergen — тоже «скрывать»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verheimlichen auch ohne Stolz möglich ist. — Корделия показывает, что скрывать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -21053,9 +18850,6 @@
         "verraten — тоже «выдавать»",
         "замуж"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verheiraten ist. — Во время бури становится понятно, насколько важно выдавать замуж."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21085,9 +18879,6 @@
       ],
       "synonyms": [
         "ожесточаться"
-      ],
-      "collocations": [
-        "Mein Herz verhärtet sich gegen alle Bitten. — Моё сердце ожесточается против всех просьб."
       ],
       "visual_hint": "📚"
     },
@@ -21124,10 +18915,6 @@
         "насмехаться",
         "spotten — тоже «насмехаться»"
       ],
-      "collocations": [
-        "Ich verhöhne seine königliche Würde. — Я высмеиваю его королевское достоинство.",
-        "Ich verhöhne seine väterliche Liebe. — Я насмехаюсь над его отцовской любовью."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21156,9 +18943,6 @@
       "synonyms": [
         "допрашивать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verhören alle verändert. — Шут чувствует, как умение допрашивать меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21186,9 +18970,6 @@
       ],
       "synonyms": [
         "продавать"
-      ],
-      "collocations": [
-        "Das Verkaufen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело продавать."
       ],
       "visual_hint": "📚"
     },
@@ -21219,9 +19000,6 @@
         "обвинять",
         "anklagen — тоже «обвинять»",
         "beschuldigen — тоже «обвинять»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verklagen auch ohne Stolz möglich ist. — Корделия показывает, что обвинять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -21256,10 +19034,6 @@
       "synonyms": [
         "провозглашать"
       ],
-      "collocations": [
-        "Ich verkünde die Teilung meines Reiches. — Я провозглашаю раздел моего королевства.",
-        "Ich verkünde nur die Wahrheit meines Herzens. — Я провозглашаю только правду моего сердца."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21291,10 +19065,6 @@
         "wünschen — тоже «желать»",
         "требовать"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verlangen ist. — Во время бури становится понятно, насколько важно требовать.",
-        "Ich verlange mehr als mir zusteht. — Я желаю больше, чем мне положено."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21322,11 +19092,6 @@
       ],
       "synonyms": [
         "покидать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Verlassen alle verändert. — Шут чувствует, как умение покидать меняет всех.",
-        "Auch Regan will mich verlassen und verstoßen! — И Регана хочет меня покинуть и отвергнуть!",
-        "Schweren Herzens verlasse ich mein Vaterland. — С тяжёлым сердцем я покидаю родину."
       ],
       "visual_hint": "📚"
     },
@@ -21356,9 +19121,6 @@
       "synonyms": [
         "проходить"
       ],
-      "collocations": [
-        "Das Verlaufen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело проходить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21386,9 +19148,6 @@
       ],
       "synonyms": [
         "одалживать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verleihen auch ohne Stolz möglich ist. — Корделия показывает, что одалживать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -21418,9 +19177,6 @@
       "synonyms": [
         "ранить",
         "verwunden — тоже «ранить»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verletzen ist. — Во время бури становится понятно, насколько важно ранить."
       ],
       "visual_hint": "📚"
     },
@@ -21452,10 +19208,6 @@
         "unterliegen — тоже «проигрывать»",
         "терять"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verlieren alle verändert. — Шут чувствует, как умение терять меняет всех.",
-        "Ich verliere alles, was ich gewann. — Я проигрываю всё, что выиграл."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21483,9 +19235,6 @@
       ],
       "synonyms": [
         "обручаться"
-      ],
-      "collocations": [
-        "Das Verloben fällt Lear unerwartet schwer. — Лиру неожиданно тяжело обручаться."
       ],
       "visual_hint": "📚"
     },
@@ -21517,9 +19266,6 @@
       "synonyms": [
         "завлекать"
       ],
-      "collocations": [
-        "Ich verlocke sie mit falschen Versprechen. — Я завлекаю их ложными обещаниями."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21547,9 +19293,6 @@
       ],
       "synonyms": [
         "избегать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Vermeiden auch ohne Stolz möglich ist. — Корделия показывает, что избегать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -21581,9 +19324,6 @@
       "synonyms": [
         "скучать"
       ],
-      "collocations": [
-        "Ich vermisse die süße Корделия sehr. — Я очень скучаю по милой Корделии."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21611,10 +19351,6 @@
       ],
       "synonyms": [
         "уничтожать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Vernichten ist. — Во время бури становится понятно, насколько важно уничтожать.",
-        "Ich vernichte mich selbst durch meine Bosheit. — Я уничтожаю себя своим злом."
       ],
       "visual_hint": "📚"
     },
@@ -21647,12 +19383,6 @@
         "ausliefern — тоже «выдавать»",
         "verheiraten — тоже «выдавать»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verraten alle verändert. — Шут чувствует, как умение предавать меняет всех.",
-        "Ich verrate jeden an meine Herrin. — Я выдаю каждого своей госпоже.",
-        "Ich verrate meinen eigenen Vater. — Я предаю собственного отца.",
-        "Ich verrate meinen Mann für Edmund. — Я предаю мужа ради Эдмунда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21681,9 +19411,6 @@
       "synonyms": [
         "собирать"
       ],
-      "collocations": [
-        "Das Versammeln fällt Lear unerwartet schwer. — Лиру неожиданно тяжело собирать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21711,9 +19438,6 @@
       ],
       "synonyms": [
         "доставать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verschaffen auch ohne Stolz möglich ist. — Корделия показывает, что доставать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -21745,9 +19469,6 @@
       "synonyms": [
         "хитрый"
       ],
-      "collocations": [
-        "Verschlagen verberge ich meine wahren Absichten. — Хитро я скрываю свои истинные намерения."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21777,10 +19498,6 @@
         "запирать",
         "einsperren — тоже «запирать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verschließen ist. — Во время бури становится понятно, насколько важно запирать.",
-        "Ich verschließe meine Türen vor ihm. — Я запираю двери перед ним."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21808,9 +19525,6 @@
       ],
       "synonyms": [
         "умалчивать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Verschweigen alle verändert. — Шут чувствует, как умение умалчивать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -21840,10 +19554,6 @@
       "synonyms": [
         "исчезать"
       ],
-      "collocations": [
-        "Das Verschwinden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело исчезать.",
-        "Ich verschwinde wie ein Traum im Morgen. — Я исчезаю как сон поутру."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21872,10 +19582,6 @@
       "synonyms": [
         "заговорить"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verschwören auch ohne Stolz möglich ist. — Корделия показывает, что заговорить можно и без гордыни.",
-        "Wir verschwören uns gegen ihn. — Мы составляем заговор против него."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21903,9 +19609,6 @@
       ],
       "synonyms": [
         "обещать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Versprechen alle verändert. — Шут чувствует, как умение обещать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -21936,10 +19639,6 @@
         "прятать",
         "прятаться"
       ],
-      "collocations": [
-        "Das Verstecken fällt Lear unerwartet schwer. — Лиру неожиданно тяжело прятать.",
-        "Ich muss mich in den Wäldern verstecken. — Я должен прятаться в лесах."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -21968,10 +19667,6 @@
       "synonyms": [
         "понимать",
         "begreifen — тоже «понимать»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verstehen auch ohne Stolz möglich ist. — Корделия показывает, что понимать можно и без гордыни.",
-        "Jetzt verstehe ich, wer mich wirklich liebte. — Теперь я понимаю, кто действительно меня любил."
       ],
       "visual_hint": "📚"
     },
@@ -22003,9 +19698,6 @@
       "synonyms": [
         "изменять",
         "betrügen — тоже «изменять»"
-      ],
-      "collocations": [
-        "Ich verstelle meine Stimme und Haltung. — Я изменяю свой голос и осанку."
       ],
       "visual_hint": "📚"
     },
@@ -22039,13 +19731,6 @@
         "отвергать",
         "abweisen — тоже «отвергать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verstoßen ist. — Во время бури становится понятно, насколько важно изгонять.",
-        "Meine Töchter verstoßen mich wie einen Bettler! — Мои дочери отвергают меня как нищего!",
-        "Der König verstößt mich aus seinem Herzen. — Король изгоняет меня из своего сердца.",
-        "Ich verstoße meinen unschuldigen Sohn. — Я изгоняю своего невинного сына.",
-        "Ich verstoße meinen Vater in die Nacht. — Я отвергаю отца в ночь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22076,9 +19761,6 @@
       "synonyms": [
         "калечить"
       ],
-      "collocations": [
-        "Ich verstümmle ihn ohne Erbarmen. — Я калечу его без милосердия."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22107,9 +19789,6 @@
       "synonyms": [
         "пытаться"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Versuchen alle verändert. — Шут чувствует, как умение пытаться меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22137,10 +19816,6 @@
       ],
       "synonyms": [
         "примирять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Versöhnen ist. — Во время бури становится понятно, насколько важно примирять.",
-        "Ich will die Getrennten versöhnen. — Я хочу примирить разделённых."
       ],
       "visual_hint": "📚"
     },
@@ -22172,10 +19847,6 @@
         "beschützen — тоже «защищать»",
         "schützen — тоже «защищать»"
       ],
-      "collocations": [
-        "Das Verteidigen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело защищать.",
-        "Ich verteidige Корделия gegen Ungerechtigkeit. — Я защищаю Корделию от несправедливости."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22203,9 +19874,6 @@
       ],
       "synonyms": [
         "распределять"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verteilen auch ohne Stolz möglich ist. — Корделия показывает, что распределять можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -22236,11 +19904,6 @@
         "доверять",
         "misstrauen — тоже «доверять»",
         "trauen — тоже «доверять»"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Vertrauen ist. — Во время бури становится понятно, насколько важно доверять.",
-        "Mein Vater vertraut mir vollkommen. — Мой отец полностью мне доверяет.",
-        "Ich vertraue beiden Söhnen gleich. — Я доверяю обоим сыновьям одинаково."
       ],
       "visual_hint": "📚"
     },
@@ -22273,12 +19936,6 @@
         "verstoßen — тоже «изгонять»",
         "прогонять"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Vertreiben alle verändert. — Шут чувствует, как умение прогонять меняет всех.",
-        "Aus meinem eigenen Haus will sie mich vertreiben! — Из моего собственного дома она хочет меня изгнать!",
-        "Ich vertreibe Edgar aus seinem Erbe. — Я изгоняю Эдгара из его наследства.",
-        "Ich vertreibe ihn aus meinem Haus. — Я изгоняю его из моего дома."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22307,9 +19964,6 @@
       "synonyms": [
         "осуждать"
       ],
-      "collocations": [
-        "Das Verurteilen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело осуждать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22337,9 +19991,6 @@
       ],
       "synonyms": [
         "превращать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verwandeln auch ohne Stolz möglich ist. — Корделия показывает, что превращать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -22371,9 +20022,6 @@
       "synonyms": [
         "отказывать"
       ],
-      "collocations": [
-        "Ich verweigere ihm jeden Komfort. — Я отказываю ему в любом комфорте."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22401,9 +20049,6 @@
       ],
       "synonyms": [
         "смущать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verwirren ist. — Во время бури становится понятно, насколько важно смущать."
       ],
       "visual_hint": "📚"
     },
@@ -22433,9 +20078,6 @@
       "synonyms": [
         "ранить",
         "verletzen — тоже «ранить»"
-      ],
-      "collocations": [
-        "Das Verwunden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело ранить."
       ],
       "visual_hint": "📚"
     },
@@ -22467,9 +20109,6 @@
       "synonyms": [
         "раненый"
       ],
-      "collocations": [
-        "Schwer verwundet sinke ich zu Boden. — Тяжело раненый я падаю на землю."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22497,9 +20136,6 @@
       ],
       "synonyms": [
         "баловать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Verwöhnen alle verändert. — Шут чувствует, как умение баловать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -22533,9 +20169,6 @@
         "fluchen — тоже «проклинать»",
         "verfluchen — тоже «проклинать»"
       ],
-      "collocations": [
-        "Ich verwünsche meine Schwester mit letzter Kraft. — Я проклинаю сестру последними силами."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22565,11 +20198,6 @@
         "прощать",
         "vergeben — тоже «прощать»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Verzeihen auch ohne Stolz möglich ist. — Корделия показывает, что прощать можно и без гордыни.",
-        "Verzeih mir, ich bin nur ein törichter alter Mann. — Прости меня, я всего лишь глупый старик.",
-        "Ich verzeihe dir alles, mein lieber Vater. — Я прощаю тебе всё, мой дорогой отец."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22597,9 +20225,6 @@
       ],
       "synonyms": [
         "отказываться"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Verzichten ist. — Во время бури становится понятно, насколько важно отказываться."
       ],
       "visual_hint": "📚"
     },
@@ -22629,9 +20254,6 @@
       "synonyms": [
         "отчаиваться"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Verzweifeln alle verändert. — Шут чувствует, как умение отчаиваться меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22660,9 +20282,6 @@
       "synonyms": [
         "совершать"
       ],
-      "collocations": [
-        "Das Vollbringen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело совершать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22690,9 +20309,6 @@
       ],
       "synonyms": [
         "готовить"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Vorbereiten auch ohne Stolz möglich ist. — Корделия показывает, что готовить можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -22725,9 +20341,6 @@
         "притворяться",
         "vortäuschen — тоже «притворяться»"
       ],
-      "collocations": [
-        "Ich gebe vor, ein einfacher Mann zu sein. — Я притворяюсь простым человеком."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22757,9 +20370,6 @@
       ],
       "synonyms": [
         "предсказывать"
-      ],
-      "collocations": [
-        "Ich sage das kommende Unheil vorher. — Я предсказываю грядущую беду."
       ],
       "visual_hint": "📚"
     },
@@ -22791,9 +20401,6 @@
       "synonyms": [
         "разыгрывать"
       ],
-      "collocations": [
-        "Ich spiele ihm Töchterliebe vor. — Я разыгрываю перед ним дочернюю любовь."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22821,9 +20428,6 @@
       ],
       "synonyms": [
         "представлять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Vorstellen ist. — Во время бури становится понятно, насколько важно представлять."
       ],
       "visual_hint": "📚"
     },
@@ -22856,9 +20460,6 @@
         "притворяться",
         "vorgeben — тоже «притворяться»"
       ],
-      "collocations": [
-        "Ich täusche Liebe vor, die nie existierte. — Я притворяюсь в любви, которой никогда не было."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22886,9 +20487,6 @@
       ],
       "synonyms": [
         "бодрствовать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Wachen alle verändert. — Шут чувствует, как умение бодрствовать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -22919,9 +20517,6 @@
         "расти",
         "aufwachsen — тоже «расти»"
       ],
-      "collocations": [
-        "Das Wachsen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело расти."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -22949,10 +20544,6 @@
       ],
       "synonyms": [
         "осмеливаться"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Wagen auch ohne Stolz möglich ist. — Корделия показывает, что осмеливаться можно и без гордыни.",
-        "Ich wage es, gegen die Töchter zu handeln. — Я осмеливаюсь действовать против дочерей."
       ],
       "visual_hint": "📚"
     },
@@ -22984,9 +20575,6 @@
       "synonyms": [
         "безумный"
       ],
-      "collocations": [
-        "Ich gebe vor, wahnsinnig zu sein. — Я притворяюсь безумным."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23015,9 +20603,6 @@
       "synonyms": [
         "воспринимать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Wahrnehmen alle verändert. — Шут чувствует, как умение воспринимать меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23045,9 +20630,6 @@
       ],
       "synonyms": [
         "странствовать"
-      ],
-      "collocations": [
-        "Das Wandern fällt Lear unerwartet schwer. — Лиру неожиданно тяжело странствовать."
       ],
       "visual_hint": "📚"
     },
@@ -23079,9 +20661,6 @@
       "synonyms": [
         "предупреждать"
       ],
-      "collocations": [
-        "Ich warne den König vor seinem Fehler. — Я предупреждаю короля об его ошибке."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23110,9 +20689,6 @@
       "synonyms": [
         "ждать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Warten auch ohne Stolz möglich ist. — Корделия показывает, что ждать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23140,9 +20716,6 @@
       ],
       "synonyms": [
         "будить"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wecken ist. — Во время бури становится понятно, насколько важно будить."
       ],
       "visual_hint": "📚"
     },
@@ -23173,9 +20746,6 @@
         "защищаться",
         "sich wehren — тоже «защищаться»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Wehren alle verändert. — Шут чувствует, как умение защищаться меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23203,10 +20773,6 @@
       ],
       "synonyms": [
         "плакать"
-      ],
-      "collocations": [
-        "Das Weinen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело плакать.",
-        "Ich weine um meinen gefallenen König. — Я плачу о моём павшем короле."
       ],
       "visual_hint": "📚"
     },
@@ -23236,9 +20802,6 @@
       "synonyms": [
         "указывать"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Weisen auch ohne Stolz möglich ist. — Корделия показывает, что указывать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23266,9 +20829,6 @@
       ],
       "synonyms": [
         "поворачивать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wenden ist. — Во время бури становится понятно, насколько важно поворачивать."
       ],
       "visual_hint": "📚"
     },
@@ -23299,10 +20859,6 @@
         "добиваться",
         "вербовать"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Werben alle verändert. — Шут чувствует, как умение вербовать меняет всех.",
-        "Ich werbe schamlos um seine Gunst. — Я бесстыдно добиваюсь его благосклонности."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23331,9 +20887,6 @@
       "synonyms": [
         "становиться"
       ],
-      "collocations": [
-        "Das Werden fällt Lear unerwartet schwer. — Лиру неожиданно тяжело становиться."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23361,9 +20914,6 @@
       ],
       "synonyms": [
         "бросать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Werfen auch ohne Stolz möglich ist. — Корделия показывает, что бросать можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -23395,9 +20945,6 @@
       "synonyms": [
         "состязаться"
       ],
-      "collocations": [
-        "Wir wetteifern um das größte Erbe. — Мы состязаемся за большее наследство."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23428,9 +20975,6 @@
       "synonyms": [
         "соревноваться"
       ],
-      "collocations": [
-        "Wir wettkämpfen um Edmunds Liebe. — Мы соревнуемся за любовь Эдмунда."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23458,9 +21002,6 @@
       ],
       "synonyms": [
         "отменять"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Widerrufen ist. — Во время бури становится понятно, насколько важно отменять."
       ],
       "visual_hint": "📚"
     },
@@ -23491,10 +21032,6 @@
         "возражать",
         "противоречить"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Widersprechen alle verändert. — Шут чувствует, как умение противоречить меняет всех.",
-        "Ich widerspreche dem König für seine eigene Ehre. — Я возражаю королю ради его же чести."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23522,9 +21059,6 @@
       ],
       "synonyms": [
         "сопротивляться"
-      ],
-      "collocations": [
-        "Das Widerstehen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело сопротивляться."
       ],
       "visual_hint": "📚"
     },
@@ -23558,9 +21092,6 @@
         "вновь",
         "wiedersehen — тоже «вновь»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Wiedererkennen auch ohne Stolz möglich ist. — Корделия показывает, что узнавать вновь можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23589,9 +21120,6 @@
       "synonyms": [
         "воспроизводить"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wiedergeben ist. — Во время бури становится понятно, насколько важно воспроизводить."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23619,9 +21147,6 @@
       ],
       "synonyms": [
         "повторять"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Wiederholen alle verändert. — Шут чувствует, как умение повторять меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -23653,9 +21178,6 @@
         "umkehren — тоже «возвращаться»",
         "zurückkehren — тоже «возвращаться»"
       ],
-      "collocations": [
-        "Das Wiederkehren fällt Lear unerwartet schwer. — Лиру неожиданно тяжело возвращаться."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23685,9 +21207,6 @@
         "встречаться",
         "вновь",
         "wiedererkennen — тоже «вновь»"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Wiedersehen auch ohne Stolz möglich ist. — Корделия показывает, что встречаться вновь можно и без гордыни."
       ],
       "visual_hint": "📚"
     },
@@ -23719,9 +21238,6 @@
       "synonyms": [
         "хныкать"
       ],
-      "collocations": [
-        "Wimmernd bitte ich um Gnade. — Хныкая, я прошу о пощаде."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23752,9 +21268,6 @@
         "der Adel — тоже «знать»",
         "kennen — тоже «знать»"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wissen ist. — Во время бури становится понятно, насколько важно знать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23784,9 +21297,6 @@
         "жить",
         "leben — тоже «жить»"
       ],
-      "collocations": [
-        "Der Narr spürt, wie das Wohnen alle verändert. — Шут чувствует, как умение жить меняет всех."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23815,9 +21325,6 @@
       "synonyms": [
         "хотеть"
       ],
-      "collocations": [
-        "Das Wollen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело хотеть."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23845,10 +21352,6 @@
       ],
       "synonyms": [
         "выбирать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wählen ist. — Во время бури становится понятно, насколько важно выбирать.",
-        "Ich wähle den schweren Weg der Tugend. — Я выбираю трудный путь добродетели."
       ],
       "visual_hint": "📚"
     },
@@ -23880,9 +21383,6 @@
         "begehren — тоже «желать»",
         "verlangen — тоже «желать»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Wünschen auch ohne Stolz möglich ist. — Корделия показывает, что желать можно и без гордыни."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23910,9 +21410,6 @@
       ],
       "synonyms": [
         "свирепствовать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Wüten ist. — Во время бури становится понятно, насколько важно свирепствовать."
       ],
       "visual_hint": "📚"
     },
@@ -23942,9 +21439,6 @@
       "synonyms": [
         "показывать"
       ],
-      "collocations": [
-        "Das Zeigen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело показывать."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -23972,10 +21466,6 @@
       ],
       "synonyms": [
         "разрушать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Zerstören auch ohne Stolz möglich ist. — Корделия показывает, что разрушать можно и без гордыни.",
-        "Ich zerstöre alles, was uns verband. — Я разрушаю всё, что нас связывало."
       ],
       "visual_hint": "📚"
     },
@@ -24007,9 +21497,6 @@
       "synonyms": [
         "растаптывать"
       ],
-      "collocations": [
-        "Ich zertrete seine Augen unter meinem Fuß. — Я растаптываю его глаза под ногой."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24038,9 +21525,6 @@
       "synonyms": [
         "тянуть"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Ziehen ist. — Во время бури становится понятно, насколько важно тянуть."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24068,11 +21552,6 @@
       ],
       "synonyms": [
         "дрожать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Zittern alle verändert. — Шут чувствует, как умение дрожать меняет всех.",
-        "Vor Kälte und Angst zittere ich ständig. — От холода и страха я постоянно дрожу.",
-        "Vor Kälte zittern wir wie Espenlaub. — От холода мы дрожим как осиновый лист."
       ],
       "visual_hint": "📚"
     },
@@ -24104,11 +21583,6 @@
         "umkehren — тоже «возвращаться»",
         "wiederkehren — тоже «возвращаться»"
       ],
-      "collocations": [
-        "Cordelia zeigt, dass das Zurückkehren auch ohne Stolz möglich ist. — Корделия показывает, что возвращаться можно и без гордыни.",
-        "Mit einer Armee kehre ich zurück, meinen Vater zu retten. — С армией я возвращаюсь спасти моего отца.",
-        "Ich schwöre, verkleidet zurückzukehren. — Я клянусь вернуться переодетым."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24137,9 +21611,6 @@
       "synonyms": [
         "рушиться"
       ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Zusammenbrechen ist. — Во время бури становится понятно, насколько важно рушиться."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24167,9 +21638,6 @@
       ],
       "synonyms": [
         "сомневаться"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Zweifeln alle verändert. — Шут чувствует, как умение сомневаться меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -24200,10 +21668,6 @@
         "заставлять",
         "принуждать"
       ],
-      "collocations": [
-        "Das Zwingen fällt Lear unerwartet schwer. — Лиру неожиданно тяжело заставлять.",
-        "Ich zwinge alle zu absolutem Gehorsam. — Я принуждаю всех к абсолютному послушанию."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24231,9 +21695,6 @@
       ],
       "synonyms": [
         "считать"
-      ],
-      "collocations": [
-        "Der Narr spürt, wie das Zählen alle verändert. — Шут чувствует, как умение считать меняет всех."
       ],
       "visual_hint": "📚"
     },
@@ -24263,10 +21724,6 @@
       "synonyms": [
         "колебаться",
         "медлить"
-      ],
-      "collocations": [
-        "Das Zögern fällt Lear unerwartet schwer. — Лиру неожиданно тяжело медлить.",
-        "Ich zögere, wenn ich handeln sollte. — Я колеблюсь, когда должен действовать."
       ],
       "visual_hint": "📚"
     },
@@ -24300,9 +21757,6 @@
         "bestrafen — тоже «наказывать»",
         "strafen — тоже «наказывать»"
       ],
-      "collocations": [
-        "Öffentlich züchtige ich die Widerspenstigen. — Публично я наказываю непокорных."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24333,9 +21787,6 @@
       "synonyms": [
         "передавать"
       ],
-      "collocations": [
-        "Ich überbringe Befehle an alle Diener. — Я передаю приказы всем слугам."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24363,10 +21814,6 @@
       ],
       "synonyms": [
         "выживать"
-      ],
-      "collocations": [
-        "Cordelia zeigt, dass das Überleben auch ohne Stolz möglich ist. — Корделия показывает, что выживать можно и без гордыни.",
-        "Ich habe alle Prüfungen überlebt. — Я пережил все испытания."
       ],
       "visual_hint": "📚"
     },
@@ -24398,9 +21845,6 @@
       "synonyms": [
         "превосходить"
       ],
-      "collocations": [
-        "Ich will meine Schwester in der Lüge übertreffen. — Я хочу превзойти сестру во лжи."
-      ],
       "visual_hint": "📚"
     },
     {
@@ -24428,9 +21872,6 @@
       ],
       "synonyms": [
         "преодолевать"
-      ],
-      "collocations": [
-        "Im Sturm zeigt sich, wie wichtig das Überwinden ist. — Во время бури становится понятно, насколько важно преодолевать."
       ],
       "visual_hint": "📚"
     }

--- a/generators/html/vocabulary_processor.py
+++ b/generators/html/vocabulary_processor.py
@@ -53,7 +53,7 @@ class VocabularyProcessor:
 
     @staticmethod
     def _apply_defaults(word: Dict[str, Any], entry: Dict[str, Any]) -> None:
-        for key, source_key in (("wordFamily", "word_family"), ("synonyms", "synonyms"), ("collocations", "collocations")):
+        for key, source_key in (("wordFamily", "word_family"), ("synonyms", "synonyms")):
             if not word.get(key) and (values := _ensure_list(entry.get(source_key))):
                 word[key] = values
         if not word.get("visual_hint") and entry.get("visual_hint"):
@@ -67,12 +67,10 @@ class VocabularyProcessor:
             words = phase.get("vocabulary", [])
             has_family = any(_ensure_list(item.get("wordFamily")) for item in words)
             has_synonyms = any(_ensure_list(item.get("synonyms")) for item in words)
-            has_collocations = any(_ensure_list(item.get("collocations")) for item in words)
             metadata[phase.get("id", f"phase-{index}")] = {
                 "has_word_families": has_family,
                 "has_synonyms": has_synonyms,
-                "has_collocations": has_collocations,
-                "has_relations": has_family or has_synonyms or has_collocations,
+                "has_relations": has_family or has_synonyms,
             }
         return metadata
 

--- a/generators/js/serializer.py
+++ b/generators/js/serializer.py
@@ -73,7 +73,6 @@ class PhaseSerializer:
     def _serialize_word(word: Dict[str, Any]) -> Dict[str, Any]:
         themes = _ensure_list(word.get("themes"))
         word_family = _ensure_list(word.get("wordFamily"))
-        collocations = _ensure_list(word.get("collocations"))
         sentence_parts = _ensure_list(word.get("sentence_parts"))
         return {
             "word": word.get("german", ""),
@@ -85,7 +84,6 @@ class PhaseSerializer:
             "visual_hint": word.get("visual_hint", ""),
             "themes": themes,
             "wordFamily": word_family,
-            "collocations": collocations,
             "sentenceParts": sentence_parts,
         }
 

--- a/scripts/analyze_runtime.py
+++ b/scripts/analyze_runtime.py
@@ -21,8 +21,7 @@ checks = [
     ('currentPhaseIndex', 'Индекс текущей фазы'),
     ('phaseKeys', 'Массив ключей фаз'),
     ('relations-container', 'Контейнер для упражнений'),
-    ('word-families-section', 'Секция семьи слов'),
-    ('collocations-section', 'Секция коллокаций')
+    ('word-families-section', 'Секция семьи слов')
 ]
 
 for check, desc in checks:

--- a/scripts/test_exercises.py
+++ b/scripts/test_exercises.py
@@ -57,8 +57,7 @@ def test_exercises_integration():
     # 3. Проверка секций в HTML
     print("\n[3/5] Проверка секций упражнений...")
     sections = [
-        ('word-families-section', 'Секция артиклей (бывшая Семья слов)'),
-        ('collocations-section', 'Секция контекстного перевода (бывшие Коллокации)')
+        ('word-families-section', 'Секция артиклей (бывшая Семья слов)')
     ]
     
     for section, desc in sections:

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -1142,8 +1142,7 @@ body {
 }
 
 .relation-group,
-.synonym-group,
-.collocation-group {
+.synonym-group {
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -1151,14 +1150,12 @@ body {
 }
 
 .relation-group:last-child,
-.synonym-group:last-child,
-.collocation-group:last-child {
+.synonym-group:last-child {
     margin-bottom: 0;
 }
 
 .relation-header,
-.synonym-word,
-.collocation-word {
+.synonym-word {
     font-weight: 700;
     color: #4338ca;
     font-size: 1.05em;
@@ -1331,117 +1328,13 @@ body {
     color: #dc2626;
 }
 
-.memory-game-container {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-
-.memory-card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 14px;
-}
-
-.memory-card {
-    position: relative;
-    border: 2px solid #c7d2fe;
-    border-radius: 16px;
-    background: linear-gradient(135deg, rgba(224, 231, 255, 0.85), rgba(199, 210, 254, 0.95));
-    color: #312e81;
-    font-weight: 600;
-    min-height: 110px;
-    padding: 14px 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
-    cursor: pointer;
-    overflow: hidden;
-}
-
-.memory-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 12px 26px rgba(129, 140, 248, 0.3);
-}
-
-.memory-card-placeholder {
-    font-size: 1.6em;
-    font-weight: 700;
-    opacity: 0.75;
-    transition: opacity 0.3s ease, transform 0.3s ease;
-}
-
-.memory-card-content {
-    position: absolute;
-    left: 12px;
-    right: 12px;
-    opacity: 0;
-    transform: translateY(12px);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    line-height: 1.3;
-}
-
-.memory-card.flipped {
-    background: #ffffff;
-    box-shadow: 0 14px 30px rgba(129, 140, 248, 0.32);
-}
-
-.memory-card.flipped .memory-card-placeholder {
-    opacity: 0;
-    transform: scale(0.85);
-}
-
-.memory-card.flipped .memory-card-content {
-    opacity: 1;
-    transform: translateY(0);
-}
-
-.memory-card.correct {
-    background: linear-gradient(135deg, #34d399, #10b981);
-    border-color: #10b981;
-    color: #ffffff;
-}
-
-.memory-card.incorrect {
-    border-color: #f87171;
-    background: rgba(248, 113, 113, 0.18);
-    color: #b91c1c;
-}
-
-.memory-card.matched,
-.memory-card[disabled] {
-    cursor: default;
-    pointer-events: none;
-}
-
-.memory-status {
-    text-align: center;
-    font-size: 0.95em;
-    font-weight: 500;
-    color: #4b5563;
-    min-height: 24px;
-    transition: color 0.3s ease;
-}
-
-.memory-status.success {
-    color: #059669;
-}
-
-.memory-status.error {
-    color: #dc2626;
-}
-
-.synonym-list,
-.collocation-list {
+.synonym-list {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
 }
 
-.synonym-item,
-.collocation-item {
+.synonym-item {
     padding: 6px 14px;
     border-radius: 999px;
     background: rgba(102, 126, 234, 0.15);

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -79,7 +79,7 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и устойчивые выражения текущей фазы.</p>
+            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">
@@ -93,23 +93,6 @@
                             {% for phase in journey_phases %}
                             <section class="exercise-phase{% if loop.first %} active{% endif %}" data-phase="{{ phase.id }}">
                                 <div class="matching-container" data-matching-container data-phase="{{ phase.id }}"></div>
-                            </section>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </div>
-
-                <div class="exercise-panel" data-exercise="collocations">
-                    <button class="exercise-toggle" type="button">
-                        <span class="toggle-icon">▶</span>
-                        🧩 Коллокации
-                    </button>
-                    <div class="exercise-content collapsed">
-                        <p class="exercise-description">Найдите устойчивые выражения с ключевыми словами фазы, открывая совпадающие пары.</p>
-                        <div class="exercise-phase-wrapper" data-phase-wrapper="collocations">
-                            {% for phase in journey_phases %}
-                            <section class="exercise-phase{% if loop.first %} active{% endif %}" data-phase="{{ phase.id }}">
-                                <div class="collocations-container" data-collocations-container data-phase="{{ phase.id }}"></div>
                             </section>
                             {% endfor %}
                         </div>


### PR DESCRIPTION
## Summary
- remove the collocations exercise from the journey template so only the remaining five activities render
- drop collocation-specific runtime logic and styles, including the memory game implementation
- strip collocation metadata from shared vocabulary data and related generators

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ceed97d2f08320a55f107740d5457f