### PR TITLE
Update character synonym and antonym sets

### DIFF
--- a/data/characters/albany.json
+++ b/data/characters/albany.json
@@ -242,7 +242,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "first_doubts_die_verzweiflung",
+          "title": "Семантическое поле: отчаяние",
+          "target": {
+            "word": "die Verzweiflung",
+            "translation": "отчаяние",
+            "hint": "сомнения, терзающие герцога"
+          },
+          "synonyms": [
+            {
+              "word": "die Angst",
+              "translation": "страх"
+            },
+            {
+              "word": "das Elend",
+              "translation": "нищета"
+            },
+            {
+              "word": "die Trauer",
+              "translation": "печаль, печаль, скорбь, скорбь"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "die Hoffnung",
+              "translation": "надежда"
+            },
+            {
+              "word": "vertrauen",
+              "translation": "доверять"
+            },
+            {
+              "word": "die Freude",
+              "translation": "радость"
+            }
+          ],
+          "narration": "От отчаяние через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "awakening",
@@ -368,7 +407,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "awakening_die_wahrheit",
+          "title": "Семантическое поле: правда",
+          "target": {
+            "word": "die Wahrheit",
+            "translation": "правда",
+            "hint": "истина, которую Олбани осознаёт"
+          },
+          "synonyms": [
+            {
+              "word": "die Erkenntnis",
+              "translation": "осознание, осознание, познание, познание"
+            },
+            {
+              "word": "aufrichtig",
+              "translation": "искренний"
+            },
+            {
+              "word": "enthüllen",
+              "translation": "разоблачать, разоблачать, раскрывать, раскрывать"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "die Lüge",
+              "translation": "ложь"
+            },
+            {
+              "word": "verbergen",
+              "translation": "скрывать"
+            },
+            {
+              "word": "verschweigen",
+              "translation": "умалчивать"
+            }
+          ],
+          "narration": "От правда через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "confrontation",

--- a/data/characters/cordelia.json
+++ b/data/characters/cordelia.json
@@ -180,12 +180,16 @@
           },
           "synonyms": [
             {
-              "word": "die Ehrlichkeit",
-              "translation": "честность"
+              "word": "die Erkenntnis",
+              "translation": "осознание, осознание, познание, познание"
             },
             {
-              "word": "die Aufrichtigkeit",
-              "translation": "искренность"
+              "word": "aufrichtig",
+              "translation": "искренний"
+            },
+            {
+              "word": "enthüllen",
+              "translation": "разоблачать, разоблачать, раскрывать, раскрывать"
             }
           ],
           "antonyms": [
@@ -194,12 +198,12 @@
               "translation": "ложь"
             },
             {
-              "word": "die Heuchelei",
-              "translation": "лицемерие"
+              "word": "verbergen",
+              "translation": "скрывать"
             },
             {
-              "word": "der Betrug",
-              "translation": "обман"
+              "word": "verschweigen",
+              "translation": "умалчивать"
             }
           ],
           "narration": "Корделия выбирает правду, даже если это стоит ей наследства."
@@ -218,8 +222,12 @@
               "translation": "верность"
             },
             {
-              "word": "die Pflicht",
-              "translation": "долг"
+              "word": "die Güte",
+              "translation": "доброта"
+            },
+            {
+              "word": "die Familie",
+              "translation": "семья"
             }
           ],
           "antonyms": [
@@ -228,8 +236,12 @@
               "translation": "ненависть"
             },
             {
-              "word": "die Gleichgültigkeit",
-              "translation": "равнодушие"
+              "word": "die Grausamkeit",
+              "translation": "жестокость"
+            },
+            {
+              "word": "die Lüge",
+              "translation": "ложь"
             }
           ],
           "narration": "Её любовь честна, без преувеличений."
@@ -244,19 +256,32 @@
           },
           "synonyms": [
             {
-              "word": "der Ritus",
-              "translation": "обряд"
+              "word": "feierlich",
+              "translation": "торжественный"
             },
             {
-              "word": "das Ritual",
-              "translation": "ритуал"
+              "word": "verkünden",
+              "translation": "провозглашать"
             },
             {
-              "word": "die Feier",
-              "translation": "торжество"
+              "word": "die Krone",
+              "translation": "корона"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "das Chaos",
+              "translation": "хаос"
+            },
+            {
+              "word": "der Streit",
+              "translation": "спор"
+            },
+            {
+              "word": "die Flucht",
+              "translation": "бегство"
+            }
+          ],
           "narration": "Від церемония через контрасти до розуміння."
         }
       ],
@@ -482,19 +507,32 @@
           },
           "synonyms": [
             {
-              "word": "abweisen",
-              "translation": "отвергать"
-            },
-            {
-              "word": "verleugnen",
-              "translation": "отрекаться"
+              "word": "verbannen",
+              "translation": "изгнать, изгнать, изгонять"
             },
             {
               "word": "vertreiben",
-              "translation": "выгонять"
+              "translation": "изгонять, изгонять, прогонять"
+            },
+            {
+              "word": "abweisen",
+              "translation": "отвергать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "zurückkehren",
+              "translation": "возвращаться"
+            },
+            {
+              "word": "halten",
+              "translation": "держать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від изгонять через контрасти до розуміння."
         },
         {
@@ -507,19 +545,32 @@
           },
           "synonyms": [
             {
-              "word": "zurücklassen",
-              "translation": "оставлять"
+              "word": "aufgeben",
+              "translation": "сдаваться"
             },
             {
-              "word": "fortgehen",
-              "translation": "уходить"
+              "word": "entfliehen",
+              "translation": "убегать"
             },
             {
-              "word": "im Stich lassen",
-              "translation": "бросать"
+              "word": "fliehen",
+              "translation": "бежать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "zurückkehren",
+              "translation": "возвращаться"
+            },
+            {
+              "word": "bleiben",
+              "translation": "оставаться"
+            },
+            {
+              "word": "behalten",
+              "translation": "сохранять"
+            }
+          ],
           "narration": "Від покидать через контрасти до розуміння."
         }
       ]
