### PR TITLE
Fix German synonyms for synonym exercises

### DIFF
--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -244,15 +244,15 @@
           },
           "synonyms": [
             {
-              "word": "das Обряд",
+              "word": "der Ritus",
               "translation": "обряд"
             },
             {
-              "word": "das Ритуал",
+              "word": "das Ritual",
               "translation": "ритуал"
             },
             {
-              "word": "das Торжество",
+              "word": "die Feier",
               "translation": "торжество"
             }
           ],
@@ -482,15 +482,15 @@
           },
           "synonyms": [
             {
-              "word": "das Отвергать",
+              "word": "abweisen",
               "translation": "отвергать"
             },
             {
-              "word": "das Отрекаться",
+              "word": "verleugnen",
               "translation": "отрекаться"
             },
             {
-              "word": "das Выгонять",
+              "word": "vertreiben",
               "translation": "выгонять"
             }
           ],
@@ -507,15 +507,15 @@
           },
           "synonyms": [
             {
-              "word": "das Оставлять",
+              "word": "zurücklassen",
               "translation": "оставлять"
             },
             {
-              "word": "das Уходить",
+              "word": "fortgehen",
               "translation": "уходить"
             },
             {
-              "word": "das Бросать",
+              "word": "im Stich lassen",
               "translation": "бросать"
             }
           ],
@@ -723,15 +723,15 @@
           },
           "synonyms": [
             {
-              "word": "das Беспокойство",
+              "word": "die Unruhe",
               "translation": "беспокойство"
             },
             {
-              "word": "das Тревога",
+              "word": "die Besorgnis",
               "translation": "тревога"
             },
             {
-              "word": "das Попечение",
+              "word": "die Fürsorge",
               "translation": "попечение"
             }
           ],
@@ -973,15 +973,15 @@
           },
           "synonyms": [
             {
-              "word": "das Вернуться",
+              "word": "zurückkommen",
               "translation": "вернуться"
             },
             {
-              "word": "das Прибыть",
+              "word": "ankommen",
               "translation": "прибыть"
             },
             {
-              "word": "das Воротиться",
+              "word": "heimkehren",
               "translation": "воротиться"
             }
           ],
@@ -998,15 +998,15 @@
           },
           "synonyms": [
             {
-              "word": "das Битва",
+              "word": "die Schlacht",
               "translation": "битва"
             },
             {
-              "word": "das Сражение",
+              "word": "das Gefecht",
               "translation": "сражение"
             },
             {
-              "word": "das Схватка",
+              "word": "der Zweikampf",
               "translation": "схватка"
             }
           ],
@@ -1214,15 +1214,15 @@
           },
           "synonyms": [
             {
-              "word": "das Извинять",
+              "word": "entschuldigen",
               "translation": "извинять"
             },
             {
-              "word": "das Миловать",
+              "word": "begnadigen",
               "translation": "миловать"
             },
             {
-              "word": "das Отпускать",
+              "word": "vergeben",
               "translation": "отпускать"
             }
           ],
@@ -1239,15 +1239,15 @@
           },
           "synonyms": [
             {
-              "word": "das Рыдания",
+              "word": "das Schluchzen",
               "translation": "рыдания"
             },
             {
-              "word": "das Плач",
+              "word": "das Weinen",
               "translation": "плач"
             },
             {
-              "word": "das Слезинки",
+              "word": "die Tränchen",
               "translation": "слезинки"
             }
           ],
@@ -1455,15 +1455,15 @@
           },
           "synonyms": [
             {
-              "word": "das Плененный",
+              "word": "inhaftiert",
               "translation": "плененный"
             },
             {
-              "word": "das Арестованный",
+              "word": "verhaftet",
               "translation": "арестованный"
             },
             {
-              "word": "das Схваченный",
+              "word": "festgenommen",
               "translation": "схваченный"
             }
           ],
@@ -1480,15 +1480,15 @@
           },
           "synonyms": [
             {
-              "word": "das Темница",
+              "word": "der Kerker",
               "translation": "темница"
             },
             {
-              "word": "das Узилище",
+              "word": "die Haftanstalt",
               "translation": "узилище"
             },
             {
-              "word": "das Застенок",
+              "word": "das Zuchthaus",
               "translation": "застенок"
             }
           ],
@@ -1696,15 +1696,15 @@
           },
           "synonyms": [
             {
-              "word": "das Кончина",
+              "word": "das Ableben",
               "translation": "кончина"
             },
             {
-              "word": "das Гибель",
+              "word": "der Exitus",
               "translation": "гибель"
             },
             {
-              "word": "das Уход",
+              "word": "das Lebensende",
               "translation": "уход"
             }
           ],
