### PR TITLE
Add synonym and antonym exercises

### DIFF
--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -137,6 +137,45 @@
           "synonyms": ["преданность", "надёжность", "постоянство"]
         }
       ],
+      "synonym_antonym_sets": [
+        {
+          "id": "truth_vs_lie",
+          "title": "Правда против лжи",
+          "target": {
+            "word": "die Wahrheit",
+            "translation": "правда",
+            "hint": "главная ценность Корделии"
+          },
+          "synonyms": [
+            { "word": "die Ehrlichkeit", "translation": "честность" },
+            { "word": "die Aufrichtigkeit", "translation": "искренность" }
+          ],
+          "antonyms": [
+            { "word": "die Lüge", "translation": "ложь" },
+            { "word": "die Heuchelei", "translation": "лицемерие" },
+            { "word": "der Betrug", "translation": "обман" }
+          ],
+          "narration": "Корделия выбирает правду, даже если это стоит ей наследства."
+        },
+        {
+          "id": "love_spectrum",
+          "title": "Оттенки любви",
+          "target": {
+            "word": "die Liebe",
+            "translation": "любовь",
+            "hint": "чувство дочери к отцу"
+          },
+          "synonyms": [
+            { "word": "die Treue", "translation": "верность" },
+            { "word": "die Pflicht", "translation": "долг" }
+          ],
+          "antonyms": [
+            { "word": "der Hass", "translation": "ненависть" },
+            { "word": "die Gleichgültigkeit", "translation": "равнодушие" }
+          ],
+          "narration": "Её любовь честна, без преувеличений."
+        }
+      ],
       "quizzes": [
         {
           "question": "Что означает немецкое слово «die Wahrheit»?",

--- a/data/characters/edmund.json
+++ b/data/characters/edmund.json
@@ -105,6 +105,27 @@
           ]
         }
       ],
+      "synonym_antonym_sets": [
+        {
+          "id": "ambition_humility",
+          "title": "Амбиции против смирения",
+          "target": {
+            "word": "die Ambition",
+            "translation": "амбиция",
+            "hint": "движущая сила Эдмунда"
+          },
+          "synonyms": [
+            { "word": "der Ehrgeiz", "translation": "честолюбие" },
+            { "word": "das Streben", "translation": "стремление" },
+            { "word": "der Neid", "translation": "зависть" }
+          ],
+          "antonyms": [
+            { "word": "die Bescheidenheit", "translation": "скромность" },
+            { "word": "die Demut", "translation": "смирение" }
+          ],
+          "narration": "Бастард не знает смирения - только безграничные амбиции."
+        }
+      ],
       "quizzes": [
         {
           "question": "Что означает немецкое слово «der Bastard»?",

--- a/data/characters/fool.json
+++ b/data/characters/fool.json
@@ -100,6 +100,27 @@
           ]
         }
       ],
+      "synonym_antonym_sets": [
+        {
+          "id": "wisdom_folly",
+          "title": "Мудрость и глупость",
+          "target": {
+            "word": "die Weisheit",
+            "translation": "мудрость",
+            "hint": "скрытая за маской шута"
+          },
+          "synonyms": [
+            { "word": "die Klugheit", "translation": "ум" },
+            { "word": "der Verstand", "translation": "разум" }
+          ],
+          "antonyms": [
+            { "word": "die Dummheit", "translation": "глупость" },
+            { "word": "die Torheit", "translation": "безумие" },
+            { "word": "der Wahnsinn", "translation": "сумасшествие" }
+          ],
+          "narration": "Шут - единственный, кто говорит мудрые вещи под маской глупости."
+        }
+      ],
       "theatrical_scene": {
         "title": "МАСКА СМЕХА",
         "narrative": "Я - <b>DER NARR (шут)</b>, но я самый <b>KLUG (умный)</b> человек в этом дворце дураков! <b>DIE WEISHEIT (мудрость)</b> прячется за моими колокольчиками. Я <b>SCHERZEN (шучу)</b>, но <b>DIE TRAUER (печаль)</b> о Корделии разрывает моё сердце! Я <b>VERMISSEN (скучаю)</b> по ней каждый день! <b>DER SPAß (забава)</b> - моя маска, <b>DER WITZ (остроумие)</b> - мой щит. Король отдал королевство лживым дочерям, а истинную любовь изгнал! О, какая глупость! И только я, шут, вижу правду! Но кто слушает шута? Все смеются над моими песнями, не слыша горечи в словах.",

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -169,6 +169,27 @@
           ]
         }
       ],