@@ -723,19 +774,32 @@
           },
           "synonyms": [
             {
-              "word": "die Unruhe",
-              "translation": "беспокойство"
+              "word": "die Verantwortung",
+              "translation": "ответственность"
             },
             {
-              "word": "die Besorgnis",
-              "translation": "тревога"
+              "word": "die Pflicht",
+              "translation": "долг"
             },
             {
-              "word": "die Fürsorge",
-              "translation": "попечение"
+              "word": "die Angst",
+              "translation": "страх"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Kälte",
+              "translation": "холод"
+            },
+            {
+              "word": "die Bosheit",
+              "translation": "злоба"
+            },
+            {
+              "word": "der Spott",
+              "translation": "насмешка"
+            }
+          ],
           "narration": "Від забота через контрасти до розуміння."
         },
         {
@@ -748,26 +812,30 @@
           },
           "synonyms": [
             {
-              "word": "die Isolation",
-              "translation": "ізоляція"
+              "word": "die Nacht",
+              "translation": "ночь"
             },
             {
-              "word": "die Verlassenheit",
-              "translation": "покинутість"
+              "word": "die Kälte",
+              "translation": "холод"
             },
             {
-              "word": "die Abgeschiedenheit",
-              "translation": "відлюдність"
+              "word": "die Trauer",
+              "translation": "печаль, печаль, скорбь, скорбь"
             }
           ],
           "antonyms": [
             {
-              "word": "die Gemeinschaft",
-              "translation": "спільнота"
+              "word": "die Familie",
+              "translation": "семья"
             },
             {
-              "word": "die Gesellschaft",
-              "translation": "товариство"
+              "word": "die Freundschaft",
+              "translation": "дружба"
+            },
+            {
+              "word": "die Liebe",
+              "translation": "любовь"
             }
           ],
           "narration": "Від одиночество через контрасти до розуміння."
@@ -973,19 +1041,32 @@
           },
           "synonyms": [
             {
-              "word": "zurückkommen",
-              "translation": "вернуться"
+              "word": "wiederkehren",
+              "translation": "возвращаться"
             },
             {
-              "word": "ankommen",
-              "translation": "прибыть"
+              "word": "umkehren",
+              "translation": "возвращаться"
             },
             {
-              "word": "heimkehren",
-              "translation": "воротиться"
+              "word": "wiedersehen",
+              "translation": "встречаться вновь"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "verlassen",
+              "translation": "покидать"
+            },
+            {
+              "word": "fliehen",
+              "translation": "бежать"
+            },
+            {
+              "word": "verbannen",
+              "translation": "изгнать, изгнать, изгонять"
+            }
+          ],
           "narration": "Від возвращаться через контрасти до розуміння."
         },
         {
@@ -998,19 +1079,32 @@
           },
           "synonyms": [
             {
+              "word": "der Krieg",
+              "translation": "война"
+            },
+            {
               "word": "die Schlacht",
               "translation": "битва"
             },
             {
-              "word": "das Gefecht",
-              "translation": "сражение"
-            },
-            {
-              "word": "der Zweikampf",
-              "translation": "схватка"
+              "word": "der Widerstand",
+              "translation": "сопротивление"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "der Friede",
+              "translation": "мир"
+            },
+            {
+              "word": "die Versöhnung",
+              "translation": "примирение"
+            },
+            {
+              "word": "das Bündnis",
+              "translation": "союз"
+            }
+          ],
           "narration": "Від борьба через контрасти до розуміння."
         }
       ]
@@ -1214,19 +1308,32 @@
           },
           "synonyms": [
             {
+              "word": "vergeben",
+              "translation": "прощать"
+            },
+            {
               "word": "entschuldigen",
               "translation": "извинять"
             },
             {
-              "word": "begnadigen",
-              "translation": "миловать"
-            },
-            {
-              "word": "vergeben",
-              "translation": "отпускать"
+              "word": "versöhnen",
+              "translation": "примирять"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "bestrafen",
+              "translation": "карать, карать, наказывать"
+            },
+            {
+              "word": "anklagen",
+              "translation": "обвинять"
+            },
+            {
+              "word": "verurteilen",
+              "translation": "осуждать"
+            }
+          ],
           "narration": "Від прощать через контрасти до розуміння."
         },
         {
@@ -1239,19 +1346,32 @@
           },
           "synonyms": [
             {
-              "word": "das Schluchzen",
-              "translation": "рыдания"
+              "word": "weinen",
+              "translation": "плакать"
             },
             {
-              "word": "das Weinen",
-              "translation": "плач"
+              "word": "trauern",
+              "translation": "горевать"
             },
             {
-              "word": "die Tränchen",
-              "translation": "слезинки"
+              "word": "die Trauer",
+              "translation": "печаль, печаль, скорбь, скорбь"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "lachen",
+              "translation": "смеяться"
+            },
+            {
+              "word": "die Freude",
+              "translation": "радость"
+            },
+            {
+              "word": "die Hoffnung",
+              "translation": "надежда"
+            }
+          ],
           "narration": "Від слёзы через контрасти до розуміння."
         }
       ]
@@ -1455,19 +1575,32 @@
           },
           "synonyms": [
             {
-              "word": "inhaftiert",
-              "translation": "плененный"
+              "word": "einsperren",
+              "translation": "запирать"
             },
             {
-              "word": "verhaftet",
-              "translation": "арестованный"
+              "word": "fesseln",
+              "translation": "сковывать"
             },
             {
-              "word": "festgenommen",
-              "translation": "схваченный"
+              "word": "bewachen",
+              "translation": "охранять"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "befreien",
+              "translation": "освобождать"
+            },
+            {
+              "word": "fliehen",
+              "translation": "бежать"
+            },
+            {
+              "word": "retten",
+              "translation": "спасать"
+            }
+          ],
           "narration": "Від пленный через контрасти до розуміння."
         },
         {
@@ -1480,19 +1613,32 @@
           },
           "synonyms": [
             {
-              "word": "der Kerker",
-              "translation": "темница"
+              "word": "die Verbannung",
+              "translation": "изгнание"
             },
             {
-              "word": "die Haftanstalt",
-              "translation": "узилище"
+              "word": "das Exil",
+              "translation": "изгнание"
             },
             {
-              "word": "das Zuchthaus",
-              "translation": "застенок"
+              "word": "gefangen",
+              "translation": "пленный"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Freiheit",
+              "translation": "свобода"
+            },
+            {
+              "word": "die Zuflucht",
+              "translation": "убежище"
+            },
+            {
+              "word": "die Heimat",
+              "translation": "родина"
+            }
+          ],
           "narration": "Від тюрьма через контрасти до розуміння."
         }
       ]
