### PR TITLE
Fix context exercise regex escaping

### DIFF
--- a/static/js/modules/exercises/context.js
+++ b/static/js/modules/exercises/context.js
@@ -32,7 +32,7 @@ export class ContextExercise {
                 return;
             }
             const germanWord = word.german.replace(/^(der|die|das)\s+/i, '');
-            const pattern = new RegExp(`\\b${germanWord.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\w*\\b`, 'gi');
+            const pattern = new RegExp(`\\b${germanWord.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\w*\\b`, 'gi');
             if (!word.sentence.match(pattern)) {
                 return;
             }


### PR DESCRIPTION
## Summary
- fix the regex escape pattern for German word replacements in the context exercise builder

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68cf4b268344832081de850af996b08f