### PR TITLE
Add German relations for demütigen vocabulary entry

### DIFF
--- a/data/vocabulary/vocabulary.json
+++ b/data/vocabulary/vocabulary.json
@@ -3650,7 +3650,7 @@
       ],
       "example_sentences": [
         {
-          "de": "Im Kerker von Lear hallt die Stimme eines treuen Freundes. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
+          "de": "Im Kerker Lears hallt die Stimme eines treuen Freundes wider. Ich flüstere den Wächtern des Schicksals zu: Das Wort „demütigen“ darf nicht vergehen.",
           "ru": "В темнице Лира звучит голос верного друга. Я шепчу стражам судьбы: слово «унижать» не должно исчезнуть."
         }
       ],
@@ -3660,9 +3660,16 @@
         "Совершенный оттенок: завершённое действие «унижать»"
       ],
       "synonyms": [
-        "унижать",
-        "erniedrigen — тоже «унижать»"
+        "erniedrigen",
+        "herabsetzen",
+        "beschämen"
       ],
+      "antonyms": [
+        "ehren",
+        "würdigen",
+        "respektieren"
+      ],
+      "explanation_de": "Jemanden in seiner Würde herabsetzen und ihn klein oder beschämt fühlen lassen.",
       "visual_hint": "📚"
     },
     {


### PR DESCRIPTION
## Summary
- update the demütigen vocabulary card with a polished German example sentence and purely German synonym list
- add antonyms and a concise German explanation for demütigen to enrich relational data

## Testing
- `python - <<'PY'
import json
from pathlib import Path
path = Path('data/vocabulary/vocabulary.json')
data = json.loads(path.read_text(encoding='utf-8'))
entry = next(item for item in data['vocabulary'] if item['id'] == 'word_0486')
print(entry['german'], entry['synonyms'], entry['antonyms'], entry['explanation_de'])
PY`
- `python - <<'PY'
from generators.html.vocabulary_processor import VocabularyProcessor
from pathlib import Path
vp = VocabularyProcessor(Path('data'))
cache = vp.load_cache()
entry = cache.get('demütigen')
print(bool(entry))
print('antonyms' in entry, entry.get('antonyms'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d1c3e1d350832082417efe93d86f10