### PR TITLE
Remove exercises description paragraph

### DIFF
--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -163,7 +163,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -79,7 +79,6 @@
 
         <div class="exercises-section">
             <h2>📝 Упражнения</h2>
-            <p>Расширяйте лексику: найдите семьи слов, синонимы и применяйте лексику текущей фазы.</p>
 
             <div class="exercises-accordion">
                 <div class="exercise-panel" data-exercise="matching">


### PR DESCRIPTION
## Summary
- remove the vocabulary expansion description paragraph from the Lira journey template
- drop the same paragraph from all prebuilt journey HTML files so exercises follow the header directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf30684abc8320bb391c3ceedd817b