### PR TITLE
Add russian hints to vocabulary cards

### DIFF
--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -4140,6 +4140,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4426,6 +4427,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5074,17 +5076,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -4696,6 +4696,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4982,6 +4983,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5630,17 +5632,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -4178,6 +4178,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4464,6 +4465,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5112,17 +5114,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -4300,6 +4300,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4586,6 +4587,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5234,17 +5236,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -4371,6 +4371,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4657,6 +4658,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5305,17 +5307,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -4183,6 +4183,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4469,6 +4470,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5117,17 +5119,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -4176,6 +4176,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4462,6 +4463,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5110,17 +5112,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -4600,6 +4600,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4886,6 +4887,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5534,17 +5536,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -4199,6 +4199,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4485,6 +4486,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5133,17 +5135,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -4758,6 +4758,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -5044,6 +5045,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5692,17 +5694,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -4187,6 +4187,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4473,6 +4474,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5121,17 +5123,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -4269,6 +4269,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -4555,6 +4556,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -5203,17 +5205,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/output/static/css/journey.css
+++ b/output/static/css/journey.css
@@ -30,6 +30,15 @@
     margin-bottom: 5px;
 }
 
+.word-hint {
+    font-size: 14px;
+    color: #7f8c8d;
+    font-style: italic;
+    margin-bottom: 8px;
+    padding: 0 10px;
+    line-height: 1.3;
+}
+
 .word-transcription {
     font-size: 14px;
     color: #9ca3af;

--- a/output/static/js/journey_runtime.js
+++ b/output/static/js/journey_runtime.js
@@ -72,6 +72,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -358,6 +359,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -1006,17 +1008,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"

--- a/static/css/journey.css
+++ b/static/css/journey.css
@@ -30,6 +30,15 @@
     margin-bottom: 5px;
 }
 
+.word-hint {
+    font-size: 14px;
+    color: #7f8c8d;
+    font-style: italic;
+    margin-bottom: 8px;
+    padding: 0 10px;
+    line-height: 1.3;
+}
+
 .word-transcription {
     font-size: 14px;
     color: #9ca3af;

--- a/static/js/journey_runtime.js
+++ b/static/js/journey_runtime.js
@@ -72,6 +72,7 @@ function sanitizeStudyEntry(entry) {
 
     sanitized.word = typeof sanitized.word === 'string' ? sanitized.word : '';
     sanitized.translation = typeof sanitized.translation === 'string' ? sanitized.translation : '';
+    sanitized.russian_hint = typeof sanitized.russian_hint === 'string' ? sanitized.russian_hint : '';
     sanitized.transcription = typeof sanitized.transcription === 'string' ? sanitized.transcription : '';
     sanitized.characterId = typeof sanitized.characterId === 'string' && sanitized.characterId
         ? sanitized.characterId
@@ -358,6 +359,7 @@ function buildStudyPayloadFromButton(button, item) {
     const payload = {
         word: dataset.word || (item && item.word) || '',
         translation: dataset.translation || (item && item.translation) || '',
+        russian_hint: dataset.russianHint || (item && item.russian_hint) || '',
         transcription: dataset.transcription || (item && item.transcription) || '',
         characterId: dataset.characterId || (typeof characterId === 'string' ? characterId : ''),
         phaseKey: dataset.phaseKey || '',
@@ -1006,17 +1008,23 @@ function displayVocabulary(phaseKey) {
             card.className = 'word-card';
             card.style.animationDelay = `${index * 0.1}s`;
 
+            const hintMarkup = item.russian_hint
+                ? `<div class="word-hint">(${item.russian_hint})</div>`
+                : '';
+
             // Простая карточка словаря
             card.innerHTML = `
                 <div class="word-meta">
                     <div class="word-german">${item.word}</div>
                     <div class="word-translation">${item.translation}</div>
+                    ${hintMarkup}
                     <div class="word-transcription">${item.transcription}</div>
                 </div>
                 <button class="btn-study" type="button"
                     data-word="${item.word || ''}"
                     data-translation="${item.translation || ''}"
                     data-transcription="${item.transcription || ''}"
+                    data-russian-hint="${item.russian_hint || ''}"
                     data-sentence="${item.sentence || ''}"
                     data-sentence-translation="${item.sentenceTranslation || ''}"
                     data-character-id="${characterId || ''}"


### PR DESCRIPTION
## Summary
- show optional russian hints on vocabulary cards and pass the value through study queue data
- style the hint row for readability
- update pre-rendered journey pages and static bundles with the new hint markup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2f14c4088320b60aedfd46265e53