+      "synonym_antonym_sets": [
+        {
+          "id": "deception_tools",
+          "title": "Инструменты обмана",
+          "target": {
+            "word": "die Lüge",
+            "translation": "ложь",
+            "hint": "оружие Гонерильи"
+          },
+          "synonyms": [
+            { "word": "die Heuchelei", "translation": "лицемерие" },
+            { "word": "der Betrug", "translation": "обман" },
+            { "word": "die Täuschung", "translation": "заблуждение" }
+          ],
+          "antonyms": [
+            { "word": "die Wahrheit", "translation": "правда" },
+            { "word": "die Ehrlichkeit", "translation": "честность" }
+          ],
+          "narration": "Гонерилья мастерски использует ложь для достижения целей."
+        }
+      ],
       "quizzes": [
         {
           "question": "Что означает немецкое слово «die Lüge»?",

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -137,6 +137,27 @@
           "synonyms": ["роскошный", "пышный", "величественный"]
         }
       ],
+      "synonym_antonym_sets": [
+        {
+          "id": "power_dynamics",
+          "title": "Власть и бессилие",
+          "target": {
+            "word": "die Macht",
+            "translation": "власть",
+            "hint": "то, что Лир теряет"
+          },
+          "synonyms": [
+            { "word": "die Herrschaft", "translation": "господство" },
+            { "word": "die Gewalt", "translation": "сила" },
+            { "word": "die Stärke", "translation": "мощь" }
+          ],
+          "antonyms": [
+            { "word": "die Schwäche", "translation": "слабость" },
+            { "word": "die Ohnmacht", "translation": "бессилие" }
+          ],
+          "narration": "От абсолютной власти к полному бессилию."
+        }
+      ],
       "quizzes": [
         {
           "question": "Что означает немецкое слово «der Thron»?",

--- a/generators/js/serializer.py
+++ b/generators/js/serializer.py
@@ -47,6 +47,10 @@ class PhaseSerializer:
                 "title": phase.get("title", ""),
                 "description": phase.get("description", ""),
                 "vocabulary": vocabulary_entries,
+                "synonymAntonymSets": [
+                    self._serialize_semantic_set(item)
+                    for item in phase.get("synonym_antonym_sets", [])
+                ],
                 "words": [self._serialize_word(word) for word in phase.get("vocabulary", [])],
                 "quizzes": [self._serialize_quiz(quiz) for quiz in phase.get("quizzes", [])],
                 "quizAttempts": {},
@@ -99,6 +103,37 @@ class PhaseSerializer:
             "question": quiz.get("question", ""),
             "choices": choices,
             "correctIndex": correct_index,
+        }
+
+    @staticmethod
+    def _serialize_semantic_set(item: Dict[str, Any]) -> Dict[str, Any]:
+        """Сериализует набор синонимов/антонимов"""
+        if not isinstance(item, dict):
+            return {}
+
+        return {
+            "id": item.get("id", ""),
+            "title": item.get("title", ""),
+            "target": {
+                "word": item.get("target", {}).get("word", ""),
+                "translation": item.get("target", {}).get("translation", ""),
+                "hint": item.get("target", {}).get("hint", ""),
+            },
+            "synonyms": [
+                {
+                    "word": entry.get("word", ""),
+                    "translation": entry.get("translation", ""),
+                }
+                for entry in item.get("synonyms", [])
+            ],
+            "antonyms": [
+                {
+                    "word": entry.get("word", ""),
+                    "translation": entry.get("translation", ""),
+                }
+                for entry in item.get("antonyms", [])
+            ],
+            "narration": item.get("narration", ""),
         }
 
     @staticmethod

--- a/static/css/exercises.css
+++ b/static/css/exercises.css
@@ -342,3 +342,453 @@
     padding: 30px;
     font-style: italic;
 }