@@ -1721,15 +1721,15 @@
           },
           "synonyms": [
             {
-              "word": "das Погибать",
+              "word": "umkommen",
               "translation": "погибать"
             },
             {
-              "word": "das Скончаться",
+              "word": "versterben",
               "translation": "скончаться"
             },
             {
-              "word": "das Почить",
+              "word": "entschlafen",
               "translation": "почить"
             }
           ],

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -214,15 +214,15 @@
           },
           "synonyms": [
             {
-              "word": "das Присягать",
+              "word": "geloben",
               "translation": "присягать"
             },
             {
-              "word": "das Обещать",
+              "word": "versprechen",
               "translation": "обещать"
             },
             {
-              "word": "das Заклясться",
+              "word": "beschwören",
               "translation": "заклясться"
             }
           ],
@@ -711,15 +711,15 @@
           },
           "synonyms": [
             {
-              "word": "das Унижать",
+              "word": "erniedrigen",
               "translation": "унижать"
             },
             {
-              "word": "das Оскорблять",
+              "word": "beleidigen",
               "translation": "оскорблять"
             },
             {
-              "word": "das Принижать",
+              "word": "herabsetzen",
               "translation": "принижать"
             }
           ],
@@ -736,15 +736,15 @@
           },
           "synonyms": [
             {
-              "word": "das Жестокий",
+              "word": "brutal",
               "translation": "жестокий"
             },
             {
-              "word": "das Безжалостный",
+              "word": "gnadenlos",
               "translation": "безжалостный"
             },
             {
-              "word": "das Свирепый",
+              "word": "unbarmherzig",
               "translation": "свирепый"
             }
           ],
@@ -933,15 +933,15 @@
           },
           "synonyms": [
             {
-              "word": "das Изгонять",
+              "word": "vertreiben",
               "translation": "изгонять"
             },
             {
-              "word": "das Отвергать",
+              "word": "abweisen",
               "translation": "отвергать"
             },
             {
-              "word": "das Отрекаться",
+              "word": "verleugnen",
               "translation": "отрекаться"
             }
           ],
@@ -1183,15 +1183,15 @@
           },
           "synonyms": [
             {
-              "word": "das Ссориться",
+              "word": "zanken",
               "translation": "ссориться"
             },
             {
-              "word": "das Ругаться",
+              "word": "schimpfen",
               "translation": "ругаться"
             },
             {
-              "word": "das Препираться",
+              "word": "hadern",
               "translation": "препираться"
             }
           ],
@@ -1208,15 +1208,15 @@
           },
           "synonyms": [
             {
-              "word": "das Предавать",
+              "word": "hintergehen",
               "translation": "предавать"
             },
             {
-              "word": "das Выдавать",
+              "word": "preisgeben",
               "translation": "выдавать"
             },
             {
-              "word": "das Изменять",
+              "word": "betrügen",
               "translation": "изменять"
             }
           ],
@@ -1424,15 +1424,15 @@
           },
           "synonyms": [
             {
-              "word": "das Ревность",
+              "word": "der Neid",
               "translation": "ревность"
             },
             {
-              "word": "das Зависть",
+              "word": "die Missgunst",
               "translation": "зависть"
             },
             {
-              "word": "das Подозрение",
+              "word": "der Argwohn",
               "translation": "подозрение"
             }
           ],
@@ -1449,15 +1449,15 @@
           },
           "synonyms": [
             {
-              "word": "das Соперничать",
+              "word": "konkurrieren",
               "translation": "соперничать"
             },
             {
-              "word": "das Конкурировать",
+              "word": "wetteifern",
               "translation": "конкурировать"
             },
             {
-              "word": "das Бороться",
+              "word": "kämpfen",
               "translation": "бороться"
             }
           ],
@@ -1665,15 +1665,15 @@
           },
           "synonyms": [
             {
-              "word": "das Отравлять",
+              "word": "giftmischen",
               "translation": "отравлять"
             },
             {
-              "word": "das Травить",
+              "word": "intoxizieren",
               "translation": "травить"
             },
             {
-              "word": "das Поражать",
+              "word": "schädigen",
               "translation": "поражать"
             }
           ],

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -214,15 +214,15 @@
           },
           "synonyms": [
             {
-              "word": "das Престол",
+              "word": "der Herrschersitz",
               "translation": "престол"
             },
             {
-              "word": "das Царское место",
+              "word": "der Königsstuhl",
               "translation": "царское место"
             },
             {
-              "word": "das Королевское кресло",
+              "word": "der Thronsessel",
               "translation": "королевское кресло"
             }
           ],