@@ -1696,19 +1842,32 @@
           },
           "synonyms": [
             {
-              "word": "das Ableben",
-              "translation": "кончина"
+              "word": "das Ende",
+              "translation": "конец"
             },
             {
-              "word": "der Exitus",
-              "translation": "гибель"
+              "word": "das Grab",
+              "translation": "могила"
             },
             {
-              "word": "das Lebensende",
-              "translation": "уход"
+              "word": "der Abschied",
+              "translation": "прощание"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "das Leben",
+              "translation": "жизнь"
+            },
+            {
+              "word": "die Hoffnung",
+              "translation": "надежда"
+            },
+            {
+              "word": "die Erlösung",
+              "translation": "спасение"
+            }
+          ],
           "narration": "Від смерть через контрасти до розуміння."
         },
         {
@@ -1721,19 +1880,32 @@
           },
           "synonyms": [
             {
-              "word": "umkommen",
+              "word": "untergehen",
               "translation": "погибать"
             },
             {
-              "word": "versterben",
-              "translation": "скончаться"
+              "word": "verenden",
+              "translation": "издыхать"
             },
             {
-              "word": "entschlafen",
-              "translation": "почить"
+              "word": "fallen",
+              "translation": "падать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "leben",
+              "translation": "жить"
+            },
+            {
+              "word": "überleben",
+              "translation": "выживать"
+            },
+            {
+              "word": "erwachen",
+              "translation": "пробуждаться, пробуждаться, просыпаться"
+            }
+          ],
           "narration": "Від умирать через контрасти до розуміння."
         }
       ]

--- a/data/characters/cornwall.json
+++ b/data/characters/cornwall.json
@@ -495,25 +495,29 @@
           "synonyms": [
             {
               "word": "die Wut",
-              "translation": "лють"
+              "translation": "ярость"
             },
             {
-              "word": "der Ärger",
-              "translation": "злість"
+              "word": "der Hass",
+              "translation": "ненависть"
             },
             {
-              "word": "die Rage",
-              "translation": "шаленість"
+              "word": "die Bosheit",
+              "translation": "злоба"
             }
           ],
           "antonyms": [
             {
-              "word": "die Ruhe",
-              "translation": "спокій"
+              "word": "der Friede",
+              "translation": "мир"
             },
             {
-              "word": "der Frieden",
-              "translation": "мир"
+              "word": "die Vergebung",
+              "translation": "прощение"
+            },
+            {
+              "word": "die Ruhe",
+              "translation": "покой"
             }
           ],
           "narration": "Від гнев через контрасти до розуміння."

--- a/data/characters/edgar.json
+++ b/data/characters/edgar.json
@@ -391,26 +391,30 @@
           },
           "synonyms": [
             {
-              "word": "die Verrücktheit",
-              "translation": "божевілля"
+              "word": "das Chaos",
+              "translation": "хаос"
             },
             {
-              "word": "der Irrsinn",
-              "translation": "безумство"
+              "word": "das Entsetzen",
+              "translation": "ужас"
             },
             {
-              "word": "die Geisteskrankheit",
-              "translation": "психічна хвороба"
+              "word": "die Verzweiflung",
+              "translation": "отчаяние"
             }
           ],
           "antonyms": [
             {
               "word": "die Vernunft",
-              "translation": "розум"
+              "translation": "разум"
             },
             {
-              "word": "die Klarheit",
-              "translation": "ясність"
+              "word": "die Weisheit",
+              "translation": "мудрость"
+            },
+            {
+              "word": "die Ordnung",
+              "translation": "порядок"
             }
           ],
           "narration": "Від безумие через контрасти до розуміння."
@@ -552,26 +556,30 @@
           },
           "synonyms": [
             {
-              "word": "das Unwetter",
-              "translation": "негода"
+              "word": "der Donner",
+              "translation": "гром"
             },
             {
-              "word": "der Orkan",
-              "translation": "ураган"
+              "word": "der Regen",
+              "translation": "дождь"
             },
             {
-              "word": "das Gewitter",
-              "translation": "гроза"
+              "word": "die Kälte",
+              "translation": "холод"
             }
           ],
           "antonyms": [
             {
-              "word": "die Stille",
-              "translation": "тиша"
+              "word": "die Sonne",
+              "translation": "солнце"
             },
             {
-              "word": "die Windstille",
-              "translation": "штиль"
+              "word": "die Ruhe",
+              "translation": "покой"
+            },
+            {
+              "word": "der Schutz",
+              "translation": "защита"
             }
           ],
           "narration": "Від буря через контрасти до розуміння."

--- a/data/characters/edmund.json
+++ b/data/characters/edmund.json
@@ -120,22 +120,26 @@
               "translation": "честолюбие"
             },
             {
-              "word": "das Streben",
-              "translation": "стремление"
+              "word": "das Ziel",
+              "translation": "цель"
             },
             {
-              "word": "der Neid",
-              "translation": "зависть"
+              "word": "die Gier",
+              "translation": "жадность"
             }
           ],
           "antonyms": [
             {
-              "word": "die Bescheidenheit",
-              "translation": "скромность"
-            },
-            {
               "word": "die Demut",
               "translation": "смирение"
+            },
+            {
+              "word": "die Ruhe",
+              "translation": "покой"
+            },
+            {
+              "word": "die Treue",
+              "translation": "верность"
             }
           ],
           "narration": "Бастард не знает смирения - только безграничные амбиции."
@@ -554,25 +558,29 @@
           "synonyms": [
             {
               "word": "die Herrschaft",
-              "translation": "господство"
+              "translation": "господство, господство, правление, правление"
             },
             {
-              "word": "die Gewalt",
-              "translation": "сила"
+              "word": "der Befehl",
+              "translation": "приказ"
             },
             {
-              "word": "die Autorität",
-              "translation": "авторитет"
+              "word": "herrschen",
+              "translation": "править"
             }
           ],
           "antonyms": [
             {
               "word": "die Schwäche",
-              "translation": "слабість"
+              "translation": "слабость"
             },
             {
-              "word": "die Ohnmacht",
-              "translation": "безсилля"
+              "word": "die Demut",
+              "translation": "смирение"
+            },
+            {
+              "word": "die Niederlage",
+              "translation": "поражение"
             }
           ],
           "narration": "Від власть через контрасти до розуміння."

--- a/data/characters/fool.json
+++ b/data/characters/fool.json
@@ -111,26 +111,30 @@
           },
           "synonyms": [
             {
-              "word": "die Klugheit",
-              "translation": "ум"
+              "word": "klug",
+              "translation": "умный"
             },
             {
-              "word": "der Verstand",
+              "word": "die Einsicht",
+              "translation": "прозрение"
+            },
+            {
+              "word": "die Vernunft",
               "translation": "разум"
             }
           ],
           "antonyms": [
             {
-              "word": "die Dummheit",
-              "translation": "глупость"
-            },
-            {
-              "word": "die Torheit",
+              "word": "der Wahnsinn",
               "translation": "безумие"
             },
             {
-              "word": "der Wahnsinn",
-              "translation": "сумасшествие"
+              "word": "der Dummkopf",
+              "translation": "дурак"
+            },
+            {
+              "word": "blind",
+              "translation": "слепой"
             }
           ],
           "narration": "Шут - единственный, кто говорит мудрые вещи под маской глупости."