+/* ========== СИНОНИМЫ И АНТОНИМЫ ========== */
+
+.synonym-exercise {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    padding: 8px;
+}
+
+.synonym-set {
+    background: linear-gradient(135deg, #f8f5ff 0%, #ede8ff 100%);
+    border: 2px solid #d6ccff;
+    border-radius: 16px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    box-shadow: 0 4px 12px rgba(124, 58, 237, 0.08);
+    transition: transform 0.3s ease;
+}
+
+.synonym-set:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(124, 58, 237, 0.12);
+}
+
+/* Header Section */
+.synonym-header {
+    text-align: center;
+    padding-bottom: 16px;
+    border-bottom: 2px dashed #d6ccff;
+}
+
+.synonym-header h4 {
+    margin: 0 0 12px;
+    font-size: 1.3rem;
+    color: #4a357a;
+    font-weight: 700;
+}
+
+.synonym-target {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    margin: 12px 0;
+}
+
+.target-label {
+    color: #8b7aa8;
+    font-size: 0.9rem;
+}
+
+.target-word {
+    font-weight: 800;
+    font-size: 1.4rem;
+    color: #7c3aed;
+    text-shadow: 1px 1px 2px rgba(124, 58, 237, 0.1);
+}
+
+.target-translation {
+    color: #6b5b8a;
+    font-size: 1.1rem;
+}
+
+.target-hint {
+    background: linear-gradient(135deg, #7c3aed15, #9333ea15);
+    color: #7c3aed;
+    border-radius: 20px;
+    padding: 4px 12px;
+    font-size: 0.85rem;
+    cursor: help;
+    transition: all 0.3s ease;
+}
+
+.target-hint:hover {
+    background: linear-gradient(135deg, #7c3aed25, #9333ea25);
+    transform: scale(1.05);
+}
+
+.synonym-narration {
+    color: #6b5b8a;
+    font-style: italic;
+    margin: 8px 0 0;
+    padding: 12px;
+    background: rgba(255, 255, 255, 0.5);
+    border-radius: 8px;
+}
+
+/* Game Board */
+.synonym-board {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    margin: 20px 0;
+}
+
+.synonym-column {
+    background: white;
+    border-radius: 12px;
+    border: 3px dashed #c9b7f6;
+    padding: 20px;
+    min-height: 180px;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.synonym-column.drag-over {
+    background: linear-gradient(135deg, #7c3aed08, #9333ea08);
+    border-color: #7c3aed;
+    transform: scale(1.02);
+}
+
+.synonym-column h5 {
+    margin: 0 0 8px;
+    text-align: center;
+    color: #543d8f;
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+.column-hint {
+    text-align: center;
+    color: #9b8db5;
+    font-size: 0.85rem;
+    margin: 0 0 12px;
+}
+
+.synonym-dropzone {
+    min-height: 120px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px;
+    border-radius: 8px;
+    transition: background 0.3s ease;
+}
+
+.synonym-dropzone.hint-highlight {
+    animation: pulseHighlight 1s ease 3;
+    background: rgba(124, 58, 237, 0.1);
+}
+
+/* Cards Pool */
+.synonym-cards-pool {
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 12px;
+    padding: 20px;
+    border: 2px solid #e9e3ff;
+}
+
+.pool-label {
+    text-align: center;
+    color: #6b5b8a;
+    margin: 0 0 16px;
+    font-weight: 600;
+}
+
+.synonym-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: center;
+    min-height: 60px;
+}
+
+/* Card Styles */
+.synonym-card {
+    background: white;
+    border: 2px solid #7c3aed;
+    border-radius: 10px;
+    padding: 12px 16px;
+    cursor: grab;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 3px 8px rgba(124, 58, 237, 0.15);
+    transition: all 0.3s ease;
+    position: relative;
+    min-width: 140px;
+}
+
+.synonym-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 16px rgba(124, 58, 237, 0.25);
+}
+
+.synonym-card.dragging {
+    opacity: 0.6;
+    cursor: grabbing;
+    transform: rotate(5deg);
+}
+
+.synonym-card.selected {
+    border-color: #fbbf24;
+    background: #fef3c7;
+    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.3);
+}
+
+.synonym-card.placed {
+    cursor: pointer;
+}
+
+.synonym-card.correct {
+    border-color: #10b981;
+    background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+    animation: pulseSuccess 0.5s ease;
+}
+
+.synonym-card.incorrect {
+    border-color: #ef4444;
+    background: linear-gradient(135deg, #fef2f2, #fee2e2);
+    animation: shakeError 0.5s ease;
+}
+
+.synonym-card.hint-card {
+    animation: pulseHint 1s ease infinite;
+}
+
+.card-word {
+    font-weight: 700;
+    font-size: 1rem;
+    color: #4a357a;
+}
+
+.card-translation {
+    font-size: 0.85rem;
+    color: #8b7aa8;
+}
+
+/* Controls */
+.synonym-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    padding-top: 20px;
+    border-top: 2px dashed #e9e3ff;
+}
+
+.synonym-controls button {
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    border: 2px solid transparent;
+}
+
+.btn-check {
+    background: linear-gradient(135deg, #7c3aed, #9333ea);
+    color: white;
+}
+
+.btn-check:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(124, 58, 237, 0.3);
+}
+
+.btn-reset {
+    background: white;
+    color: #7c3aed;
+    border-color: #7c3aed;
+}
+
+.btn-reset:hover {
+    background: #f8f5ff;
+}
+
+.btn-hint {
+    background: linear-gradient(135deg, #fbbf24, #f59e0b);
+    color: white;
+}
+
+.btn-hint:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(251, 191, 36, 0.3);
+}
+
+/* Feedback */
+.synonym-feedback {
+    width: 100%;
+    padding: 12px;
+    border-radius: 8px;
+    font-weight: 600;
+    text-align: center;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.feedback-success {
+    background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+    color: #047857;
+    border: 1px solid #10b981;
+}
+
+.feedback-error {
+    background: linear-gradient(135deg, #fef2f2, #fee2e2);
+    color: #b91c1c;
+    border: 1px solid #ef4444;
+}
+
+/* Progress */
+.synonym-progress {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: white;
+    border-radius: 20px;
+    border: 2px solid #e9e3ff;
+}
+
+.progress-text {
+    color: #6b5b8a;
+    font-size: 0.9rem;
+}
+
+.progress-value {
+    font-weight: 700;
+    color: #7c3aed;
+    padding: 2px 8px;
+    border-radius: 12px;
+}
+
+/* Animations */
+@keyframes pulseSuccess {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+
+@keyframes shakeError {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(-5px); }
+    75% { transform: translateX(5px); }
+}
+
+@keyframes pulseHighlight {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0); }
+    50% { box-shadow: 0 0 20px 5px rgba(124, 58, 237, 0.3); }
+}
+
+@keyframes pulseHint {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.08); }
+}
+
+@keyframes fadeInUp {
+    from { 
+        opacity: 0; 
+        transform: translateY(10px); 
+    }
+    to { 
+        opacity: 1; 
+        transform: translateY(0); 
+    }
+}
+
+/* Success Celebration */
+.success-celebration {
+    position: relative;
+}
+
+.success-celebration::after {
+    content: '🎉';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 4rem;
+    animation: celebrateZoom 1s ease;
+}
+
+@keyframes celebrateZoom {
+    0% { 
+        transform: translate(-50%, -50%) scale(0) rotate(0deg); 
+        opacity: 0;
+    }
+    50% { 
+        transform: translate(-50%, -50%) scale(1.5) rotate(180deg); 
+        opacity: 1;
+    }
+    100% { 
+        transform: translate(-50%, -50%) scale(1) rotate(360deg); 
+        opacity: 0;
+    }
+}
+
+/* Empty State */
+.exercise-empty-state {
+    text-align: center;
+    padding: 40px;
+    color: #8b7aa8;
+}
+
+.exercise-empty-state p {
+    margin: 8px 0;
+}
+
+.empty-state-hint {
+    font-size: 0.9rem;
+    color: #a89cc0;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .synonym-board {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
+    
+    .synonym-column {
+        min-height: 140px;
+    }
+    
+    .synonym-card {
+        min-width: 120px;
+        padding: 10px 14px;
+    }
+    
+    .target-word {
+        font-size: 1.2rem;
+    }
+    
+    .synonym-controls {
+        flex-direction: column;
+        width: 100%;
+    }
+    
+    .synonym-controls button {
+        width: 100%;
+    }
+}
+
+/* Touch Device Optimizations */
+@media (hover: none) and (pointer: coarse) {
+    .synonym-card {
+        padding: 14px 18px;
+        min-width: 150px;
+    }
+    
+    .synonym-dropzone {
+        min-height: 140px;
+    }
+}
+

