### PR TITLE
Ensure journey data exports required globals

### DIFF
--- a/generators/js/serializer.py
+++ b/generators/js/serializer.py
@@ -33,7 +33,11 @@ class PhaseSerializer:
             "const quizStateCache = {};\n\n",
             "window.phaseData = phaseVocabularies;\n",
             "window.phaseVocabularies = phaseVocabularies;\n",
-            "window.phaseKeys = Object.keys(phaseVocabularies);\n\n",
+            "window.phaseKeys = Object.keys(phaseVocabularies);\n",
+            "window.characterId = characterId;\n",
+            "window.STORAGE_PREFIX = STORAGE_PREFIX;\n",
+            "window.REVIEW_QUEUE_KEY = REVIEW_QUEUE_KEY;\n",
+            "window.quizStateCache = quizStateCache;\n\n",
         ]
         return "".join(parts)
 


### PR DESCRIPTION
## Summary
- expose the generated journey character identifier and storage keys on the window object
- provide quiz state cache on the window so journey scripts can access it

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cf44f1eec08320add748c6a003b6a9