@@ -531,26 +535,30 @@
           },
           "synonyms": [
             {
-              "word": "die Verrücktheit",
-              "translation": "божевілля"
+              "word": "das Chaos",
+              "translation": "хаос"
             },
             {
-              "word": "der Irrsinn",
-              "translation": "безумство"
+              "word": "das Entsetzen",
+              "translation": "ужас"
             },
             {
-              "word": "die Geisteskrankheit",
-              "translation": "психічна хвороба"
+              "word": "die Verzweiflung",
+              "translation": "отчаяние"
             }
           ],
           "antonyms": [
             {
               "word": "die Vernunft",
-              "translation": "розум"
+              "translation": "разум"
             },
             {
-              "word": "die Klarheit",
-              "translation": "ясність"
+              "word": "die Weisheit",
+              "translation": "мудрость"
+            },
+            {
+              "word": "die Ordnung",
+              "translation": "порядок"
             }
           ],
           "narration": "Від безумие через контрасти до розуміння."

--- a/data/characters/gloucester.json
+++ b/data/characters/gloucester.json
@@ -749,26 +749,30 @@
           },
           "synonyms": [
             {
-              "word": "die Hoffnungslosigkeit",
-              "translation": "безнадія"
+              "word": "die Angst",
+              "translation": "страх"
             },
             {
-              "word": "die Trostlosigkeit",
-              "translation": "безвихідь"
+              "word": "das Elend",
+              "translation": "нищета"
             },
             {
-              "word": "die Depression",
-              "translation": "депресія"
+              "word": "die Trauer",
+              "translation": "печаль, печаль, скорбь, скорбь"
             }
           ],
           "antonyms": [
             {
               "word": "die Hoffnung",
-              "translation": "надія"
+              "translation": "надежда"
             },
             {
-              "word": "der Optimismus",
-              "translation": "оптимізм"
+              "word": "vertrauen",
+              "translation": "доверять"
+            },
+            {
+              "word": "die Freude",
+              "translation": "радость"
             }
           ],
           "narration": "Від отчаяние через контрасти до розуміння."
@@ -911,25 +915,29 @@
           "synonyms": [
             {
               "word": "verzeihen",
-              "translation": "вибачати"
-            },
-            {
-              "word": "begnadigen",
-              "translation": "милувати"
+              "translation": "прощать"
             },
             {
               "word": "entschuldigen",
-              "translation": "виправдовувати"
+              "translation": "извинять"
+            },
+            {
+              "word": "versöhnen",
+              "translation": "примирять"
             }
           ],
           "antonyms": [
             {
-              "word": "rächen",
-              "translation": "мстити"
+              "word": "bestrafen",
+              "translation": "карать, карать, наказывать"
             },
             {
-              "word": "bestrafen",
-              "translation": "карати"
+              "word": "verfluchen",
+              "translation": "проклинать"
+            },
+            {
+              "word": "verurteilen",
+              "translation": "осуждать"
             }
           ],
           "narration": "Від прощать через контрасти до розуміння."

--- a/data/characters/goneril.json
+++ b/data/characters/goneril.json
@@ -180,16 +180,16 @@
           },
           "synonyms": [
             {
-              "word": "die Heuchelei",
-              "translation": "лицемерие"
-            },
-            {
-              "word": "der Betrug",
+              "word": "die Täuschung",
               "translation": "обман"
             },
             {
-              "word": "die Täuschung",
-              "translation": "заблуждение"
+              "word": "die Intrige",
+              "translation": "интрига"
+            },
+            {
+              "word": "belügen",
+              "translation": "лгать"
             }
           ],
           "antonyms": [
@@ -198,8 +198,12 @@
               "translation": "правда"
             },
             {
-              "word": "die Ehrlichkeit",
-              "translation": "честность"
+              "word": "aufrichtig",
+              "translation": "искренний"
+            },
+            {
+              "word": "die Treue",
+              "translation": "верность"
             }
           ],
           "narration": "Гонерилья мастерски использует ложь для достижения целей."
@@ -214,19 +218,32 @@
           },
           "synonyms": [
             {
-              "word": "geloben",
-              "translation": "присягать"
-            },
-            {
               "word": "versprechen",
               "translation": "обещать"
             },
             {
-              "word": "beschwören",
-              "translation": "заклясться"
+              "word": "verkünden",
+              "translation": "провозглашать"
+            },
+            {
+              "word": "drohen",
+              "translation": "угрожать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "brechen",
+              "translation": "ломать"
+            },
+            {
+              "word": "lügen",
+              "translation": "лгать"
+            },
+            {
+              "word": "widerrufen",
+              "translation": "отменять"
+            }
+          ],
           "narration": "Від клясться через контрасти до розуміння."
         }
       ],
@@ -453,25 +470,29 @@
           "synonyms": [
             {
               "word": "die Herrschaft",
-              "translation": "господство"
+              "translation": "господство, господство, правление, правление"
             },
             {
-              "word": "die Gewalt",
-              "translation": "сила"
+              "word": "der Befehl",
+              "translation": "приказ"
             },
             {
-              "word": "die Autorität",
-              "translation": "авторитет"
+              "word": "herrschen",
+              "translation": "править"
             }
           ],
           "antonyms": [
             {
               "word": "die Schwäche",
-              "translation": "слабість"
+              "translation": "слабость"
             },
             {
-              "word": "die Ohnmacht",
-              "translation": "безсилля"
+              "word": "die Demut",
+              "translation": "смирение"
+            },
+            {
+              "word": "die Niederlage",
+              "translation": "поражение"
             }
           ],
           "narration": "Від власть через контрасти до розуміння."