--- a/static/js/exercises.js
+++ b/static/js/exercises.js
@@ -28,6 +28,13 @@
             initializeArticlesExercise(articlesContainer, phaseVocabulary);
         }
 
+        const synonymsContainer = document.querySelector(
+            `[data-synonyms-container][data-phase="${phaseId}"]`
+        );
+        if (synonymsContainer) {
+            initializeSynonymAntonymExercise(synonymsContainer, phaseVocabulary);
+        }
+
         const contextContainer = document.querySelector(`[data-context-container][data-phase="${phaseId}"]`);
         if (contextContainer) {
             initializeContextTranslation(contextContainer, phaseVocabulary);
@@ -439,7 +446,7 @@
     
     function attachContextHandlers(container) {
         const cards = container.querySelectorAll('.context-exercise-card');
-        
+
         cards.forEach(card => {
             const options = card.querySelectorAll('.context-option');
             const feedback = card.querySelector('.context-feedback');
@@ -488,11 +495,474 @@
             });
         });
     }
-    
+
+    function initializeSynonymAntonymExercise(container, phaseVocabulary) {
+        if (!(container instanceof HTMLElement)) return;
+
+        const sets = Array.isArray(phaseVocabulary.synonymAntonymSets)
+            ? phaseVocabulary.synonymAntonymSets.filter(
+                set => set && set.target && set.synonyms && set.antonyms
+              )
+            : [];
+
+        if (!sets.length) {
+            container.innerHTML = `
+                <div class="exercise-empty-state">
+                    <p>📚 В этой главе пока нет упражнений на синонимы и антонимы.</p>
+                    <p class="empty-state-hint">Они появятся в следующих обновлениях!</p>
+                </div>
+            `;
+            return;
+        }
+
+        const cardsHtml = sets.map(set => renderSynonymSet(set)).join('');
+        container.innerHTML = `<div class="synonym-exercise">${cardsHtml}</div>`;
+
+        // Инициализация каждого набора
+        container.querySelectorAll('.synonym-set').forEach(setElement => {
+            new SynonymAntonymSet(setElement);
+        });
+
+        refreshActiveExerciseContentHeight();
+    }
+
+    function renderSynonymSet(set) {
+        const synonyms = shuffleArray(set.synonyms || []);
+        const antonyms = shuffleArray(set.antonyms || []);
+        const cards = shuffleArray([
+            ...synonyms.map(item => ({ ...item, role: 'synonym' })),
+            ...antonyms.map(item => ({ ...item, role: 'antonym' }))
+        ]);
+
+        return `
+            <article class="synonym-set" data-set-id="${set.id}">
+                <header class="synonym-header">
+                    <h4>📖 ${set.title || 'Найдите синонимы и антонимы'}</h4>
+                    <div class="synonym-target">
+                        <span class="target-label">Целевое слово:</span>
+                        <span class="target-word">${set.target.word}</span>
+                        <span class="target-translation">(${set.target.translation})</span>
+                        ${set.target.hint ? `
+                            <span class="target-hint" title="${set.target.hint}">
+                                💡 ${set.target.hint}
+                            </span>
+                        ` : ''}
+                    </div>
+                    ${set.narration ? `
+                        <p class="synonym-narration">
+                            <em>${set.narration}</em>
+                        </p>
+                    ` : ''}
+                </header>
+
+                <div class="synonym-board">
+                    <section class="synonym-column" data-role="synonym">
+                        <h5>✅ Синонимы</h5>
+                        <p class="column-hint">Близкие по значению</p>
+                        <div class="synonym-dropzone" 
+                             data-dropzone="synonym"
+                             ondrop="event.preventDefault()"
+                             ondragover="event.preventDefault()">
+                        </div>
+                    </section>
+
+                    <section class="synonym-column" data-role="antonym">
+                        <h5>❌ Антонимы</h5>
+                        <p class="column-hint">Противоположные</p>
+                        <div class="synonym-dropzone" 
+                             data-dropzone="antonym"
+                             ondrop="event.preventDefault()"
+                             ondragover="event.preventDefault()">
+                        </div>
+                    </section>
+                </div>
+
+                <div class="synonym-cards-pool">
+                    <p class="pool-label">Перетащите карточки в нужные колонки:</p>
+                    <div class="synonym-cards">
+                        ${cards.map((item, index) => `
+                            <button class="synonym-card"
+                                    type="button"
+                                    draggable="true"
+                                    data-role="${item.role}"
+                                    data-word="${item.word}"
+                                    data-index="${index}">
+                                <span class="card-word">${item.word}</span>
+                                <span class="card-translation">${item.translation}</span>
+                            </button>
+                        `).join('')}
+                    </div>
+                </div>
+
+                <footer class="synonym-controls">
+                    <button type="button" class="btn-check synonym-check">
+                        ✔️ Проверить
+                    </button>
+                    <button type="button" class="btn-reset synonym-reset">
+                        🔄 Сбросить
+                    </button>
+                    <button type="button" class="btn-hint synonym-hint">
+                        💡 Подсказка
+                    </button>
+                    <div class="synonym-feedback" aria-live="polite"></div>
+                    <div class="synonym-progress">
+                        <span class="progress-text">Прогресс: </span>
+                        <span class="progress-value">0 / ${cards.length}</span>
+                    </div>
+                </footer>
+            </article>
+        `;
+    }
+
+    class SynonymAntonymSet {
+        constructor(root) {
+            this.root = root;
+            this.cards = Array.from(root.querySelectorAll('.synonym-card'));
+            this.dropzones = Array.from(root.querySelectorAll('.synonym-dropzone'));
+            this.feedback = root.querySelector('.synonym-feedback');
+            this.checkButton = root.querySelector('.synonym-check');
+            this.resetButton = root.querySelector('.synonym-reset');
+            this.hintButton = root.querySelector('.synonym-hint');
+            this.progressValue = root.querySelector('.progress-value');
+            this.cardsPool = root.querySelector('.synonym-cards');
+
+            this.selectedCard = null;
+            this.hintsUsed = 0;
+            this.attempts = 0;
+
+            this.bindEvents();
+            this.updateProgress();
+        }
+
+        bindEvents() {
+            // Drag and Drop
+            this.cards.forEach(card => {
+                card.addEventListener('dragstart', e => this.handleDragStart(e, card));
+                card.addEventListener('dragend', e => this.handleDragEnd(e, card));
+                card.addEventListener('click', () => this.handleCardClick(card));
+
+                // Touch events для мобильных
+                card.addEventListener('touchstart', e => this.handleTouchStart(e, card), {passive: false});
+                card.addEventListener('touchmove', e => this.handleTouchMove(e, card), {passive: false});
+                card.addEventListener('touchend', e => this.handleTouchEnd(e, card));
+            });
+
+            this.dropzones.forEach(zone => {
+                zone.addEventListener('dragover', e => this.handleDragOver(e, zone));
+                zone.addEventListener('dragleave', e => this.handleDragLeave(e, zone));
+                zone.addEventListener('drop', e => this.handleDrop(e, zone));
+                zone.addEventListener('click', () => this.handleZoneClick(zone));
+            });
+
+            // Кнопки
+            this.checkButton?.addEventListener('click', () => this.checkAnswers());
+            this.resetButton?.addEventListener('click', () => this.reset());
+            this.hintButton?.addEventListener('click', () => this.showHint());
+
+            // Возврат карточки в пул по клику
+            this.root.addEventListener('click', e => {
+                if (e.target.closest('.synonym-dropzone .synonym-card')) {
+                    const card = e.target.closest('.synonym-card');
+                    this.returnToPool(card);
+                }
+            });
+        }
+
+        handleDragStart(event, card) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', card.dataset.index || '');
+            card.classList.add('dragging');
+            this.selectedCard = card;
+        }
+
+        handleDragEnd(event, card) {
+            card.classList.remove('dragging');
+            this.dropzones.forEach(zone => zone.classList.remove('drag-over'));
+        }
+
+        handleDragOver(event, zone) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+            zone.classList.add('drag-over');
+        }
+
+        handleDragLeave(event, zone) {
+            if (!zone.contains(event.relatedTarget)) {
+                zone.classList.remove('drag-over');
+            }
+        }
+
+        handleDrop(event, zone) {
+            event.preventDefault();
+            zone.classList.remove('drag-over');
+
+            const draggingCard = this.root.querySelector('.synonym-card.dragging') || this.selectedCard;
+            if (!draggingCard) return;
+
+            // Анимация
+            draggingCard.style.transition = 'transform 0.3s ease';
+
+            // Проверка правильности сразу (опционально)
+            const isCorrect = this.isCorrectDrop(draggingCard, zone);
+
+            zone.appendChild(draggingCard);
+            draggingCard.classList.add('placed');
+            draggingCard.classList.remove('dragging');
+
+            if (isCorrect) {
+                this.animateSuccess(draggingCard);
+                this.setFeedback('Отлично! ✨', true);
+            } else {
+                this.animateError(draggingCard);
+                this.setFeedback('Попробуйте ещё раз 🤔', false);
+            }
+
+            this.updateProgress();
+            refreshActiveExerciseContentHeight();
+        }
+
+        handleCardClick(card) {
+            // Toggle selection
+            if (card.classList.contains('selected')) {
+                card.classList.remove('selected');
+                this.selectedCard = null;
+            } else {
+                this.cards.forEach(c => c.classList.remove('selected'));
+                card.classList.add('selected');
+                this.selectedCard = card;
+            }
+        }
+
+        handleZoneClick(zone) {
+            if (this.selectedCard && !this.selectedCard.classList.contains('placed')) {
+                zone.appendChild(this.selectedCard);
+                this.selectedCard.classList.add('placed');
+                this.selectedCard.classList.remove('selected');
+
+                const isCorrect = this.isCorrectDrop(this.selectedCard, zone);
+                if (isCorrect) {
+                    this.animateSuccess(this.selectedCard);
+                }
+
+                this.selectedCard = null;
+                this.updateProgress();
+                refreshActiveExerciseContentHeight();
+            }
+        }
+
+        handleTouchStart(event, card) {
+            event.preventDefault();
+            this.touchCard = card;
+            card.classList.add('dragging');
+        }
+
+        handleTouchMove(event, card) {
+            event.preventDefault();
+            const touch = event.touches[0];
+            const elem = document.elementFromPoint(touch.clientX, touch.clientY);
+            const zone = elem?.closest('.synonym-dropzone');
+
+            this.dropzones.forEach(z => z.classList.remove('drag-over'));
+            if (zone) zone.classList.add('drag-over');
+        }
+
+        handleTouchEnd(event, card) {
+            event.preventDefault();
+            const touch = event.changedTouches[0];
+            const elem = document.elementFromPoint(touch.clientX, touch.clientY);
+            const zone = elem?.closest('.synonym-dropzone');
+
+            if (zone) {
+                this.handleDrop(event, zone);
+            }
+
+            card.classList.remove('dragging');
+            this.dropzones.forEach(z => z.classList.remove('drag-over'));
+        }
+
+        returnToPool(card) {
+            card.classList.remove('placed', 'correct', 'incorrect');
+            this.cardsPool?.appendChild(card);
+            this.updateProgress();
+            this.setFeedback('Карточка возвращена в пул', true);
+            refreshActiveExerciseContentHeight();
+        }
+
+        isCorrectDrop(card, zone) {
+            const expectedRole = zone.dataset.dropzone;
+            return card.dataset.role === expectedRole;
+        }
+
+        checkAnswers() {
+            this.attempts++;
+            let correctCount = 0;
+            let total = this.cards.length;
+            let placedCount = 0;
+
+            this.dropzones.forEach(zone => {
+                Array.from(zone.children).forEach(card => {
+                    placedCount++;
+                    if (this.isCorrectDrop(card, zone)) {
+                        correctCount++;
+                        card.classList.add('correct');
+                        card.classList.remove('incorrect');
+                        this.animateSuccess(card);
+                    } else {
+                        card.classList.add('incorrect');
+                        card.classList.remove('correct');
+                        this.animateError(card);
+                    }
+                });
+            });
+
+            if (placedCount === 0) {
+                this.setFeedback('Сначала распределите карточки! 📝', false);
+            } else if (placedCount < total) {
+                this.setFeedback(
+                    `Распределите все карточки! Осталось: ${total - placedCount}`,
+                    false
+                );
+            } else if (correctCount === total) {
+                this.setFeedback(
+                    `🎉 Превосходно! Все ${total} слов распределены правильно! ` +
+                    `${this.attempts === 1 ? 'С первой попытки!' : `Попыток: ${this.attempts}`}`,
+                    true
+                );
+                this.celebrateSuccess();
+            } else {
+                this.setFeedback(
+                    `Правильно: ${correctCount} из ${total}. ` +
+                    `Проверьте красные карточки и попробуйте снова! 💪`,
+                    false
+                );
+            }
+        }
+
+        showHint() {
+            this.hintsUsed++;
+            const unplacedCards = this.cards.filter(card => !card.classList.contains('placed'));
+
+            if (unplacedCards.length === 0) {
+                this.setFeedback('Все карточки уже размещены! Нажмите "Проверить"', true);
+                return;
+            }
+
+            // Показываем подсказку для первой неразмещённой карточки
+            const card = unplacedCards[0];
+            const correctZone = this.dropzones.find(
+                zone => zone.dataset.dropzone === card.dataset.role
+            );
+
+            if (correctZone) {
+                // Подсвечиваем нужную зону
+                correctZone.classList.add('hint-highlight');
+                card.classList.add('hint-card');
+
+                this.setFeedback(
+                    `Подсказка: "${card.dataset.word}" должно быть в колонке ` +
+                    `"${card.dataset.role === 'synonym' ? 'Синонимы' : 'Антонимы'}"`,
+                    true
+                );
+
+                setTimeout(() => {
+                    correctZone.classList.remove('hint-highlight');
+                    card.classList.remove('hint-card');
+                }, 3000);
+            }
+        }
+
+        reset() {
+            const pool = this.cardsPool;
+            if (!pool) return;
+
+            this.cards.forEach(card => {
+                card.classList.remove(
+                    'placed', 'correct', 'incorrect',
+                    'selected', 'hint-card'
+                );
+                card.style.transition = 'all 0.3s ease';
+                pool.appendChild(card);
+            });
+
+            this.selectedCard = null;
+            this.attempts = 0;
+            this.hintsUsed = 0;
+
+            this.setFeedback('Упражнение сброшено. Попробуйте снова! 🔄', true);
+            this.updateProgress();
+            refreshActiveExerciseContentHeight();
+        }
+
+        updateProgress() {
+            if (!this.progressValue) return;
+
+            const placed = this.cards.filter(
+                card => card.classList.contains('placed')
+            ).length;
+            const total = this.cards.length;
+
+            this.progressValue.textContent = `${placed} / ${total}`;
+
+            // Добавляем визуальный индикатор прогресса
+            const percent = (placed / total) * 100;
+            this.progressValue.style.background = `linear-gradient(
+                to right, 
+                #7c3aed ${percent}%, 
+                #f3f4f6 ${percent}%
+            )`;
+        }
+
+        animateSuccess(card) {
+            card.style.animation = 'pulseSuccess 0.5s ease';
+            setTimeout(() => {
+                card.style.animation = '';
+            }, 500);
+        }
+
+        animateError(card) {
+            card.style.animation = 'shakeError 0.5s ease';
+            setTimeout(() => {
+                card.style.animation = '';
+            }, 500);
+        }
+
+        celebrateSuccess() {
+            // Конфетти или другая праздничная анимация
+            this.root.classList.add('success-celebration');
+            setTimeout(() => {
+                this.root.classList.remove('success-celebration');
+            }, 2000);
+        }
+
+        setFeedback(message, isSuccess) {
+            if (!this.feedback) return;
+
+            this.feedback.textContent = message;
+            this.feedback.className = 'synonym-feedback ' + 
+                (isSuccess ? 'feedback-success' : 'feedback-error');
+
+            // Анимация появления
+            this.feedback.style.animation = 'fadeInUp 0.3s ease';
+            setTimeout(() => {
+                this.feedback.style.animation = '';
+            }, 300);
+        }
+    }
+
+    // Вспомогательная функция перемешивания
+    function shuffleArray(items) {
+        const array = Array.isArray(items) ? [...items] : [];
+        for (let i = array.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [array[i], array[j]] = [array[j], array[i]];
+        }
+        return array;
+    }
+
     // ==========================================
     // ОБНОВЛЕНИЕ НАЗВАНИЙ В UI
     // ==========================================