@@ -239,15 +239,15 @@
           },
           "synonyms": [
             {
-              "word": "das Царство",
+              "word": "das Reich",
               "translation": "царство"
             },
             {
-              "word": "das Держава",
+              "word": "der Staat",
               "translation": "держава"
             },
             {
-              "word": "das Государство",
+              "word": "das Imperium",
               "translation": "государство"
             }
           ],
@@ -477,15 +477,15 @@
           },
           "synonyms": [
             {
-              "word": "das Оскорблять",
+              "word": "beleidigen",
               "translation": "оскорблять"
             },
             {
-              "word": "das Позорить",
+              "word": "beschämen",
               "translation": "позорить"
             },
             {
-              "word": "das Уничижать",
+              "word": "erniedrigen",
               "translation": "уничижать"
             }
           ],
@@ -727,15 +727,15 @@
           },
           "synonyms": [
             {
-              "word": "das Оставлять",
+              "word": "zurücklassen",
               "translation": "оставлять"
             },
             {
-              "word": "das Уходить",
+              "word": "fortgehen",
               "translation": "уходить"
             },
             {
-              "word": "das Бросать",
+              "word": "im Stich lassen",
               "translation": "бросать"
             }
           ],
@@ -752,15 +752,15 @@
           },
           "synonyms": [
             {
-              "word": "das Отрекаться",
+              "word": "verleugnen",
               "translation": "отрекаться"
             },
             {
-              "word": "das Изгонять",
+              "word": "vertreiben",
               "translation": "изгонять"
             },
             {
-              "word": "das Отталкивать",
+              "word": "abweisen",
               "translation": "отталкивать"
             }
           ],
@@ -1227,15 +1227,15 @@
           },
           "synonyms": [
             {
-              "word": "das Бедность",
+              "word": "die Armut",
               "translation": "бедность"
             },
             {
-              "word": "das Убожество",
+              "word": "die Dürftigkeit",
               "translation": "убожество"
             },
             {
-              "word": "das Лишения",
+              "word": "die Entbehrung",
               "translation": "лишения"
             }
           ],
@@ -1252,15 +1252,15 @@
           },
           "synonyms": [
             {
-              "word": "das Попрошайка",
+              "word": "der Bettelmann",
               "translation": "попрошайка"
             },
             {
-              "word": "das Бедняк",
+              "word": "der Arme",
               "translation": "бедняк"
             },
             {
-              "word": "das Оборванец",
+              "word": "der Landstreicher",
               "translation": "оборванец"
             }
           ],
@@ -1468,15 +1468,15 @@
           },
           "synonyms": [
             {
-              "word": "das Опознавать",
+              "word": "identifizieren",
               "translation": "опознавать"
             },
             {
-              "word": "das Распознавать",
+              "word": "wiedererkennen",
               "translation": "распознавать"
             },
             {
-              "word": "das Признавать",
+              "word": "anerkennen",
               "translation": "признавать"
             }
           ],
@@ -1493,15 +1493,15 @@
           },
           "synonyms": [
             {
-              "word": "das Постигать",
+              "word": "begreifen",
               "translation": "постигать"
             },
             {
-              "word": "das Осознавать",
+              "word": "erfassen",
               "translation": "осознавать"
             },
             {
-              "word": "das Уразумевать",
+              "word": "einsehen",
               "translation": "уразумевать"
             }
           ],
@@ -1709,15 +1709,15 @@
           },
           "synonyms": [
             {
-              "word": "das Извинять",
+              "word": "entschuldigen",
               "translation": "извинять"
             },
             {
-              "word": "das Отпускать",
+              "word": "vergeben",
               "translation": "отпускать"
             },
             {
-              "word": "das Миловать",
+              "word": "begnadigen",
               "translation": "миловать"
             }
           ],
@@ -1734,15 +1734,15 @@
           },
           "synonyms": [
             {
-              "word": "das Кончина",
+              "word": "das Ableben",
               "translation": "кончина"
             },
             {
-              "word": "das Гибель",
+              "word": "der Exitus",
               "translation": "гибель"
             },
             {
-              "word": "das Уход",
+              "word": "das Lebensende",
               "translation": "уход"
             }
           ],


### PR DESCRIPTION
## Summary
- replace pseudo-German throne and kingdom synonyms in King Lear's materials with authentic German nouns
- swap out Cyrillic placeholders for verbs and nouns across Goneril and Cordelia synonym sets using real German vocabulary
- ensure all synonym entries keep the existing translations while using correct German spelling, articles, and parts of speech

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d241672fb083209c6f4fd5e8105247