@@ -487,25 +508,29 @@
           "synonyms": [
             {
               "word": "regieren",
-              "translation": "керувати"
+              "translation": "править, править, управлять, управлять"
             },
             {
-              "word": "befehlen",
-              "translation": "наказувати"
+              "word": "beherrschen",
+              "translation": "владеть, господствовать, господствовать"
             },
             {
-              "word": "dominieren",
-              "translation": "домінувати"
+              "word": "führen",
+              "translation": "вести"
             }
           ],
           "antonyms": [
             {
-              "word": "gehorchen",
-              "translation": "підкорятися"
+              "word": "dienen",
+              "translation": "служить"
             },
             {
-              "word": "dienen",
-              "translation": "служити"
+              "word": "folgen",
+              "translation": "следовать"
+            },
+            {
+              "word": "gehorchen",
+              "translation": "повиноваться, повиноваться, подчиняться"
             }
           ],
           "narration": "Від править через контрасти до розуміння."
@@ -715,15 +740,28 @@
               "translation": "унижать"
             },
             {
-              "word": "beleidigen",
-              "translation": "оскорблять"
+              "word": "verhöhnen",
+              "translation": "высмеивать, высмеивать, насмехаться, насмехаться"
             },
             {
-              "word": "herabsetzen",
-              "translation": "принижать"
+              "word": "beleidigen",
+              "translation": "оскорблять"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "ehren",
+              "translation": "чтить"
+            },
+            {
+              "word": "achten",
+              "translation": "уважать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від унижать через контрасти до розуміння."
         },
         {
@@ -736,19 +774,32 @@
           },
           "synonyms": [
             {
-              "word": "brutal",
-              "translation": "жестокий"
+              "word": "erbarmungslos",
+              "translation": "беспощадный"
             },
             {
               "word": "gnadenlos",
               "translation": "безжалостный"
             },
             {
-              "word": "unbarmherzig",
-              "translation": "свирепый"
+              "word": "die Härte",
+              "translation": "жёсткость, жёсткость, суровость, суровость"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "mild",
+              "translation": "мягкий"
+            },
+            {
+              "word": "die Güte",
+              "translation": "доброта"
+            },
+            {
+              "word": "die Liebe",
+              "translation": "любовь"
+            }
+          ],
           "narration": "Від жестокий через контрасти до розуміння."
         }
       ]
@@ -933,19 +984,32 @@
           },
           "synonyms": [
             {
+              "word": "verbannen",
+              "translation": "изгнать, изгнать, изгонять"
+            },
+            {
               "word": "vertreiben",
-              "translation": "изгонять"
+              "translation": "изгонять, изгонять, прогонять"
             },
             {
               "word": "abweisen",
               "translation": "отвергать"
-            },
-            {
-              "word": "verleugnen",
-              "translation": "отрекаться"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "zurückkehren",
+              "translation": "возвращаться"
+            },
+            {
+              "word": "halten",
+              "translation": "держать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від отвергать через контрасти до розуміння."
         },
         {
@@ -958,26 +1022,30 @@
           },
           "synonyms": [
             {
-              "word": "das Unwetter",
-              "translation": "негода"
+              "word": "der Donner",
+              "translation": "гром"
             },
             {
-              "word": "der Orkan",
-              "translation": "ураган"
+              "word": "der Regen",
+              "translation": "дождь"
             },
             {
-              "word": "das Gewitter",
-              "translation": "гроза"
+              "word": "die Kälte",
+              "translation": "холод"
             }
           ],
           "antonyms": [
             {
-              "word": "die Stille",
-              "translation": "тиша"
+              "word": "die Sonne",
+              "translation": "солнце"
             },
             {
-              "word": "die Windstille",
-              "translation": "штиль"
+              "word": "die Ruhe",
+              "translation": "покой"
+            },
+            {
+              "word": "der Schutz",
+              "translation": "защита"
             }
           ],
           "narration": "Від буря через контрасти до розуміння."
@@ -1183,19 +1251,32 @@
           },
           "synonyms": [
             {
-              "word": "zanken",
-              "translation": "ссориться"
+              "word": "kämpfen",
+              "translation": "бороться, бороться, сражаться, сражаться"
             },
             {
-              "word": "schimpfen",
-              "translation": "ругаться"
+              "word": "rivalisieren",
+              "translation": "соперничать"
             },
             {
-              "word": "hadern",
-              "translation": "препираться"
+              "word": "schreien",
+              "translation": "кричать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "versöhnen",
+              "translation": "примирять"
+            },
+            {
+              "word": "vergeben",
+              "translation": "прощать"
+            },
+            {
+              "word": "umarmen",
+              "translation": "обнимать"
+            }
+          ],
           "narration": "Від ссориться через контрасти до розуміння."
         },
         {
@@ -1208,19 +1289,32 @@
           },
           "synonyms": [
             {
-              "word": "hintergehen",
-              "translation": "предавать"
-            },
-            {
-              "word": "preisgeben",
+              "word": "ausliefern",
               "translation": "выдавать"
             },
             {
-              "word": "betrügen",
-              "translation": "изменять"
+              "word": "verkaufen",
+              "translation": "продавать"
+            },
+            {
+              "word": "enthüllen",
+              "translation": "разоблачать, разоблачать, раскрывать, раскрывать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            },
+            {
+              "word": "treu",
+              "translation": "верный"
+            },
+            {
+              "word": "verteidigen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від предавать через контрасти до розуміння."
         }
       ]
@@ -1425,18 +1519,31 @@
           "synonyms": [
             {
               "word": "der Neid",
-              "translation": "ревность"
-            },
-            {
-              "word": "die Missgunst",
               "translation": "зависть"
             },
             {
-              "word": "der Argwohn",
-              "translation": "подозрение"
+              "word": "die Rivalität",
+              "translation": "соперничество"
+            },
+            {
+              "word": "die Gier",
+              "translation": "жадность"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Treue",
+              "translation": "верность"
+            },
+            {
+              "word": "die Liebe",
+              "translation": "любовь"
+            },
+            {
+              "word": "die Freundschaft",
+              "translation": "дружба"
+            }
+          ],
           "narration": "Від ревность через контрасти до розуміння."
         },
         {
@@ -1449,19 +1556,32 @@
           },
           "synonyms": [
             {
-              "word": "konkurrieren",
-              "translation": "соперничать"
-            },
-            {
-              "word": "wetteifern",
-              "translation": "конкурировать"
-            },
-            {
               "word": "kämpfen",
-              "translation": "бороться"
+              "translation": "бороться, бороться, сражаться, сражаться"
+            },
+            {
+              "word": "streiten",
+              "translation": "спорить, ссориться, ссориться"
+            },
+            {
+              "word": "wettkämpfen",
+              "translation": "соревноваться"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "versöhnen",
+              "translation": "примирять"
+            },
+            {
+              "word": "verbinden",
+              "translation": "соединять"
+            },
+            {
+              "word": "vereinen",
+              "translation": "объединять"
+            }
+          ],
           "narration": "Від соперничать через контрасти до розуміння."
         }
       ]