-    
+
     document.addEventListener('DOMContentLoaded', function() {
         setTimeout(() => {
             if (window.phaseKeys && window.phaseKeys.length > 0) {

--- a/templates/journey.html
+++ b/templates/journey.html
@@ -115,6 +115,32 @@
                     </div>
                 </div>
 
+                <div class="exercise-panel" data-exercise="synonyms">
+                    <button class="exercise-toggle" type="button">
+                        <span class="toggle-icon">▶</span>
+                        🌈 Синонимы и антонимы
+                    </button>
+                    <div class="exercise-content collapsed">
+                        <p class="exercise-description">
+                            Распределите слова по категориям: найдите синонимы (близкие по значению) 
+                            и антонимы (противоположные) к целевому слову. Перетащите карточки 
+                            в правильные колонки или кликните для выбора.
+                        </p>
+                        <div class="exercise-phase-wrapper" data-phase-wrapper="synonyms">
+                            {% for phase in journey_phases %}
+                            <section class="exercise-phase{% if loop.first %} active{% endif %}" 
+                                     data-phase="{{ phase.id }}">
+                                <div class="synonyms-container" 
+                                     data-synonyms-container 
+                                     data-phase="{{ phase.id }}">
+                                    <!-- Контент генерируется через JS -->
+                                </div>
+                            </section>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+
                 <div class="exercise-panel" data-exercise="quiz">
                     <button class="exercise-toggle" type="button">
                         <span class="toggle-icon">▶</span>


### PR DESCRIPTION
## Summary
- add synonym/antonym sets to character phase data so each journey exposes semantic practice content
- extend the phase serializer and journey template to surface a new "🌈 Синонимы и антонимы" accordion panel
- implement drag-and-drop synonym/antonym gameplay with styling, feedback, hints, and touch support

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68d177fb8c2c8320a16aa710eb2f21b3