### PR TITLE
Ensure journey data exposed via expected global

### DIFF
--- a/generators/js/serializer.py
+++ b/generators/js/serializer.py
@@ -32,6 +32,7 @@ class PhaseSerializer:
             "const REVIEW_QUEUE_KEY = `${STORAGE_PREFIX}:reviewQueue`;\n",
             "const quizStateCache = {};\n\n",
             "window.phaseData = phaseVocabularies;\n",
+            "window.phaseVocabularies = phaseVocabularies;\n",
             "window.phaseKeys = Object.keys(phaseVocabularies);\n\n",
         ]
         return "".join(parts)


### PR DESCRIPTION
## Summary
- expose generated journey payload on both `window.phaseData` and `window.phaseVocabularies` so the front-end loader can access it

## Testing
- python main.py
- python -m compileall generators/js/serializer.py

------
https://chatgpt.com/codex/tasks/task_e_68cf4390cf948320bc819edc16e70118