@@ -1665,19 +1785,32 @@
           },
           "synonyms": [
             {
-              "word": "giftmischen",
-              "translation": "отравлять"
+              "word": "töten",
+              "translation": "убивать"
             },
             {
-              "word": "intoxizieren",
-              "translation": "травить"
+              "word": "vernichten",
+              "translation": "уничтожать"
             },
             {
-              "word": "schädigen",
-              "translation": "поражать"
+              "word": "verderben",
+              "translation": "портить"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "heilen",
+              "translation": "исцелять"
+            },
+            {
+              "word": "retten",
+              "translation": "спасать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від отравлять через контрасти до розуміння."
         },
         {
@@ -1690,26 +1823,30 @@
           },
           "synonyms": [
             {
-              "word": "die Hoffnungslosigkeit",
-              "translation": "безнадія"
+              "word": "die Angst",
+              "translation": "страх"
             },
             {
-              "word": "die Trostlosigkeit",
-              "translation": "безвихідь"
+              "word": "das Elend",
+              "translation": "нищета"
             },
             {
-              "word": "die Depression",
-              "translation": "депресія"
+              "word": "die Trauer",
+              "translation": "печаль, печаль, скорбь, скорбь"
             }
           ],
           "antonyms": [
             {
               "word": "die Hoffnung",
-              "translation": "надія"
+              "translation": "надежда"
             },
             {
-              "word": "der Optimismus",
-              "translation": "оптимізм"
+              "word": "vertrauen",
+              "translation": "доверять"
+            },
+            {
+              "word": "die Freude",
+              "translation": "радость"
             }
           ],
           "narration": "Від отчаяние через контрасти до розуміння."

--- a/data/characters/kent.json
+++ b/data/characters/kent.json
@@ -739,26 +739,30 @@
           },
           "synonyms": [
             {
-              "word": "das Unwetter",
-              "translation": "негода"
+              "word": "der Donner",
+              "translation": "гром"
             },
             {
-              "word": "der Orkan",
-              "translation": "ураган"
+              "word": "der Regen",
+              "translation": "дождь"
             },
             {
-              "word": "das Gewitter",
-              "translation": "гроза"
+              "word": "die Kälte",
+              "translation": "холод"
             }
           ],
           "antonyms": [
             {
-              "word": "die Stille",
-              "translation": "тиша"
+              "word": "die Sonne",
+              "translation": "солнце"
             },
             {
-              "word": "die Windstille",
-              "translation": "штиль"
+              "word": "die Ruhe",
+              "translation": "покой"
+            },
+            {
+              "word": "der Schutz",
+              "translation": "защита"
             }
           ],
           "narration": "Від буря через контрасти до розуміння."

--- a/data/characters/king_lear.json
+++ b/data/characters/king_lear.json
@@ -181,15 +181,15 @@
           "synonyms": [
             {
               "word": "die Herrschaft",
-              "translation": "господство"
+              "translation": "господство, господство, правление, правление"
             },
             {
-              "word": "die Gewalt",
-              "translation": "сила"
+              "word": "der Befehl",
+              "translation": "приказ"
             },
             {
-              "word": "die Stärke",
-              "translation": "мощь"
+              "word": "herrschen",
+              "translation": "править"
             }
           ],
           "antonyms": [
@@ -198,8 +198,12 @@
               "translation": "слабость"
             },
             {
-              "word": "die Ohnmacht",
-              "translation": "бессилие"
+              "word": "die Demut",
+              "translation": "смирение"
+            },
+            {
+              "word": "die Niederlage",
+              "translation": "поражение"
             }
           ],
           "narration": "От абсолютной власти к полному бессилию."
@@ -214,19 +218,32 @@
           },
           "synonyms": [
             {
-              "word": "der Herrschersitz",
-              "translation": "престол"
+              "word": "die Krone",
+              "translation": "корона"
             },
             {
-              "word": "der Königsstuhl",
-              "translation": "царское место"
+              "word": "die Herrschaft",
+              "translation": "господство, господство, правление, правление"
             },
             {
-              "word": "der Thronsessel",
-              "translation": "королевское кресло"
+              "word": "der König",
+              "translation": "король"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Verbannung",
+              "translation": "изгнание"
+            },
+            {
+              "word": "das Elend",
+              "translation": "нищета"
+            },
+            {
+              "word": "der Bettler",
+              "translation": "нищий"
+            }
+          ],
           "narration": "Від трон через контрасти до розуміння."
         },
         {
@@ -240,18 +257,31 @@
           "synonyms": [
             {
               "word": "das Reich",
-              "translation": "царство"
+              "translation": "империя"
             },
             {
-              "word": "der Staat",
-              "translation": "держава"
+              "word": "das Land",
+              "translation": "страна"
             },
             {
-              "word": "das Imperium",
-              "translation": "государство"
+              "word": "die Herrschaft",
+              "translation": "господство, господство, правление, правление"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Verbannung",
+              "translation": "изгнание"
+            },
+            {
+              "word": "das Chaos",
+              "translation": "хаос"
+            },
+            {
+              "word": "das Elend",
+              "translation": "нищета"
+            }
+          ],
           "narration": "Від королевство через контрасти до розуміння."
         }
       ],
@@ -477,19 +507,32 @@
           },
           "synonyms": [
             {
+              "word": "erniedrigen",
+              "translation": "унижать"
+            },
+            {
+              "word": "verhöhnen",
+              "translation": "высмеивать, высмеивать, насмехаться, насмехаться"
+            },
+            {
               "word": "beleidigen",
               "translation": "оскорблять"
-            },
-            {
-              "word": "beschämen",
-              "translation": "позорить"
-            },
-            {
-              "word": "erniedrigen",
-              "translation": "уничижать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "ehren",
+              "translation": "чтить"
+            },
+            {
+              "word": "achten",
+              "translation": "уважать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від унижать через контрасти до розуміння."
         },
         {
@@ -503,25 +546,29 @@
           "synonyms": [
             {
               "word": "die Wut",
-              "translation": "лють"
+              "translation": "ярость"
             },
             {
-              "word": "der Ärger",
-              "translation": "злість"
+              "word": "der Hass",
+              "translation": "ненависть"
             },
             {
-              "word": "die Rage",
-              "translation": "шаленість"
+              "word": "die Bosheit",
+              "translation": "злоба"
             }
           ],
           "antonyms": [
             {
-              "word": "die Ruhe",
-              "translation": "спокій"
+              "word": "der Friede",
+              "translation": "мир"
             },
             {
-              "word": "der Frieden",
-              "translation": "мир"
+              "word": "die Vergebung",
+              "translation": "прощение"
+            },
+            {
+              "word": "die Ruhe",
+              "translation": "покой"
             }
           ],
           "narration": "Від гнев через контрасти до розуміння."
@@ -727,19 +774,32 @@
           },
           "synonyms": [
             {
-              "word": "zurücklassen",
-              "translation": "оставлять"
+              "word": "aufgeben",
+              "translation": "сдаваться"
             },
             {
-              "word": "fortgehen",
-              "translation": "уходить"
+              "word": "entfliehen",
+              "translation": "убегать"
             },
             {
-              "word": "im Stich lassen",
-              "translation": "бросать"
+              "word": "fliehen",
+              "translation": "бежать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "zurückkehren",
+              "translation": "возвращаться"
+            },
+            {
+              "word": "bleiben",
+              "translation": "оставаться"
+            },
+            {
+              "word": "behalten",
+              "translation": "сохранять"
+            }
+          ],
           "narration": "Від покидать через контрасти до розуміння."
         },
         {
@@ -752,19 +812,32 @@
           },
           "synonyms": [
             {
-              "word": "verleugnen",
-              "translation": "отрекаться"
+              "word": "verbannen",
+              "translation": "изгнать, изгнать, изгонять"
             },
             {
               "word": "vertreiben",
-              "translation": "изгонять"
+              "translation": "изгонять, изгонять, прогонять"
             },
             {
               "word": "abweisen",
-              "translation": "отталкивать"
+              "translation": "отвергать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "zurückkehren",
+              "translation": "возвращаться"
+            },
+            {
+              "word": "halten",
+              "translation": "держать"
+            },
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            }
+          ],
           "narration": "Від отвергать через контрасти до розуміння."
         }
       ]
@@ -968,26 +1041,30 @@
           },
           "synonyms": [
             {
-              "word": "das Unwetter",
-              "translation": "негода"
+              "word": "der Donner",
+              "translation": "гром"
             },
             {
-              "word": "der Orkan",
-              "translation": "ураган"
+              "word": "der Regen",
+              "translation": "дождь"
             },
             {
-              "word": "das Gewitter",
-              "translation": "гроза"
+              "word": "die Kälte",
+              "translation": "холод"
             }
           ],
           "antonyms": [
             {
-              "word": "die Stille",
-              "translation": "тиша"
+              "word": "die Sonne",
+              "translation": "солнце"
             },
             {
-              "word": "die Windstille",
-              "translation": "штиль"
+              "word": "die Ruhe",
+              "translation": "покой"
+            },
+            {
+              "word": "der Schutz",
+              "translation": "защита"
             }
           ],
           "narration": "Від буря через контрасти до розуміння."
@@ -1002,26 +1079,30 @@
           },
           "synonyms": [
             {
-              "word": "die Verrücktheit",
-              "translation": "божевілля"
+              "word": "das Chaos",
+              "translation": "хаос"
             },
             {
-              "word": "der Irrsinn",
-              "translation": "безумство"
+              "word": "das Entsetzen",
+              "translation": "ужас"
             },
             {
-              "word": "die Geisteskrankheit",
-              "translation": "психічна хвороба"
+              "word": "die Verzweiflung",
+              "translation": "отчаяние"
             }
           ],
           "antonyms": [
             {
               "word": "die Vernunft",
-              "translation": "розум"
+              "translation": "разум"
             },
             {
-              "word": "die Klarheit",
-              "translation": "ясність"
+              "word": "die Weisheit",
+              "translation": "мудрость"
+            },
+            {
+              "word": "die Ordnung",
+              "translation": "порядок"
             }
           ],
           "narration": "Від безумие через контрасти до розуміння."
@@ -1227,19 +1308,32 @@
           },
           "synonyms": [
             {
-              "word": "die Armut",
-              "translation": "бедность"
+              "word": "das Leid",
+              "translation": "страдание"
             },
             {
-              "word": "die Dürftigkeit",
-              "translation": "убожество"
+              "word": "die Not",
+              "translation": "нужда"
             },
             {
-              "word": "die Entbehrung",
-              "translation": "лишения"
+              "word": "das Unglück",
+              "translation": "несчастье"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "die Freude",
+              "translation": "радость"
+            },
+            {
+              "word": "die Hoffnung",
+              "translation": "надежда"
+            },
+            {
+              "word": "der Trost",
+              "translation": "утешение"
+            }
+          ],
           "narration": "Від нищета через контрасти до розуміння."
         },
         {
@@ -1252,19 +1346,32 @@
           },
           "synonyms": [
             {
-              "word": "der Bettelmann",
-              "translation": "попрошайка"
+              "word": "betteln",
+              "translation": "просить, просить, умолять, умолять"
             },
             {
-              "word": "der Arme",
-              "translation": "бедняк"
+              "word": "die Not",
+              "translation": "нужда"
             },
             {
-              "word": "der Landstreicher",
-              "translation": "оборванец"
+              "word": "das Elend",
+              "translation": "нищета"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "der König",
+              "translation": "король"
+            },
+            {
+              "word": "die Krone",
+              "translation": "корона"
+            },
+            {
+              "word": "der Thron",
+              "translation": "трон"
+            }
+          ],
           "narration": "Від нищий через контрасти до розуміння."
         }
       ]
@@ -1468,19 +1575,32 @@
           },
           "synonyms": [
             {
-              "word": "identifizieren",
-              "translation": "опознавать"
+              "word": "begreifen",
+              "translation": "понимать"
             },
             {
-              "word": "wiedererkennen",
-              "translation": "распознавать"
+              "word": "wahrnehmen",
+              "translation": "воспринимать"
             },
             {
-              "word": "anerkennen",
-              "translation": "признавать"
+              "word": "entdecken",
+              "translation": "обнаруживать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "vergessen",
+              "translation": "забывать"
+            },
+            {
+              "word": "abweisen",
+              "translation": "отвергать"
+            },
+            {
+              "word": "verbergen",
+              "translation": "скрывать"
+            }
+          ],
           "narration": "Від узнавать через контрасти до розуміння."
         },
         {
@@ -1494,18 +1614,31 @@
           "synonyms": [
             {
               "word": "begreifen",
-              "translation": "постигать"
+              "translation": "понимать"
             },
             {
-              "word": "erfassen",
-              "translation": "осознавать"
+              "word": "erkennen",
+              "translation": "познавать, познавать, узнавать, узнавать"
             },
             {
-              "word": "einsehen",
-              "translation": "уразумевать"
+              "word": "wissen",
+              "translation": "знать"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "vergessen",
+              "translation": "забывать"
+            },
+            {
+              "word": "verwirren",
+              "translation": "смущать"
+            },
+            {
+              "word": "abweisen",
+              "translation": "отвергать"
+            }
+          ],
           "narration": "Від понимать через контрасти до розуміння."
         }
       ]
@@ -1709,19 +1842,32 @@
           },
           "synonyms": [
             {
+              "word": "vergeben",
+              "translation": "прощать"
+            },
+            {
               "word": "entschuldigen",
               "translation": "извинять"
             },
             {
-              "word": "vergeben",
-              "translation": "отпускать"
-            },
-            {
-              "word": "begnadigen",
-              "translation": "миловать"
+              "word": "versöhnen",
+              "translation": "примирять"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "bestrafen",
+              "translation": "карать, карать, наказывать"
+            },
+            {
+              "word": "anklagen",
+              "translation": "обвинять"
+            },
+            {
+              "word": "verurteilen",
+              "translation": "осуждать"
+            }
+          ],
           "narration": "Від прощать через контрасти до розуміння."
         },
         {
@@ -1734,19 +1880,32 @@
           },
           "synonyms": [
             {
-              "word": "das Ableben",
-              "translation": "кончина"
+              "word": "das Ende",
+              "translation": "конец"
             },
             {
-              "word": "der Exitus",
-              "translation": "гибель"
+              "word": "das Grab",
+              "translation": "могила"
             },
             {
-              "word": "das Lebensende",
-              "translation": "уход"
+              "word": "der Abschied",
+              "translation": "прощание"
             }
           ],
-          "antonyms": [],
+          "antonyms": [
+            {
+              "word": "das Leben",
+              "translation": "жизнь"
+            },
+            {
+              "word": "die Hoffnung",
+              "translation": "надежда"
+            },
+            {
+              "word": "die Erlösung",
+              "translation": "спасение"
+            }
+          ],
           "narration": "Від смерть через контрасти до розуміння."
         }
       ]

--- a/data/characters/oswald.json
+++ b/data/characters/oswald.json
@@ -485,7 +485,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "spy_verraten",
+          "title": "Семантическое поле: предавать",
+          "target": {
+            "word": "verraten",
+            "translation": "предавать",
+            "hint": "шпионские предательства Освальда"
+          },
+          "synonyms": [
+            {
+              "word": "ausliefern",
+              "translation": "выдавать"
+            },
+            {
+              "word": "verkaufen",
+              "translation": "продавать"
+            },
+            {
+              "word": "enthüllen",
+              "translation": "разоблачать, разоблачать, раскрывать, раскрывать"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "beschützen",
+              "translation": "защищать"
+            },
+            {
+              "word": "treu",
+              "translation": "верный"
+            },
+            {
+              "word": "verteidigen",
+              "translation": "защищать"
+            }
+          ],
+          "narration": "От предавать через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "schemer",
@@ -614,7 +653,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "schemer_die_luege",
+          "title": "Семантическое поле: ложь",
+          "target": {
+            "word": "die Lüge",
+            "translation": "ложь",
+            "hint": "расчётливые обманы слуги"
+          },
+          "synonyms": [
+            {
+              "word": "die Täuschung",
+              "translation": "обман"
+            },
+            {
+              "word": "die Intrige",
+              "translation": "интрига"
+            },
+            {
+              "word": "belügen",
+              "translation": "лгать"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "die Wahrheit",
+              "translation": "правда"
+            },
+            {
+              "word": "aufrichtig",
+              "translation": "искренний"
+            },
+            {
+              "word": "die Treue",
+              "translation": "верность"
+            }
+          ],
+          "narration": "От ложь через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "pursuer",

--- a/data/characters/regan.json
+++ b/data/characters/regan.json
@@ -242,7 +242,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "goneril_die_macht",
+          "title": "Семантическое поле: власть",
+          "target": {
+            "word": "die Macht",
+            "translation": "власть",
+            "hint": "жажда власти сестёр"
+          },
+          "synonyms": [
+            {
+              "word": "die Herrschaft",
+              "translation": "господство, господство, правление, правление"
+            },
+            {
+              "word": "der Befehl",
+              "translation": "приказ"
+            },
+            {
+              "word": "herrschen",
+              "translation": "править"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "die Schwäche",
+              "translation": "слабость"
+            },
+            {
+              "word": "die Demut",
+              "translation": "смирение"
+            },
+            {
+              "word": "die Niederlage",
+              "translation": "поражение"
+            }
+          ],
+          "narration": "От власть через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "regan",
@@ -369,7 +408,46 @@
           "correct_index": 3
         }
       ],
-      "synonym_antonym_sets": []
+      "synonym_antonym_sets": [
+        {
+          "id": "regan_grausam",
+          "title": "Семантическое поле: жестокий",
+          "target": {
+            "word": "grausam",
+            "translation": "жестокий",
+            "hint": "холодная жестокость Реганы"
+          },
+          "synonyms": [
+            {
+              "word": "erbarmungslos",
+              "translation": "беспощадный"
+            },
+            {
+              "word": "gnadenlos",
+              "translation": "безжалостный"
+            },
+            {
+              "word": "die Härte",
+              "translation": "жёсткость, жёсткость, суровость, суровость"
+            }
+          ],
+          "antonyms": [
+            {
+              "word": "mild",
+              "translation": "мягкий"
+            },
+            {
+              "word": "die Güte",
+              "translation": "доброта"
+            },
+            {
+              "word": "die Liebe",
+              "translation": "любовь"
+            }
+          ],
+          "narration": "От жестокий через контрасты к пониманию."
+        }
+      ]
     },
     {
       "id": "storm",


### PR DESCRIPTION
## Summary
- Replace all character synonym and antonym entries with vocabulary-sourced German words while guaranteeing at least three synonyms and two antonyms
- Add new semantic field sets for Albany, Regan, and Oswald so their arcs now include vocabulary-backed contrasts

## Testing
- python - <<'PY'
import json, glob
for path in glob.glob('data/characters/*.json'):
    with open(path, encoding='utf-8') as f:
        json.load(f)
print('validated', len(list(glob.glob('data/characters/*.json'))), 'files')
PY


------
https://chatgpt.com/codex/tasks/task_e_68d248cb74e883208c5181e860a893d8