### PR TITLE
Refactor vocabulary cards rendering

### DIFF
--- a/generators/mnemonics_gen.py
+++ b/generators/mnemonics_gen.py
@@ -548,59 +548,7 @@ class MnemonicsGenerator:
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-"""
-        
-        # Отримуємо слова конкретної фази
-        if phase_id:
-            vocabulary = self.get_phase_vocabulary(character_data, phase_id)
-        else:
-            # Якщо phase_id не вказано - беремо першу фазу
-            phases = character_data.get('journey_phases', [])
-            vocabulary = phases[0].get('vocabulary', []) if phases else []
-        
-        # Генеруємо картки для кожного слова
-        for word in vocabulary:
-            german = word['german']
-            article = self.extract_article(german)
-            color_data = self.GENDER_COLORS.get(article)
-
-            if color_data:
-                card_class = f"is-{article}"
-                word_display = german.replace(f"{article} ", "", 1)
-                badge_html = ''.join([
-                    f'<span class="article-chip {article}">',
-                    f'<span class="article-icon">{color_data["icon"]}</span>',
-                    f'<span>{article}</span>',
-                    '</span>'
-                ])
-                data_article = article
-            else:
-                card_class = "is-neutral"
-                word_display = german
-                neutral_label = word.get('part_of_speech') or word.get('pos') or word.get('type')
-                if neutral_label:
-                    label_text = neutral_label
-                else:
-                    label_text = "лексика без артикля"
-                badge_html = f'<span class="word-type-chip">{label_text}</span>'
-                data_article = ""
-
-            data_article_attr = f" data-article=\"{data_article}\"" if data_article else ""
-
-            html += f"""
-        <div class=\"vocab-card {card_class}\" data-word=\"{word_display}\"{data_article_attr}>
-            <div class=\"vocab-header\">
-                {badge_html}
-                <div class=\"vocab-word\">{word_display}</div>
-            </div>
-            <div class=\"vocab-translation\">{word['russian']}</div>
-            <div class=\"vocab-transcription\">{word['transcription']}</div>
-        </div>
-"""
-        
-        html += """
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 """
         return html

--- a/output/journeys/albany.html
+++ b/output/journeys/albany.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-das" data-word="Schweigen" data-article="das">
-            <div class="vocab-header">
-                <span class="article-chip das"><span class="article-icon">⚪</span><span>das</span></span>
-                <div class="vocab-word">Schweigen</div>
-            </div>
-            <div class="vocab-translation">молчание</div>
-            <div class="vocab-transcription">[дас ШВАЙ-ген]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Schwäche" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Schwäche</div>
-            </div>
-            <div class="vocab-translation">слабость</div>
-            <div class="vocab-transcription">[ди ШВЕ-хе]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Ehe" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Ehe</div>
-            </div>
-            <div class="vocab-translation">брак</div>
-            <div class="vocab-transcription">[ди Э-е]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="dulden">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">dulden</div>
-            </div>
-            <div class="vocab-translation">терпеть</div>
-            <div class="vocab-transcription">[ДУЛЬ-ден]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="passiv">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">passiv</div>
-            </div>
-            <div class="vocab-translation">пассивный</div>
-            <div class="vocab-transcription">[па-СИФ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="nachgeben">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">nachgeben</div>
-            </div>
-            <div class="vocab-translation">уступать</div>
-            <div class="vocab-transcription">[НАХ-ге-бен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="zögern">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">zögern</div>
-            </div>
-            <div class="vocab-translation">колебаться</div>
-            <div class="vocab-transcription">[ЦЁ-герн]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="mild">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">mild</div>
-            </div>
-            <div class="vocab-translation">мягкий</div>
-            <div class="vocab-transcription">[МИЛЬД]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1917,81 +1843,81 @@
                 "question": "Что означает немецкое слово «das Schweigen»?",
                 "choices": [
                     "брак",
+                    "молчание",
                     "слабость",
-                    "терпеть",
-                    "молчание"
+                    "терпеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schwäche»?",
                 "choices": [
-                    "слабость",
-                    "терпеть",
                     "брак",
-                    "молчание"
+                    "слабость",
+                    "молчание",
+                    "терпеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ehe»?",
                 "choices": [
-                    "пассивный",
-                    "слабость",
+                    "колебаться",
+                    "уступать",
                     "брак",
-                    "молчание"
+                    "пассивный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dulden»?",
                 "choices": [
+                    "уступать",
                     "терпеть",
-                    "колебаться",
+                    "пассивный",
+                    "мягкий"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «passiv»?",
+                "choices": [
+                    "пассивный",
+                    "брак",
                     "молчание",
                     "мягкий"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «passiv»?",
-                "choices": [
-                    "колебаться",
-                    "слабость",
-                    "пассивный",
-                    "терпеть"
-                ],
-                "correctIndex": 2
-            },
-            {
                 "question": "Что означает немецкое слово «nachgeben»?",
                 "choices": [
-                    "пассивный",
-                    "слабость",
-                    "мягкий",
-                    "уступать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «zögern»?",
-                "choices": [
-                    "терпеть",
                     "колебаться",
-                    "молчание",
-                    "слабость"
+                    "уступать",
+                    "слабость",
+                    "молчание"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «mild»?",
+                "question": "Что означает немецкое слово «zögern»?",
                 "choices": [
-                    "колебаться",
-                    "пассивный",
+                    "мягкий",
                     "терпеть",
-                    "мягкий"
+                    "молчание",
+                    "колебаться"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «mild»?",
+                "choices": [
+                    "терпеть",
+                    "молчание",
+                    "мягкий",
+                    "колебаться"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2636,50 +2562,50 @@
             {
                 "question": "Что означает немецкое слово «der Zweifel»?",
                 "choices": [
-                    "беспокойство",
-                    "сомнение",
                     "совесть",
-                    "подвергать сомнению"
+                    "подвергать сомнению",
+                    "сомнение",
+                    "беспокойство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Gewissen»?",
                 "choices": [
-                    "совесть",
-                    "сомнение",
                     "беспокойство",
-                    "подвергать сомнению"
+                    "сомнение",
+                    "подвергать сомнению",
+                    "совесть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Unbehagen»?",
                 "choices": [
-                    "неуверенный",
+                    "подвергать сомнению",
                     "сомнение",
-                    "беспокойство",
-                    "тревожить"
+                    "тревожить",
+                    "беспокойство"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hinterfragen»?",
                 "choices": [
-                    "тревожить",
-                    "беспокойство",
+                    "размышлять",
                     "подвергать сомнению",
-                    "неуверенный"
+                    "сомнение",
+                    "совесть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beunruhigen»?",
                 "choices": [
+                    "сомнение",
                     "совесть",
-                    "размышлять",
                     "тревожить",
-                    "сомнение"
+                    "беспокойство"
                 ],
                 "correctIndex": 2
             },
@@ -2687,18 +2613,18 @@
                 "question": "Что означает немецкое слово «unsicher»?",
                 "choices": [
                     "размышлять",
-                    "беспокойство",
                     "неуверенный",
-                    "подвергать сомнению"
+                    "тревожить",
+                    "сомнение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «grübeln»?",
                 "choices": [
-                    "беспокойство",
-                    "сомнение",
+                    "подвергать сомнению",
                     "тревожить",
+                    "совесть",
                     "размышлять"
                 ],
                 "correctIndex": 3
@@ -3415,71 +3341,71 @@
                 "question": "Что означает немецкое слово «das Entsetzen»?",
                 "choices": [
                     "пробуждаться",
-                    "ужас",
                     "понимать",
+                    "ужас",
                     "осознание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erwachen»?",
                 "choices": [
                     "ясно видеть",
-                    "понимать",
+                    "просыпаться",
                     "пробуждаться",
-                    "превращение"
+                    "ужас"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «begreifen»?",
                 "choices": [
-                    "просыпаться",
-                    "понимать",
                     "пробуждаться",
-                    "пугаться"
+                    "пугаться",
+                    "понимать",
+                    "ясно видеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «erschrecken»?",
                 "choices": [
-                    "превращение",
-                    "пугаться",
                     "просыпаться",
-                    "осознание"
+                    "ужас",
+                    "понимать",
+                    "пугаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «aufwachen»?",
                 "choices": [
-                    "понимать",
-                    "просыпаться",
                     "превращение",
-                    "пробуждаться"
+                    "пугаться",
+                    "осознание",
+                    "просыпаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «klar sehen»?",
                 "choices": [
-                    "понимать",
                     "превращение",
                     "ясно видеть",
-                    "осознание"
+                    "осознание",
+                    "ужас"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verwandlung»?",
                 "choices": [
-                    "пробуждаться",
-                    "пугаться",
+                    "просыпаться",
                     "превращение",
-                    "осознание"
+                    "пугаться",
+                    "понимать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4124,29 +4050,29 @@
             {
                 "question": "Что означает немецкое слово «der Streit»?",
                 "choices": [
-                    "мужество",
                     "спор",
-                    "противостоять",
-                    "сопротивление"
+                    "мужество",
+                    "сопротивление",
+                    "противостоять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "сопротивление",
                     "спор",
-                    "противостоять",
-                    "мужество"
+                    "мужество",
+                    "сопротивление",
+                    "противостоять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Widerstand»?",
                 "choices": [
-                    "восставать",
+                    "противостоять",
                     "сопротивление",
-                    "спор",
+                    "обвинять",
                     "мужество"
                 ],
                 "correctIndex": 1
@@ -4154,18 +4080,18 @@
             {
                 "question": "Что означает немецкое слово «konfrontieren»?",
                 "choices": [
+                    "противостоять",
                     "защищаться",
-                    "восставать",
                     "спор",
-                    "противостоять"
+                    "обвинять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «anklagen»?",
                 "choices": [
-                    "мужество",
-                    "защищаться",
+                    "восставать",
+                    "спор",
                     "обвинять",
                     "сопротивление"
                 ],
@@ -4174,22 +4100,22 @@
             {
                 "question": "Что означает немецкое слово «sich wehren»?",
                 "choices": [
+                    "защищаться",
+                    "обвинять",
                     "восставать",
-                    "сопротивление",
-                    "спор",
-                    "защищаться"
+                    "мужество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufbegehren»?",
                 "choices": [
+                    "восставать",
+                    "сопротивление",
                     "противостоять",
-                    "спор",
-                    "защищаться",
-                    "восставать"
+                    "обвинять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4897,32 +4823,32 @@
             {
                 "question": "Что означает немецкое слово «die Moral»?",
                 "choices": [
-                    "справедливость",
                     "выбирать",
+                    "решение",
                     "мораль",
-                    "решение"
+                    "справедливость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
-                    "справедливость",
                     "решение",
-                    "мораль",
-                    "выбирать"
+                    "выбирать",
+                    "справедливость",
+                    "мораль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Entscheidung»?",
                 "choices": [
+                    "справедливость",
+                    "принцип",
                     "добродетель",
-                    "решение",
-                    "праведный",
-                    "мораль"
+                    "решение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «wählen»?",
@@ -4930,49 +4856,49 @@
                     "принцип",
                     "добродетель",
                     "выбирать",
-                    "решение"
+                    "справедливость"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "благородный",
-                    "справедливость",
+                    "принцип",
                     "добродетель",
-                    "праведный"
+                    "праведный",
+                    "выбирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Prinzip»?",
                 "choices": [
-                    "благородный",
-                    "выбирать",
+                    "мораль",
                     "принцип",
-                    "справедливость"
+                    "благородный",
+                    "решение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «edel»?",
                 "choices": [
                     "благородный",
-                    "выбирать",
+                    "добродетель",
                     "справедливость",
-                    "решение"
+                    "выбирать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Tugend»?",
                 "choices": [
-                    "справедливость",
+                    "добродетель",
+                    "выбирать",
                     "мораль",
-                    "решение",
-                    "добродетель"
+                    "праведный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -5606,72 +5532,72 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
+                    "наказывать",
                     "право",
                     "борьба",
-                    "доброта",
-                    "наказывать"
+                    "доброта"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Recht»?",
                 "choices": [
+                    "доброта",
                     "право",
                     "наказывать",
-                    "доброта",
                     "борьба"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Güte»?",
                 "choices": [
-                    "судить",
                     "доброта",
-                    "защищать",
-                    "борьба"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «strafen»?",
-                "choices": [
                     "борьба",
-                    "наказывать",
-                    "доброта",
-                    "судить"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «richten»?",
-                "choices": [
-                    "право",
-                    "судить",
-                    "защищать",
-                    "доброта"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «beschützen»?",
-                "choices": [
-                    "защищать",
-                    "борьба",
-                    "судить",
+                    "вмешиваться",
                     "право"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «strafen»?",
+                "choices": [
+                    "борьба",
+                    "право",
+                    "наказывать",
+                    "доброта"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «richten»?",
+                "choices": [
+                    "право",
+                    "вмешиваться",
+                    "судить",
+                    "наказывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «beschützen»?",
+                "choices": [
+                    "право",
+                    "судить",
+                    "защищать",
+                    "вмешиваться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «eingreifen»?",
                 "choices": [
-                    "доброта",
-                    "вмешиваться",
-                    "наказывать",
-                    "борьба"
+                    "защищать",
+                    "судить",
+                    "право",
+                    "вмешиваться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6405,19 +6331,19 @@
             {
                 "question": "Что означает немецкое слово «die Herrschaft»?",
                 "choices": [
-                    "направлять",
-                    "новое начало",
                     "правление",
-                    "мудрость"
+                    "направлять",
+                    "мудрость",
+                    "новое начало"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "направлять",
-                    "правление",
                     "новое начало",
+                    "правление",
+                    "направлять",
                     "мудрость"
                 ],
                 "correctIndex": 3
@@ -6425,19 +6351,19 @@
             {
                 "question": "Что означает немецкое слово «der Neuanfang»?",
                 "choices": [
-                    "строить",
-                    "мир",
+                    "правление",
                     "новое начало",
-                    "обновлять"
+                    "строить",
+                    "направлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lenken»?",
                 "choices": [
                     "обновлять",
-                    "правление",
-                    "мир",
+                    "новое начало",
+                    "мудрость",
                     "направлять"
                 ],
                 "correctIndex": 3
@@ -6445,42 +6371,42 @@
             {
                 "question": "Что означает немецкое слово «aufbauen»?",
                 "choices": [
-                    "правление",
-                    "обновлять",
                     "строить",
-                    "новое начало"
+                    "мир",
+                    "мудрость",
+                    "направлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erneuern»?",
                 "choices": [
-                    "мудрость",
-                    "строить",
+                    "правление",
                     "новое начало",
-                    "обновлять"
+                    "обновлять",
+                    "примирять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «versöhnen»?",
                 "choices": [
-                    "правление",
-                    "обновлять",
+                    "примирять",
                     "мудрость",
-                    "примирять"
+                    "правление",
+                    "мир"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Friede»?",
                 "choices": [
-                    "новое начало",
-                    "мудрость",
-                    "направлять",
-                    "мир"
+                    "правление",
+                    "обновлять",
+                    "мир",
+                    "мудрость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -6621,6 +6547,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7513,6 +7469,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7588,71 +7741,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7660,7 +7758,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/cordelia.html
+++ b/output/journeys/cordelia.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-die" data-word="Wahrheit" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Wahrheit</div>
-            </div>
-            <div class="vocab-translation">правда</div>
-            <div class="vocab-transcription">[ди ВАР-хайт]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Zeremonie" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Zeremonie</div>
-            </div>
-            <div class="vocab-translation">церемония</div>
-            <div class="vocab-transcription">[ди це-ре-мо-НИ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="verkünden">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">verkünden</div>
-            </div>
-            <div class="vocab-translation">провозглашать</div>
-            <div class="vocab-transcription">[фер-КЮН-ден]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Macht" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Macht</div>
-            </div>
-            <div class="vocab-translation">власть</div>
-            <div class="vocab-transcription">[ди МАХТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="gehorchen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">gehorchen</div>
-            </div>
-            <div class="vocab-translation">повиноваться</div>
-            <div class="vocab-transcription">[ге-ХОР-хен]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Pflicht" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Pflicht</div>
-            </div>
-            <div class="vocab-translation">долг</div>
-            <div class="vocab-transcription">[ди ПФЛИХТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="feierlich">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">feierlich</div>
-            </div>
-            <div class="vocab-translation">торжественный</div>
-            <div class="vocab-transcription">[ФАЙ-ер-лих]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Treue" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Treue</div>
-            </div>
-            <div class="vocab-translation">верность</div>
-            <div class="vocab-transcription">[ди ТРОЙ-е]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1997,10 +1923,10 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "провозглашать",
+                    "церемония",
                     "правда",
-                    "власть",
-                    "церемония"
+                    "провозглашать",
+                    "власть"
                 ],
                 "correctIndex": 1
             },
@@ -2008,8 +1934,8 @@
                 "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
                     "провозглашать",
-                    "власть",
                     "правда",
+                    "власть",
                     "церемония"
                 ],
                 "correctIndex": 3
@@ -2017,62 +1943,62 @@
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "верность",
-                    "провозглашать",
-                    "долг",
-                    "церемония"
+                    "повиноваться",
+                    "правда",
+                    "власть",
+                    "провозглашать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
+                    "церемония",
                     "провозглашать",
-                    "повиноваться",
                     "власть",
-                    "правда"
+                    "верность"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gehorchen»?",
                 "choices": [
-                    "повиноваться",
-                    "правда",
-                    "верность",
-                    "церемония"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Pflicht»?",
-                "choices": [
+                    "власть",
                     "провозглашать",
-                    "повиноваться",
-                    "правда",
-                    "долг"
+                    "верность",
+                    "повиноваться"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «feierlich»?",
+                "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "торжественный",
+                    "долг",
+                    "провозглашать",
                     "правда",
-                    "повиноваться",
-                    "власть"
+                    "повиноваться"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Treue»?",
+                "question": "Что означает немецкое слово «feierlich»?",
                 "choices": [
                     "власть",
-                    "верность",
-                    "торжественный",
-                    "церемония"
+                    "долг",
+                    "правда",
+                    "торжественный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Treue»?",
+                "choices": [
+                    "церемония",
+                    "долг",
+                    "провозглашать",
+                    "верность"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2848,19 +2774,19 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
+                    "покидать",
                     "изгонять",
                     "гнев",
-                    "наказание",
-                    "покидать"
+                    "наказание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
                     "покидать",
-                    "наказание",
                     "изгонять",
+                    "наказание",
                     "гнев"
                 ],
                 "correctIndex": 0
@@ -2868,62 +2794,62 @@
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "гнев",
+                    "надежда",
                     "чужой",
-                    "покидать",
-                    "наказание"
+                    "гнев",
+                    "принимать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "наказание",
                     "чужой",
-                    "покидать",
-                    "изгонять"
+                    "наказание",
+                    "принимать",
+                    "покидать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fremd»?",
                 "choices": [
+                    "изгонять",
                     "чужой",
                     "гнев",
-                    "наказание",
-                    "приданое"
+                    "наказание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Mitgift»?",
                 "choices": [
-                    "наказание",
                     "приданое",
-                    "гнев",
-                    "изгонять"
+                    "изгонять",
+                    "покидать",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufnehmen»?",
                 "choices": [
                     "чужой",
-                    "наказание",
                     "принимать",
-                    "гнев"
+                    "изгонять",
+                    "покидать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Hoffnung»?",
                 "choices": [
-                    "наказание",
-                    "принимать",
-                    "чужой",
-                    "надежда"
+                    "надежда",
+                    "гнев",
+                    "покидать",
+                    "принимать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3699,49 +3625,49 @@
             {
                 "question": "Что означает немецкое слово «die Sorge»?",
                 "choices": [
-                    "забота",
+                    "страх",
                     "известие",
-                    "одиночество",
-                    "страх"
+                    "забота",
+                    "одиночество"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "одиночество",
                     "забота",
-                    "страх",
-                    "известие"
+                    "одиночество",
+                    "известие",
+                    "страх"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Nachricht»?",
                 "choices": [
-                    "молиться",
+                    "защищать",
                     "известие",
-                    "страдать",
-                    "страх"
+                    "страх",
+                    "тоска"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Angst»?",
                 "choices": [
+                    "страдать",
+                    "защищать",
                     "забота",
-                    "тоска",
-                    "страх",
-                    "молиться"
+                    "страх"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "страх",
-                    "одиночество",
-                    "молиться",
+                    "известие",
+                    "защищать",
+                    "тоска",
                     "страдать"
                 ],
                 "correctIndex": 3
@@ -3749,19 +3675,19 @@
             {
                 "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
+                    "молиться",
                     "забота",
-                    "одиночество",
-                    "известие",
-                    "защищать"
+                    "защищать",
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Sehnsucht»?",
                 "choices": [
+                    "известие",
                     "молиться",
-                    "одиночество",
-                    "страх",
+                    "забота",
                     "тоска"
                 ],
                 "correctIndex": 3
@@ -3769,12 +3695,12 @@
             {
                 "question": "Что означает немецкое слово «beten»?",
                 "choices": [
-                    "страх",
                     "молиться",
-                    "тоска",
+                    "известие",
+                    "страх",
                     "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4546,48 +4472,48 @@
             {
                 "question": "Что означает немецкое слово «zurückkehren»?",
                 "choices": [
-                    "битва",
                     "борьба",
-                    "возвращаться",
-                    "спасать"
+                    "спасать",
+                    "битва",
+                    "возвращаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
+                    "борьба",
                     "возвращаться",
                     "битва",
-                    "спасать",
-                    "борьба"
+                    "спасать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
-                    "армия",
-                    "битва",
-                    "справедливость",
-                    "спасать"
+                    "храбрый",
+                    "спасать",
+                    "борьба",
+                    "побеждать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Schlacht»?",
                 "choices": [
-                    "борьба",
                     "побеждать",
                     "битва",
-                    "храбрый"
+                    "храбрый",
+                    "борьба"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «mutig»?",
                 "choices": [
                     "борьба",
-                    "справедливость",
+                    "спасать",
                     "армия",
                     "храбрый"
                 ],
@@ -4596,29 +4522,29 @@
             {
                 "question": "Что означает немецкое слово «die Gerechtigkeit»?",
                 "choices": [
+                    "битва",
                     "справедливость",
                     "побеждать",
-                    "храбрый",
-                    "борьба"
+                    "возвращаться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «siegen»?",
                 "choices": [
-                    "побеждать",
-                    "битва",
                     "борьба",
-                    "справедливость"
+                    "справедливость",
+                    "храбрый",
+                    "побеждать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Armee»?",
                 "choices": [
+                    "борьба",
                     "побеждать",
-                    "битва",
-                    "спасать",
+                    "храбрый",
                     "армия"
                 ],
                 "correctIndex": 3
@@ -5411,80 +5337,80 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "слёзы",
                     "узнавать",
                     "прощать",
+                    "слёзы",
                     "обнимать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Tränen»?",
                 "choices": [
-                    "обнимать",
+                    "прощать",
                     "узнавать",
                     "слёзы",
-                    "прощать"
+                    "обнимать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
-                    "прощение",
-                    "прощать",
                     "обнимать",
-                    "нежный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «erkennen»?",
-                "choices": [
+                    "прощение",
                     "узнавать",
-                    "нежный",
-                    "прощать",
-                    "прощение"
+                    "слёзы"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «heilen»?",
+                "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "прощение",
+                    "узнавать",
                     "прощать",
-                    "исцелять",
-                    "нежный",
-                    "узнавать"
+                    "обнимать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Reue»?",
+                "question": "Что означает немецкое слово «heilen»?",
                 "choices": [
-                    "прощать",
                     "слёзы",
-                    "узнавать",
-                    "раскаяние"
+                    "обнимать",
+                    "прощать",
+                    "исцелять"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Reue»?",
+                "choices": [
+                    "прощение",
+                    "прощать",
+                    "раскаяние",
+                    "слёзы"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sanft»?",
                 "choices": [
                     "прощать",
-                    "обнимать",
-                    "нежный",
-                    "исцелять"
+                    "раскаяние",
+                    "узнавать",
+                    "нежный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Vergebung»?",
                 "choices": [
-                    "нежный",
+                    "раскаяние",
                     "прощение",
-                    "обнимать",
-                    "узнавать"
+                    "слёзы",
+                    "обнимать"
                 ],
                 "correctIndex": 1
             }
@@ -6272,8 +6198,8 @@
             {
                 "question": "Что означает немецкое слово «das Gefängnis»?",
                 "choices": [
-                    "достоинство",
                     "пленный",
+                    "достоинство",
                     "тюрьма",
                     "утешать"
                 ],
@@ -6283,17 +6209,17 @@
                 "question": "Что означает немецкое слово «die Würde»?",
                 "choices": [
                     "достоинство",
-                    "смирение",
+                    "честь",
                     "тюрьма",
-                    "судьба"
+                    "смирение"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
+                    "смирение",
                     "пленный",
-                    "честь",
                     "тюрьма",
                     "утешать"
                 ],
@@ -6302,19 +6228,19 @@
             {
                 "question": "Что означает немецкое слово «tapfer»?",
                 "choices": [
-                    "судьба",
-                    "утешать",
+                    "пленный",
                     "смирение",
-                    "отважный"
+                    "отважный",
+                    "утешать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Demut»?",
                 "choices": [
                     "тюрьма",
                     "смирение",
-                    "отважный",
+                    "судьба",
                     "пленный"
                 ],
                 "correctIndex": 1
@@ -6324,20 +6250,20 @@
                 "choices": [
                     "достоинство",
                     "судьба",
-                    "смирение",
-                    "тюрьма"
+                    "тюрьма",
+                    "пленный"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "тюрьма",
+                    "отважный",
+                    "смирение",
                     "честь",
-                    "достоинство",
-                    "отважный"
+                    "пленный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -7135,82 +7061,82 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "душа",
-                    "смерть",
                     "жертва",
-                    "умирать"
+                    "смерть",
+                    "умирать",
+                    "душа"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "душа",
                     "умирать",
-                    "жертва",
-                    "смерть"
+                    "смерть",
+                    "душа",
+                    "жертва"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «das Opfer»?",
                 "choices": [
-                    "прощание",
-                    "умирать",
+                    "спасение",
+                    "жертва",
                     "вечный",
-                    "жертва"
+                    "конец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Seele»?",
                 "choices": [
                     "вечный",
-                    "жертва",
-                    "душа",
-                    "умирать"
+                    "прощание",
+                    "конец",
+                    "душа"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "смерть",
-                    "душа",
+                    "вечный",
+                    "умирать",
                     "конец",
-                    "спасение"
+                    "смерть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "прощание",
-                    "конец",
+                    "смерть",
                     "жертва",
-                    "вечный"
+                    "вечный",
+                    "конец"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
+                    "умирать",
                     "прощание",
                     "вечный",
-                    "душа",
-                    "умирать"
+                    "душа"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Erlösung»?",
                 "choices": [
-                    "умирать",
                     "спасение",
+                    "вечный",
                     "смерть",
-                    "вечный"
+                    "душа"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -7367,6 +7293,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -8259,6 +8215,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -8334,71 +8487,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -8406,7 +8504,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/cornwall.html
+++ b/output/journeys/cornwall.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Ehrgeiz" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Ehrgeiz</div>
-            </div>
-            <div class="vocab-translation">честолюбие</div>
-            <div class="vocab-transcription">[дер ЭР-гайц]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Gier" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Gier</div>
-            </div>
-            <div class="vocab-translation">жадность</div>
-            <div class="vocab-transcription">[ди ГИР]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="streben">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">streben</div>
-            </div>
-            <div class="vocab-translation">стремиться</div>
-            <div class="vocab-transcription">[ШТРЕ-бен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="verlangen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">verlangen</div>
-            </div>
-            <div class="vocab-translation">желать</div>
-            <div class="vocab-transcription">[фер-ЛАН-ген]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="begehren">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">begehren</div>
-            </div>
-            <div class="vocab-translation">вожделеть</div>
-            <div class="vocab-transcription">[бе-ГЕ-рен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="gierig">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">gierig</div>
-            </div>
-            <div class="vocab-translation">жадный</div>
-            <div class="vocab-transcription">[ГИ-риг]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Herrschsucht" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Herrschsucht</div>
-            </div>
-            <div class="vocab-translation">властолюбие</div>
-            <div class="vocab-transcription">[ди ХЕР-зухт]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="ergreifen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">ergreifen</div>
-            </div>
-            <div class="vocab-translation">захватывать</div>
-            <div class="vocab-transcription">[ер-ГРАЙ-фен]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1911,79 +1837,79 @@
             {
                 "question": "Что означает немецкое слово «der Ehrgeiz»?",
                 "choices": [
-                    "жадность",
                     "честолюбие",
-                    "стремиться",
-                    "желать"
+                    "желать",
+                    "жадность",
+                    "стремиться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Gier»?",
                 "choices": [
+                    "желать",
                     "честолюбие",
                     "жадность",
-                    "желать",
                     "стремиться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «streben»?",
                 "choices": [
                     "стремиться",
-                    "желать",
                     "честолюбие",
-                    "захватывать"
+                    "вожделеть",
+                    "властолюбие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verlangen»?",
                 "choices": [
-                    "стремиться",
-                    "властолюбие",
+                    "жадность",
                     "желать",
-                    "жадный"
+                    "захватывать",
+                    "вожделеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
                     "честолюбие",
-                    "вожделеть",
+                    "жадность",
                     "захватывать",
-                    "жадный"
+                    "вожделеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «gierig»?",
                 "choices": [
-                    "жадный",
-                    "захватывать",
-                    "стремиться",
-                    "жадность"
+                    "желать",
+                    "жадность",
+                    "вожделеть",
+                    "жадный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Herrschsucht»?",
                 "choices": [
+                    "жадность",
+                    "желать",
                     "властолюбие",
-                    "стремиться",
-                    "вожделеть",
-                    "захватывать"
+                    "вожделеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ergreifen»?",
                 "choices": [
+                    "вожделеть",
+                    "желать",
                     "властолюбие",
-                    "честолюбие",
-                    "стремиться",
                     "захватывать"
                 ],
                 "correctIndex": 3
@@ -2657,8 +2583,8 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "злоба",
                     "одобрять",
+                    "злоба",
                     "поддерживать",
                     "жестокость"
                 ],
@@ -2667,62 +2593,62 @@
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "поддерживать",
                     "одобрять",
-                    "жестокость",
-                    "злоба"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «billigen»?",
-                "choices": [
-                    "одобрять",
-                    "поощрять",
                     "злоба",
-                    "суровость"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «unterstützen»?",
-                "choices": [
-                    "суровость",
-                    "подстрекать",
-                    "одобрять",
-                    "поддерживать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «anstacheln»?",
-                "choices": [
                     "поддерживать",
-                    "поощрять",
-                    "подстрекать",
-                    "злоба"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «ermutigen»?",
-                "choices": [
-                    "злоба",
-                    "поощрять",
-                    "жестокость",
-                    "подстрекать"
+                    "жестокость"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Härte»?",
+                "question": "Что означает немецкое слово «billigen»?",
                 "choices": [
-                    "поддерживать",
                     "подстрекать",
+                    "одобрять",
+                    "злоба",
+                    "поощрять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «unterstützen»?",
+                "choices": [
+                    "подстрекать",
+                    "поддерживать",
                     "суровость",
-                    "злоба"
+                    "одобрять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «anstacheln»?",
+                "choices": [
+                    "злоба",
+                    "подстрекать",
+                    "жестокость",
+                    "одобрять"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «ermutigen»?",
+                "choices": [
+                    "жестокость",
+                    "поддерживать",
+                    "поощрять",
+                    "суровость"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Härte»?",
+                "choices": [
+                    "одобрять",
+                    "поощрять",
+                    "жестокость",
+                    "суровость"
+                ],
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -3430,12 +3356,12 @@
             {
                 "question": "Что означает немецкое слово «die Tyrannei»?",
                 "choices": [
-                    "страх",
-                    "угнетение",
                     "тирания",
-                    "подавлять"
+                    "подавлять",
+                    "страх",
+                    "угнетение"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Unterdrückung»?",
@@ -3450,62 +3376,62 @@
             {
                 "question": "Что означает немецкое слово «die Furcht»?",
                 "choices": [
-                    "порабощать",
-                    "страх",
-                    "брутальный",
-                    "произвол"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «unterdrücken»?",
-                "choices": [
-                    "произвол",
-                    "порабощать",
                     "подавлять",
-                    "брутальный"
+                    "тирания",
+                    "страх",
+                    "угнетение"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «unterdrücken»?",
+                "choices": [
+                    "подавлять",
+                    "принуждать",
+                    "тирания",
+                    "угнетение"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «knechten»?",
                 "choices": [
-                    "тирания",
-                    "порабощать",
-                    "произвол",
-                    "брутальный"
+                    "страх",
+                    "брутальный",
+                    "принуждать",
+                    "порабощать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «zwingen»?",
                 "choices": [
-                    "брутальный",
-                    "подавлять",
+                    "порабощать",
+                    "произвол",
                     "принуждать",
-                    "произвол"
+                    "брутальный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Willkür»?",
                 "choices": [
-                    "страх",
                     "брутальный",
+                    "угнетение",
                     "произвол",
-                    "подавлять"
+                    "порабощать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «brutal»?",
                 "choices": [
-                    "брутальный",
                     "произвол",
-                    "страх",
-                    "принуждать"
+                    "брутальный",
+                    "угнетение",
+                    "порабощать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4162,71 +4088,71 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "наказывать",
-                    "карать",
                     "наказание",
+                    "карать",
                     "гнев"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
-                    "наказывать",
-                    "гнев",
                     "карать",
-                    "наказание"
+                    "гнев",
+                    "наказание",
+                    "наказывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bestrafen»?",
                 "choices": [
-                    "наказывать",
                     "гнев",
-                    "карать",
-                    "наказание"
+                    "унижать",
+                    "унижать",
+                    "карать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «züchtigen»?",
                 "choices": [
+                    "мучить",
                     "карать",
-                    "наказывать",
-                    "наказание",
-                    "мучить"
+                    "унижать",
+                    "наказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
                     "унижать",
+                    "гнев",
                     "наказание",
-                    "мучить",
-                    "гнев"
+                    "наказывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "мучить",
-                    "наказание",
+                    "унижать",
                     "гнев",
-                    "унижать"
+                    "карать",
+                    "наказывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
-                    "наказывать",
-                    "мучить",
+                    "карать",
                     "унижать",
-                    "унижать"
+                    "мучить",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4963,69 +4889,69 @@
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
+                    "пытать",
                     "пытка",
                     "садизм",
-                    "пытать",
                     "кровь"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
                     "кровь",
-                    "пытать",
                     "пытка",
-                    "садизм"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Blut»?",
-                "choices": [
-                    "мука",
-                    "кровь",
-                    "пытка",
-                    "садизм"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «foltern»?",
-                "choices": [
-                    "выкалывать",
-                    "ослеплять",
-                    "пытать",
-                    "калечить"
+                    "садизм",
+                    "пытать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «verstümmeln»?",
+                "question": "Что означает немецкое слово «das Blut»?",
+                "choices": [
+                    "кровь",
+                    "пытка",
+                    "ослеплять",
+                    "выкалывать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
                     "мука",
-                    "калечить",
+                    "пытка",
                     "кровь",
+                    "пытать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verstümmeln»?",
+                "choices": [
+                    "садизм",
+                    "выкалывать",
+                    "калечить",
                     "ослеплять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "пытать",
                     "ослеплять",
                     "выкалывать",
-                    "калечить"
+                    "пытка",
+                    "мука"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
                     "выкалывать",
-                    "ослеплять",
-                    "садизм",
+                    "кровь",
+                    "калечить",
                     "пытка"
                 ],
                 "correctIndex": 0
@@ -5033,9 +4959,9 @@
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "ослеплять",
+                    "калечить",
+                    "выкалывать",
                     "пытка",
-                    "пытать",
                     "мука"
                 ],
                 "correctIndex": 3
@@ -5676,72 +5602,72 @@
             {
                 "question": "Что означает немецкое слово «die Wunde»?",
                 "choices": [
-                    "кровоточить",
                     "рана",
+                    "кровоточить",
                     "боль",
                     "удивление"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "удивление",
+                    "боль",
                     "рана",
-                    "кровоточить",
-                    "боль"
+                    "удивление",
+                    "кровоточить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Überraschung»?",
                 "choices": [
-                    "рана",
-                    "ослаблять",
                     "удивление",
-                    "раненый"
+                    "боль",
+                    "рана",
+                    "страдать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bluten»?",
                 "choices": [
                     "кровоточить",
+                    "боль",
                     "раненый",
-                    "рана",
-                    "боль"
+                    "удивление"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verwundet»?",
                 "choices": [
-                    "страдать",
-                    "боль",
+                    "раненый",
+                    "ослаблять",
                     "кровоточить",
-                    "раненый"
+                    "страдать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «schwächen»?",
                 "choices": [
+                    "рана",
                     "удивление",
                     "ослаблять",
-                    "раненый",
-                    "боль"
+                    "кровоточить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "удивление",
-                    "страдать",
+                    "боль",
                     "ослаблять",
-                    "кровоточить"
+                    "раненый",
+                    "страдать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6447,9 +6373,9 @@
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
                     "смерть",
+                    "возмездие",
                     "умирать",
-                    "конец",
-                    "возмездие"
+                    "конец"
                 ],
                 "correctIndex": 0
             },
@@ -6466,62 +6392,62 @@
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
-                    "умирать",
                     "кара",
+                    "проклинать",
                     "конец",
-                    "смерть"
+                    "возмездие"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
+                    "проклинать",
                     "умирать",
-                    "конец",
-                    "издыхать",
-                    "проклинать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verenden»?",
-                "choices": [
-                    "возмездие",
-                    "издыхать",
                     "смерть",
-                    "конец"
+                    "возмездие"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «verenden»?",
+                "choices": [
+                    "конец",
+                    "хрипеть",
+                    "умирать",
+                    "издыхать"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "хрипеть",
-                    "кара",
                     "проклинать",
-                    "возмездие"
+                    "хрипеть",
+                    "издыхать",
+                    "умирать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «röcheln»?",
                 "choices": [
                     "хрипеть",
                     "смерть",
-                    "конец",
-                    "возмездие"
+                    "проклинать",
+                    "конец"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "хрипеть",
-                    "конец",
-                    "проклинать",
-                    "кара"
+                    "кара",
+                    "смерть",
+                    "издыхать",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6663,6 +6589,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7555,6 +7511,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7630,71 +7783,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7702,7 +7800,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/edgar.html
+++ b/output/journeys/edgar.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Adel" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Adel</div>
-            </div>
-            <div class="vocab-translation">знать</div>
-            <div class="vocab-transcription">[дер А-дель]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Erbe" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Erbe</div>
-            </div>
-            <div class="vocab-translation">наследник</div>
-            <div class="vocab-transcription">[дер ЕР-бе]</div>
-        </div>
-
-        <div class="vocab-card is-das" data-word="Königreich" data-article="das">
-            <div class="vocab-header">
-                <span class="article-chip das"><span class="article-icon">⚪</span><span>das</span></span>
-                <div class="vocab-word">Königreich</div>
-            </div>
-            <div class="vocab-translation">королевство</div>
-            <div class="vocab-transcription">[дас КЁ-ниг-райх]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="vertrauen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">vertrauen</div>
-            </div>
-            <div class="vocab-translation">доверять</div>
-            <div class="vocab-transcription">[фер-ТРАУ-ен]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Ehre" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Ehre</div>
-            </div>
-            <div class="vocab-translation">честь</div>
-            <div class="vocab-transcription">[ди Э-ре]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="legitim">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">legitim</div>
-            </div>
-            <div class="vocab-translation">законный</div>
-            <div class="vocab-transcription">[ле-ги-ТИМ]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Graf" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Graf</div>
-            </div>
-            <div class="vocab-translation">граф</div>
-            <div class="vocab-transcription">[дер ГРАФ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="ahnungslos">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">ahnungslos</div>
-            </div>
-            <div class="vocab-translation">ничего не подозревающий</div>
-            <div class="vocab-transcription">[А-нунгс-лос]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1934,18 +1860,18 @@
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
                     "королевство",
+                    "знать",
                     "наследник",
-                    "доверять",
-                    "знать"
+                    "доверять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Erbe»?",
                 "choices": [
-                    "королевство",
                     "доверять",
                     "знать",
+                    "королевство",
                     "наследник"
                 ],
                 "correctIndex": 3
@@ -1953,19 +1879,19 @@
             {
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
-                    "королевство",
-                    "доверять",
                     "наследник",
-                    "ничего не подозревающий"
+                    "честь",
+                    "доверять",
+                    "королевство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
-                    "законный",
-                    "знать",
                     "наследник",
+                    "знать",
+                    "честь",
                     "доверять"
                 ],
                 "correctIndex": 3
@@ -1974,7 +1900,7 @@
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
                     "граф",
-                    "знать",
+                    "ничего не подозревающий",
                     "королевство",
                     "честь"
                 ],
@@ -1983,29 +1909,29 @@
             {
                 "question": "Что означает немецкое слово «legitim»?",
                 "choices": [
-                    "граф",
                     "наследник",
-                    "знать",
-                    "законный"
+                    "честь",
+                    "законный",
+                    "ничего не подозревающий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "наследник",
                     "доверять",
-                    "знать",
-                    "граф"
+                    "честь",
+                    "граф",
+                    "знать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ahnungslos»?",
                 "choices": [
-                    "знать",
+                    "королевство",
                     "ничего не подозревающий",
-                    "доверять",
+                    "законный",
                     "наследник"
                 ],
                 "correctIndex": 1
@@ -2709,81 +2635,81 @@
                 "question": "Что означает немецкое слово «fliehen»?",
                 "choices": [
                     "опасность",
-                    "преследовать",
                     "бежать",
+                    "преследовать",
                     "предательство"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Verrat»?",
-                "choices": [
-                    "преследовать",
-                    "опасность",
-                    "предательство",
-                    "бежать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Gefahr»?",
-                "choices": [
-                    "преследовать",
-                    "прятаться",
-                    "интрига",
-                    "опасность"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verfolgen»?",
-                "choices": [
-                    "обман",
-                    "изгнать",
-                    "интрига",
-                    "преследовать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «verstecken»?",
-                "choices": [
-                    "бежать",
-                    "прятаться",
-                    "опасность",
-                    "интрига"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Intrige»?",
+                "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "интрига",
-                    "прятаться",
                     "предательство",
-                    "бежать"
+                    "бежать",
+                    "преследовать",
+                    "опасность"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "опасность",
+                    "преследовать",
+                    "бежать",
+                    "предательство"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verfolgen»?",
+                "choices": [
+                    "предательство",
+                    "преследовать",
+                    "прятаться",
+                    "обман"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «verstecken»?",
+                "choices": [
+                    "опасность",
+                    "предательство",
+                    "интрига",
+                    "прятаться"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Intrige»?",
+                "choices": [
+                    "обман",
+                    "интрига",
+                    "изгнать",
+                    "бежать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Betrug»?",
                 "choices": [
                     "обман",
-                    "предательство",
                     "бежать",
-                    "прятаться"
+                    "предательство",
+                    "изгнать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verbannen»?",
                 "choices": [
+                    "прятаться",
                     "опасность",
                     "изгнать",
-                    "бежать",
-                    "обман"
+                    "предательство"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3518,70 +3444,70 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "маскировка",
                     "безумие",
+                    "нищий",
                     "голый",
-                    "нищий"
+                    "маскировка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "безумие",
+                    "голый",
                     "нищий",
-                    "маскировка",
-                    "голый"
+                    "безумие",
+                    "маскировка"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Verkleidung»?",
                 "choices": [
-                    "маскировка",
-                    "нищий",
-                    "безумие",
-                    "нищета"
+                    "голый",
+                    "бормотать",
+                    "нищета",
+                    "маскировка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "маскировка",
+                    "безумный",
+                    "дрожать",
                     "безумие",
-                    "голый",
-                    "дрожать"
+                    "голый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «murmeln»?",
                 "choices": [
-                    "маскировка",
+                    "безумие",
+                    "нищий",
                     "бормотать",
-                    "нищета",
                     "безумный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "нищета",
+                    "безумие",
                     "дрожать",
-                    "нищий",
-                    "бормотать"
+                    "безумный",
+                    "нищий"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "голый",
                     "безумие",
+                    "безумный",
                     "нищета",
-                    "бормотать"
+                    "маскировка"
                 ],
                 "correctIndex": 2
             },
@@ -3589,9 +3515,9 @@
                 "question": "Что означает немецкое слово «wahnsinnig»?",
                 "choices": [
                     "безумный",
+                    "нищета",
                     "маскировка",
-                    "бормотать",
-                    "дрожать"
+                    "безумие"
                 ],
                 "correctIndex": 0
             }
@@ -4328,82 +4254,82 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "хижина",
-                    "страдать",
+                    "буря",
                     "мёрзнуть",
-                    "буря"
+                    "страдать",
+                    "хижина"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
                     "мёрзнуть",
                     "хижина",
-                    "буря",
-                    "страдать"
+                    "страдать",
+                    "буря"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "страдать",
                     "хижина",
-                    "сопровождать",
-                    "защищать",
-                    "страдать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Hütte»?",
-                "choices": [
-                    "хижина",
-                    "молния",
                     "защищать",
                     "мёрзнуть"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «beschützen»?",
+                "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
-                    "молния",
-                    "гром",
-                    "мёрзнуть",
-                    "защищать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «begleiten»?",
-                "choices": [
-                    "гром",
                     "сопровождать",
-                    "буря",
-                    "мёрзнуть"
+                    "хижина",
+                    "защищать",
+                    "молния"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «der Donner»?",
+                "question": "Что означает немецкое слово «beschützen»?",
                 "choices": [
                     "сопровождать",
-                    "гром",
+                    "буря",
                     "защищать",
+                    "молния"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «begleiten»?",
+                "choices": [
+                    "защищать",
+                    "мёрзнуть",
+                    "сопровождать",
                     "страдать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "защищать",
+                    "гром",
+                    "мёрзнуть",
+                    "буря"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Blitz»?",
                 "choices": [
-                    "хижина",
-                    "гром",
+                    "сопровождать",
                     "молния",
-                    "защищать"
+                    "страдать",
+                    "хижина"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5129,31 +5055,31 @@
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
                     "обманывать",
-                    "утёс",
                     "вести",
-                    "слепой"
+                    "слепой",
+                    "утёс"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «führen»?",
                 "choices": [
                     "слепой",
-                    "вести",
                     "утёс",
+                    "вести",
                     "обманывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Klippe»?",
                 "choices": [
+                    "вести",
+                    "утешать",
                     "обманывать",
-                    "утёс",
-                    "отчаяние",
-                    "хитрость"
+                    "утёс"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «täuschen»?",
@@ -5161,49 +5087,49 @@
                     "обманывать",
                     "спасать",
                     "слепой",
-                    "утёс"
+                    "утешать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «retten»?",
                 "choices": [
+                    "утёс",
                     "спасать",
                     "хитрость",
-                    "слепой",
                     "обманывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "утешать",
-                    "вести",
+                    "слепой",
+                    "хитрость",
                     "обманывать",
-                    "хитрость"
+                    "спасать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
-                    "спасать",
-                    "утёс",
                     "утешать",
-                    "хитрость"
+                    "слепой",
+                    "хитрость",
+                    "спасать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
+                    "спасать",
+                    "утешать",
                     "отчаяние",
-                    "вести",
-                    "обманывать",
-                    "спасать"
+                    "обманывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5907,82 +5833,82 @@
             {
                 "question": "Что означает немецкое слово «der Kampf»?",
                 "choices": [
-                    "дуэль",
-                    "месть",
-                    "разоблачать",
-                    "бой"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Duell»?",
-                "choices": [
                     "бой",
                     "месть",
                     "дуэль",
                     "разоблачать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Duell»?",
+                "choices": [
+                    "разоблачать",
+                    "месть",
+                    "дуэль",
+                    "бой"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
-                    "справедливость",
-                    "месть",
-                    "дуэль",
-                    "разоблачать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «enthüllen»?",
-                "choices": [
+                    "брат",
                     "разоблачать",
-                    "меч",
-                    "дуэль",
-                    "месть"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «siegen»?",
-                "choices": [
-                    "побеждать",
-                    "дуэль",
                     "бой",
-                    "разоблачать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
-                "choices": [
-                    "дуэль",
-                    "побеждать",
-                    "месть",
-                    "справедливость"
+                    "месть"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «enthüllen»?",
+                "choices": [
+                    "брат",
+                    "месть",
+                    "бой",
+                    "разоблачать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «siegen»?",
+                "choices": [
+                    "брат",
+                    "месть",
+                    "справедливость",
+                    "побеждать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Gerechtigkeit»?",
+                "choices": [
+                    "месть",
+                    "брат",
+                    "справедливость",
+                    "разоблачать"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «das Schwert»?",
                 "choices": [
+                    "брат",
+                    "месть",
                     "меч",
-                    "разоблачать",
-                    "побеждать",
-                    "бой"
+                    "дуэль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Bruder»?",
                 "choices": [
-                    "меч",
+                    "месть",
+                    "бой",
                     "разоблачать",
-                    "брат",
-                    "дуэль"
+                    "брат"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6707,69 +6633,69 @@
             {
                 "question": "Что означает немецкое слово «überleben»?",
                 "choices": [
-                    "наследовать",
-                    "править",
                     "будущее",
-                    "выживать"
+                    "выживать",
+                    "править",
+                    "наследовать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "наследовать",
                     "выживать",
+                    "наследовать",
                     "будущее",
                     "править"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Zukunft»?",
                 "choices": [
-                    "ответственность",
+                    "выживать",
                     "будущее",
-                    "порядок",
-                    "наследовать"
+                    "править",
+                    "порядок"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «regieren»?",
                 "choices": [
-                    "выживать",
-                    "новый",
-                    "мудрость",
-                    "править"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Weisheit»?",
-                "choices": [
-                    "мудрость",
-                    "будущее",
+                    "править",
                     "ответственность",
-                    "править"
+                    "будущее",
+                    "выживать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Ordnung»?",
+                "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "наследовать",
-                    "порядок",
-                    "новый",
+                    "будущее",
+                    "ответственность",
+                    "править",
                     "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Ordnung»?",
+                "choices": [
+                    "новый",
+                    "мудрость",
+                    "порядок",
+                    "наследовать"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Verantwortung»?",
                 "choices": [
-                    "выживать",
+                    "новый",
                     "наследовать",
-                    "порядок",
+                    "выживать",
                     "ответственность"
                 ],
                 "correctIndex": 3
@@ -6777,12 +6703,12 @@
             {
                 "question": "Что означает немецкое слово «neu»?",
                 "choices": [
-                    "ответственность",
                     "новый",
-                    "наследовать",
-                    "править"
+                    "будущее",
+                    "править",
+                    "выживать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6923,6 +6849,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7815,6 +7771,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7890,71 +8043,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7962,7 +8060,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/edmund.html
+++ b/output/journeys/edmund.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Bastard" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Bastard</div>
-            </div>
-            <div class="vocab-translation">бастард</div>
-            <div class="vocab-transcription">[дер БАС-тард]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Neid" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Neid</div>
-            </div>
-            <div class="vocab-translation">зависть</div>
-            <div class="vocab-transcription">[дер НАЙД]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Ambition" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Ambition</div>
-            </div>
-            <div class="vocab-translation">амбиция</div>
-            <div class="vocab-transcription">[ди ам-би-ЦИ-он]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="benachteiligt">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">benachteiligt</div>
-            </div>
-            <div class="vocab-translation">обделённый</div>
-            <div class="vocab-transcription">[бе-НАХ-тай-лигт]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Rache" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Rache</div>
-            </div>
-            <div class="vocab-translation">месть</div>
-            <div class="vocab-transcription">[ди РА-хе]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="aufsteigen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">aufsteigen</div>
-            </div>
-            <div class="vocab-translation">возвышаться</div>
-            <div class="vocab-transcription">[АУФ-штай-ген]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="unehelich">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">unehelich</div>
-            </div>
-            <div class="vocab-translation">внебрачный</div>
-            <div class="vocab-transcription">[УН-э-е-лих]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Natur" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Natur</div>
-            </div>
-            <div class="vocab-translation">природа</div>
-            <div class="vocab-transcription">[ди на-ТУР]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1942,59 +1868,59 @@
             {
                 "question": "Что означает немецкое слово «der Bastard»?",
                 "choices": [
-                    "амбиция",
-                    "бастард",
                     "зависть",
-                    "обделённый"
+                    "обделённый",
+                    "амбиция",
+                    "бастард"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Neid»?",
                 "choices": [
-                    "амбиция",
+                    "бастард",
                     "зависть",
                     "обделённый",
-                    "бастард"
+                    "амбиция"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Ambition»?",
                 "choices": [
-                    "амбиция",
+                    "месть",
                     "обделённый",
                     "бастард",
-                    "зависть"
+                    "амбиция"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «benachteiligt»?",
                 "choices": [
+                    "внебрачный",
+                    "амбиция",
                     "обделённый",
-                    "зависть",
-                    "бастард",
+                    "бастард"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Rache»?",
+                "choices": [
+                    "месть",
+                    "возвышаться",
+                    "природа",
                     "внебрачный"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Rache»?",
-                "choices": [
-                    "обделённый",
-                    "возвышаться",
-                    "амбиция",
-                    "месть"
-                ],
-                "correctIndex": 3
-            },
-            {
                 "question": "Что означает немецкое слово «aufsteigen»?",
                 "choices": [
-                    "обделённый",
-                    "природа",
+                    "амбиция",
                     "бастард",
+                    "внебрачный",
                     "возвышаться"
                 ],
                 "correctIndex": 3
@@ -2002,22 +1928,22 @@
             {
                 "question": "Что означает немецкое слово «unehelich»?",
                 "choices": [
-                    "обделённый",
-                    "зависть",
+                    "внебрачный",
+                    "амбиция",
                     "природа",
-                    "внебрачный"
+                    "зависть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Natur»?",
                 "choices": [
-                    "природа",
+                    "амбиция",
                     "зависть",
-                    "месть",
+                    "природа",
                     "бастард"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2751,58 +2677,58 @@
             {
                 "question": "Что означает немецкое слово «fälschen»?",
                 "choices": [
+                    "интриговать",
                     "подделывать",
+                    "обвинять",
+                    "план"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «intrigieren»?",
+                "choices": [
+                    "подделывать",
+                    "обвинять",
+                    "план",
+                    "интриговать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «beschuldigen»?",
+                "choices": [
+                    "лгать",
+                    "письмо",
+                    "интриговать",
+                    "обвинять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Plan»?",
+                "choices": [
                     "план",
                     "обвинять",
+                    "интриговать",
+                    "манипулировать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «manipulieren»?",
+                "choices": [
+                    "манипулировать",
+                    "обман",
+                    "план",
                     "интриговать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «intrigieren»?",
-                "choices": [
-                    "обвинять",
-                    "подделывать",
-                    "интриговать",
-                    "план"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «beschuldigen»?",
-                "choices": [
-                    "письмо",
-                    "подделывать",
-                    "обвинять",
-                    "лгать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Plan»?",
-                "choices": [
-                    "манипулировать",
-                    "лгать",
-                    "обман",
-                    "план"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «manipulieren»?",
-                "choices": [
-                    "план",
-                    "манипулировать",
-                    "лгать",
-                    "обман"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
+                    "обвинять",
                     "манипулировать",
-                    "интриговать",
                     "письмо",
                     "план"
                 ],
@@ -2811,19 +2737,19 @@
             {
                 "question": "Что означает немецкое слово «lügen»?",
                 "choices": [
+                    "подделывать",
                     "обман",
-                    "письмо",
                     "лгать",
-                    "план"
+                    "манипулировать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "план",
-                    "интриговать",
                     "письмо",
+                    "обвинять",
+                    "подделывать",
                     "обман"
                 ],
                 "correctIndex": 3
@@ -3542,82 +3468,82 @@
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "изгонять",
+                    "успех",
                     "наследовать",
-                    "торжествовать",
-                    "успех"
+                    "изгонять",
+                    "торжествовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «triumphieren»?",
                 "choices": [
-                    "торжествовать",
+                    "наследовать",
                     "успех",
                     "изгонять",
-                    "наследовать"
+                    "торжествовать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erben»?",
                 "choices": [
-                    "успех",
-                    "наследовать",
                     "выигрывать",
-                    "вытеснять"
+                    "торжествовать",
+                    "наследовать",
+                    "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Erfolg»?",
                 "choices": [
-                    "победа",
-                    "успех",
                     "выигрывать",
-                    "награда"
+                    "награда",
+                    "успех",
+                    "торжествовать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «gewinnen»?",
                 "choices": [
-                    "победа",
-                    "выигрывать",
                     "торжествовать",
-                    "успех"
+                    "выигрывать",
+                    "наследовать",
+                    "вытеснять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Belohnung»?",
                 "choices": [
-                    "награда",
-                    "выигрывать",
                     "изгонять",
-                    "наследовать"
+                    "награда",
+                    "победа",
+                    "выигрывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verdrängen»?",
                 "choices": [
-                    "вытеснять",
                     "награда",
+                    "успех",
                     "торжествовать",
-                    "наследовать"
+                    "вытеснять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Sieg»?",
                 "choices": [
-                    "наследовать",
-                    "изгонять",
                     "выигрывать",
-                    "победа"
+                    "вытеснять",
+                    "победа",
+                    "награда"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4349,9 +4275,9 @@
             {
                 "question": "Что означает немецкое слово «verbünden»?",
                 "choices": [
-                    "союз",
-                    "завоёвывать",
                     "власть",
+                    "завоёвывать",
+                    "союз",
                     "объединяться"
                 ],
                 "correctIndex": 3
@@ -4359,40 +4285,40 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "завоёвывать",
-                    "объединяться",
                     "союз",
-                    "власть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erobern»?",
-                "choices": [
                     "завоёвывать",
                     "власть",
-                    "объединяться",
-                    "союз"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «das Bündnis»?",
-                "choices": [
-                    "завоёвывать",
-                    "власть",
-                    "союз",
-                    "соблазнять"
+                    "объединяться"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «erobern»?",
+                "choices": [
+                    "альянс",
+                    "завоёвывать",
+                    "завоевание",
+                    "союз"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «das Bündnis»?",
+                "choices": [
+                    "объединяться",
+                    "союз",
+                    "завоёвывать",
+                    "господствовать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
-                    "союз",
+                    "господствовать",
                     "соблазнять",
-                    "завоёвывать",
-                    "завоевание"
+                    "альянс",
+                    "союз"
                 ],
                 "correctIndex": 1
             },
@@ -4400,31 +4326,31 @@
                 "question": "Что означает немецкое слово «die Eroberung»?",
                 "choices": [
                     "завоевание",
-                    "господствовать",
-                    "завоёвывать",
-                    "власть"
+                    "объединяться",
+                    "власть",
+                    "завоёвывать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «beherrschen»?",
                 "choices": [
-                    "господствовать",
                     "власть",
-                    "завоевание",
-                    "завоёвывать"
+                    "альянс",
+                    "господствовать",
+                    "завоевание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Allianz»?",
                 "choices": [
+                    "соблазнять",
                     "объединяться",
                     "альянс",
-                    "завоёвывать",
-                    "завоевание"
+                    "союз"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5183,8 +5109,8 @@
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
                     "предавать",
-                    "жестокость",
                     "ослеплять",
+                    "жестокость",
                     "доносить"
                 ],
                 "correctIndex": 0
@@ -5192,59 +5118,59 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "предавать",
                     "ослеплять",
+                    "предавать",
                     "доносить",
                     "жестокость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
                     "предавать",
-                    "жестокость",
+                    "выдавать",
+                    "ослеплять",
+                    "жестокость"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «denunzieren»?",
+                "choices": [
+                    "ослеплять",
+                    "выдавать",
+                    "доносить",
+                    "пытка"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «ausliefern»?",
+                "choices": [
+                    "предавать",
+                    "выдавать",
                     "беспощадный",
                     "доносить"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «denunzieren»?",
-                "choices": [
-                    "ослеплять",
-                    "жертвовать",
-                    "беспощадный",
-                    "доносить"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «ausliefern»?",
-                "choices": [
-                    "выдавать",
-                    "пытка",
-                    "жестокость",
-                    "жертвовать"
-                ],
-                "correctIndex": 0
-            },
-            {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
+                    "беспощадный",
+                    "доносить",
                     "выдавать",
-                    "предавать",
-                    "пытка",
-                    "беспощадный"
+                    "пытка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «opfern»?",
                 "choices": [
                     "жертвовать",
-                    "пытка",
-                    "жестокость",
+                    "предавать",
+                    "ослеплять",
                     "беспощадный"
                 ],
                 "correctIndex": 0
@@ -5252,12 +5178,12 @@
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "выдавать",
-                    "ослеплять",
+                    "жертвовать",
                     "беспощадный",
-                    "жестокость"
+                    "выдавать",
+                    "ослеплять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5993,82 +5919,82 @@
             {
                 "question": "Что означает немецкое слово «die Liebschaft»?",
                 "choices": [
-                    "соперничество",
-                    "играть",
                     "завлекать",
-                    "любовная связь"
+                    "играть",
+                    "любовная связь",
+                    "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Rivalität»?",
                 "choices": [
                     "любовная связь",
-                    "соперничество",
+                    "завлекать",
                     "играть",
-                    "завлекать"
+                    "соперничество"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «spielen»?",
                 "choices": [
                     "использовать",
-                    "играть",
                     "соперничество",
-                    "завлекать"
+                    "играть",
+                    "похоть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verlocken»?",
                 "choices": [
-                    "интрига",
-                    "любовная связь",
+                    "играть",
                     "использовать",
-                    "завлекать"
+                    "завлекать",
+                    "жонглировать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "любовная связь",
+                    "завлекать",
                     "похоть",
                     "жонглировать",
-                    "интрига"
+                    "соперничество"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «ausnutzen»?",
                 "choices": [
-                    "соперничество",
-                    "играть",
+                    "завлекать",
+                    "жонглировать",
                     "использовать",
-                    "жонглировать"
+                    "похоть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «jonglieren»?",
                 "choices": [
-                    "соперничество",
                     "завлекать",
-                    "интрига",
-                    "жонглировать"
+                    "жонглировать",
+                    "похоть",
+                    "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Affäre»?",
                 "choices": [
-                    "использовать",
-                    "соперничество",
                     "интрига",
-                    "похоть"
+                    "любовная связь",
+                    "использовать",
+                    "завлекать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6778,80 +6704,80 @@
             {
                 "question": "Что означает немецкое слово «das Duell»?",
                 "choices": [
-                    "дуэль",
-                    "поражение",
                     "сожалеть",
-                    "падать"
+                    "падать",
+                    "поражение",
+                    "дуэль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "дуэль",
-                    "поражение",
                     "падать",
-                    "сожалеть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
+                    "поражение",
                     "сожалеть",
-                    "признаваться",
-                    "конец",
                     "дуэль"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Niederlage»?",
+                "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
                     "падать",
+                    "дуэль",
+                    "сожалеть",
+                    "признаваться"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Niederlage»?",
+                "choices": [
+                    "дуэль",
                     "поражение",
-                    "падение",
-                    "сожалеть"
+                    "проигрывать",
+                    "падение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verlieren»?",
                 "choices": [
-                    "дуэль",
-                    "проигрывать",
                     "падать",
-                    "падение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Untergang»?",
-                "choices": [
-                    "проигрывать",
-                    "сожалеть",
-                    "признаваться",
-                    "падение"
+                    "падение",
+                    "дуэль",
+                    "проигрывать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «gestehen»?",
+                "question": "Что означает немецкое слово «der Untergang»?",
                 "choices": [
                     "поражение",
-                    "признаваться",
-                    "проигрывать",
-                    "конец"
+                    "падение",
+                    "сожалеть",
+                    "дуэль"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «gestehen»?",
+                "choices": [
+                    "падать",
+                    "проигрывать",
+                    "конец",
+                    "признаваться"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Ende»?",
                 "choices": [
                     "конец",
-                    "поражение",
-                    "проигрывать",
-                    "падать"
+                    "признаваться",
+                    "падать",
+                    "поражение"
                 ],
                 "correctIndex": 0
             }
@@ -6994,6 +6920,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7886,6 +7842,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7961,71 +8114,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -8033,7 +8131,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/fool.html
+++ b/output/journeys/fool.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Narr" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Narr</div>
-            </div>
-            <div class="vocab-translation">шут</div>
-            <div class="vocab-transcription">[дер НАР]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Weisheit" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Weisheit</div>
-            </div>
-            <div class="vocab-translation">мудрость</div>
-            <div class="vocab-transcription">[ди ВАЙС-хайт]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Trauer" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Trauer</div>
-            </div>
-            <div class="vocab-translation">печаль</div>
-            <div class="vocab-transcription">[ди ТРАУ-ер]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="scherzen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">scherzen</div>
-            </div>
-            <div class="vocab-translation">шутить</div>
-            <div class="vocab-transcription">[ШЕР-цен]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Spaß" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Spaß</div>
-            </div>
-            <div class="vocab-translation">забава</div>
-            <div class="vocab-transcription">[дер ШПАС]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="klug">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">klug</div>
-            </div>
-            <div class="vocab-translation">умный</div>
-            <div class="vocab-transcription">[КЛУГ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="vermissen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">vermissen</div>
-            </div>
-            <div class="vocab-translation">скучать</div>
-            <div class="vocab-transcription">[фер-МИ-сен]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Witz" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Witz</div>
-            </div>
-            <div class="vocab-translation">остроумие</div>
-            <div class="vocab-transcription">[дер ВИТЦ]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1962,82 +1888,82 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "печаль",
-                    "мудрость",
                     "шут",
-                    "шутить"
+                    "шутить",
+                    "мудрость",
+                    "печаль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
                     "шутить",
-                    "мудрость",
                     "печаль",
-                    "шут"
+                    "шут",
+                    "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
-                    "мудрость",
-                    "шутить",
-                    "печаль",
-                    "умный"
+                    "скучать",
+                    "умный",
+                    "забава",
+                    "печаль"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «scherzen»?",
                 "choices": [
+                    "остроумие",
+                    "шут",
                     "шутить",
-                    "забава",
-                    "печаль",
-                    "шут"
+                    "печаль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Spaß»?",
                 "choices": [
-                    "остроумие",
+                    "забава",
                     "печаль",
-                    "скучать",
-                    "забава"
+                    "шут",
+                    "шутить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «klug»?",
                 "choices": [
-                    "остроумие",
-                    "мудрость",
-                    "шут",
-                    "умный"
+                    "умный",
+                    "шутить",
+                    "скучать",
+                    "забава"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vermissen»?",
                 "choices": [
                     "шутить",
-                    "забава",
                     "скучать",
-                    "мудрость"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Witz»?",
-                "choices": [
-                    "шутить",
-                    "остроумие",
                     "забава",
                     "шут"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «der Witz»?",
+                "choices": [
+                    "забава",
+                    "шут",
+                    "остроумие",
+                    "шутить"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2688,72 +2614,72 @@
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "правда",
                     "предупреждение",
-                    "шутка",
-                    "горький"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Scherz»?",
-                "choices": [
-                    "правда",
-                    "шутка",
-                    "горький",
-                    "предупреждение"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Warnung»?",
-                "choices": [
                     "горький",
                     "правда",
-                    "предупреждение",
                     "шутка"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «bitter»?",
+                "question": "Что означает немецкое слово «der Scherz»?",
                 "choices": [
                     "шутка",
-                    "насмехаться",
-                    "горький",
-                    "предупреждение"
+                    "правда",
+                    "предупреждение",
+                    "горький"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Warnung»?",
+                "choices": [
+                    "правда",
+                    "предупреждение",
+                    "дразнить",
+                    "горький"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «bitter»?",
+                "choices": [
+                    "предупреждение",
+                    "горький",
+                    "дразнить",
+                    "раскрывать"
+                ],
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «spotten»?",
                 "choices": [
-                    "раскрывать",
-                    "шутка",
                     "дразнить",
-                    "насмехаться"
+                    "раскрывать",
+                    "насмехаться",
+                    "правда"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «necken»?",
                 "choices": [
-                    "шутка",
+                    "предупреждение",
                     "дразнить",
-                    "раскрывать",
-                    "насмехаться"
+                    "шутка",
+                    "раскрывать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «enthüllen»?",
                 "choices": [
+                    "шутка",
                     "раскрывать",
-                    "предупреждение",
-                    "дразнить",
-                    "правда"
+                    "насмехаться",
+                    "горький"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3474,82 +3400,82 @@
             {
                 "question": "Что означает немецкое слово «die Prophezeiung»?",
                 "choices": [
-                    "пророчество",
-                    "предчувствие",
                     "предсказывать",
+                    "предчувствие",
+                    "пророчество",
                     "загадка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «das Rätsel»?",
                 "choices": [
                     "пророчество",
                     "предчувствие",
-                    "загадка",
-                    "предсказывать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Vorahnung»?",
-                "choices": [
-                    "знамение",
-                    "предчувствие",
-                    "пророчество",
-                    "предсказывать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «vorhersagen»?",
-                "choices": [
-                    "толковать",
                     "предсказывать",
-                    "знамение",
-                    "предчувствовать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «deuten»?",
-                "choices": [
-                    "знамение",
-                    "загадочный",
-                    "толковать",
-                    "пророчество"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «ahnen»?",
-                "choices": [
-                    "знамение",
-                    "предсказывать",
-                    "толковать",
-                    "предчувствовать"
+                    "загадка"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «das Omen»?",
+                "question": "Что означает немецкое слово «die Vorahnung»?",
                 "choices": [
-                    "пророчество",
+                    "толковать",
+                    "загадка",
+                    "предчувствие",
+                    "предсказывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «vorhersagen»?",
+                "choices": [
                     "знамение",
                     "предчувствовать",
-                    "загадочный"
+                    "загадочный",
+                    "предсказывать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «deuten»?",
+                "choices": [
+                    "толковать",
+                    "загадочный",
+                    "загадка",
+                    "предчувствовать"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «ahnen»?",
+                "choices": [
+                    "предчувствовать",
+                    "предчувствие",
+                    "загадка",
+                    "знамение"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Omen»?",
+                "choices": [
+                    "загадочный",
+                    "толковать",
+                    "предчувствовать",
+                    "знамение"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "загадочный",
                     "пророчество",
-                    "предчувствовать",
+                    "загадочный",
+                    "предсказывать",
                     "предчувствие"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4211,59 +4137,59 @@
             {
                 "question": "Что означает немецкое слово «der Wahnsinn»?",
                 "choices": [
-                    "сопровождать",
+                    "мёрзнуть",
                     "дружба",
-                    "безумие",
-                    "мёрзнуть"
+                    "сопровождать",
+                    "безумие"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Freundschaft»?",
                 "choices": [
                     "мёрзнуть",
+                    "дружба",
                     "сопровождать",
-                    "безумие",
-                    "дружба"
+                    "безумие"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "сопровождать",
-                    "мёрзнуть",
                     "верный",
+                    "сопровождать",
+                    "дружба",
                     "дрожать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «frieren»?",
                 "choices": [
-                    "петь",
-                    "сопровождать",
-                    "безумие",
-                    "мёрзнуть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «singen»?",
-                "choices": [
-                    "дрожать",
                     "верный",
-                    "петь",
-                    "безумие"
+                    "дрожать",
+                    "мёрзнуть",
+                    "дружба"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «singen»?",
+                "choices": [
+                    "петь",
+                    "дружба",
+                    "дрожать",
+                    "сопровождать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «zittern»?",
                 "choices": [
-                    "мёрзнуть",
+                    "петь",
                     "сопровождать",
-                    "дружба",
+                    "безумие",
                     "дрожать"
                 ],
                 "correctIndex": 3
@@ -4271,12 +4197,12 @@
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "дрожать",
                     "дружба",
-                    "сопровождать",
-                    "верный"
+                    "верный",
+                    "безумие",
+                    "дрожать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -4991,17 +4917,17 @@
                 "question": "Что означает немецкое слово «das Lied»?",
                 "choices": [
                     "напевать",
-                    "утешение",
+                    "песня",
                     "ирония",
-                    "песня"
+                    "утешение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Trost»?",
                 "choices": [
-                    "песня",
                     "напевать",
+                    "песня",
                     "утешение",
                     "ирония"
                 ],
@@ -5010,62 +4936,62 @@
             {
                 "question": "Что означает немецкое слово «die Ironie»?",
                 "choices": [
-                    "напевать",
-                    "свистеть",
                     "песня",
-                    "ирония"
+                    "ирония",
+                    "рифма",
+                    "свистеть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «summen»?",
                 "choices": [
                     "мелодия",
                     "напевать",
-                    "звучать",
-                    "песня"
+                    "свистеть",
+                    "звучать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Melodie»?",
                 "choices": [
-                    "песня",
+                    "свистеть",
                     "мелодия",
-                    "утешение",
-                    "звучать"
+                    "звучать",
+                    "ирония"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «pfeifen»?",
                 "choices": [
-                    "песня",
-                    "напевать",
-                    "свистеть",
-                    "рифма"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Reim»?",
-                "choices": [
-                    "напевать",
-                    "ирония",
+                    "утешение",
                     "звучать",
-                    "рифма"
+                    "рифма",
+                    "свистеть"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «klingen»?",
+                "question": "Что означает немецкое слово «der Reim»?",
                 "choices": [
-                    "звучать",
                     "рифма",
-                    "ирония",
-                    "напевать"
+                    "свистеть",
+                    "мелодия",
+                    "утешение"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «klingen»?",
+                "choices": [
+                    "напевать",
+                    "мелодия",
+                    "звучать",
+                    "рифма"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5708,72 +5634,72 @@
             {
                 "question": "Что означает немецкое слово «die Philosophie»?",
                 "choices": [
-                    "бренность",
-                    "философия",
                     "судьба",
-                    "размышлять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «das Schicksal»?",
-                "choices": [
-                    "бренность",
+                    "размышлять",
                     "философия",
-                    "судьба",
-                    "размышлять"
+                    "бренность"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «die Vergänglichkeit»?",
+                "question": "Что означает немецкое слово «das Schicksal»?",
                 "choices": [
                     "размышлять",
                     "философия",
-                    "смысл",
-                    "бренность"
+                    "бренность",
+                    "судьба"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Vergänglichkeit»?",
+                "choices": [
+                    "познавать",
+                    "преходящий",
+                    "бренность",
+                    "судьба"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «nachdenken»?",
                 "choices": [
-                    "размышлять",
-                    "судьба",
-                    "смысл",
-                    "философия"
+                    "познавать",
+                    "бренность",
+                    "преходящий",
+                    "размышлять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "бренность",
                     "философия",
+                    "бренность",
                     "познавать",
-                    "смысл"
+                    "судьба"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Sinn»?",
                 "choices": [
-                    "бренность",
                     "смысл",
-                    "судьба",
-                    "преходящий"
+                    "преходящий",
+                    "размышлять",
+                    "бренность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vergänglich»?",
                 "choices": [
-                    "познавать",
-                    "смысл",
+                    "судьба",
                     "преходящий",
-                    "судьба"
+                    "смысл",
+                    "бренность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -6487,39 +6413,39 @@
             {
                 "question": "Что означает немецкое слово «verschwinden»?",
                 "choices": [
-                    "тайна",
-                    "пустота",
                     "растворяться",
-                    "исчезать"
+                    "исчезать",
+                    "тайна",
+                    "пустота"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Geheimnis»?",
                 "choices": [
                     "тайна",
+                    "растворяться",
                     "исчезать",
-                    "пустота",
-                    "растворяться"
+                    "пустота"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Leere»?",
                 "choices": [
-                    "исчезать",
                     "пустота",
-                    "тайна",
-                    "бесследно"
+                    "загадочный",
+                    "растворяться",
+                    "исчезать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «sich auflösen»?",
                 "choices": [
-                    "тайна",
-                    "исчезать",
-                    "туман",
+                    "бесследно",
+                    "уходить",
+                    "пустота",
                     "растворяться"
                 ],
                 "correctIndex": 3
@@ -6527,42 +6453,42 @@
             {
                 "question": "Что означает немецкое слово «spurlos»?",
                 "choices": [
-                    "исчезать",
-                    "тайна",
-                    "загадочный",
-                    "бесследно"
+                    "бесследно",
+                    "пустота",
+                    "растворяться",
+                    "загадочный"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Nebel»?",
                 "choices": [
-                    "исчезать",
-                    "уходить",
-                    "бесследно",
-                    "туман"
+                    "тайна",
+                    "туман",
+                    "загадочный",
+                    "бесследно"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rätselhaft»?",
                 "choices": [
-                    "исчезать",
-                    "пустота",
+                    "уходить",
+                    "бесследно",
                     "загадочный",
-                    "тайна"
+                    "исчезать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «fortgehen»?",
                 "choices": [
-                    "растворяться",
                     "уходить",
-                    "бесследно",
-                    "загадочный"
+                    "загадочный",
+                    "исчезать",
+                    "растворяться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6704,6 +6630,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7596,6 +7552,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7671,71 +7824,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7743,7 +7841,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/gloucester.html
+++ b/output/journeys/gloucester.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Adel" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Adel</div>
-            </div>
-            <div class="vocab-translation">знать</div>
-            <div class="vocab-transcription">[дер А-дель]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="dienen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">dienen</div>
-            </div>
-            <div class="vocab-translation">служить</div>
-            <div class="vocab-transcription">[ДИ-нен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="vertrauen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">vertrauen</div>
-            </div>
-            <div class="vocab-translation">доверять</div>
-            <div class="vocab-transcription">[фер-ТРАУ-ен]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Graf" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Graf</div>
-            </div>
-            <div class="vocab-translation">граф</div>
-            <div class="vocab-transcription">[дер ГРАФ]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Ehre" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Ehre</div>
-            </div>
-            <div class="vocab-translation">честь</div>
-            <div class="vocab-transcription">[ди Э-ре]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="rechtschaffen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">rechtschaffen</div>
-            </div>
-            <div class="vocab-translation">праведный</div>
-            <div class="vocab-transcription">[РЕХТ-ша-фен]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Pflicht" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Pflicht</div>
-            </div>
-            <div class="vocab-translation">долг</div>
-            <div class="vocab-transcription">[ди ПФЛИХТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="achten">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">achten</div>
-            </div>
-            <div class="vocab-translation">уважать</div>
-            <div class="vocab-transcription">[АХ-тен]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1920,29 +1846,29 @@
             {
                 "question": "Что означает немецкое слово «der Adel»?",
                 "choices": [
+                    "граф",
                     "доверять",
                     "знать",
-                    "служить",
-                    "граф"
+                    "служить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
-                    "служить",
-                    "граф",
                     "знать",
-                    "доверять"
+                    "доверять",
+                    "граф",
+                    "служить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vertrauen»?",
                 "choices": [
                     "граф",
-                    "знать",
                     "служить",
+                    "знать",
                     "доверять"
                 ],
                 "correctIndex": 3
@@ -1950,52 +1876,52 @@
             {
                 "question": "Что означает немецкое слово «der Graf»?",
                 "choices": [
-                    "знать",
                     "граф",
+                    "знать",
                     "служить",
                     "долг"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Ehre»?",
                 "choices": [
-                    "праведный",
-                    "долг",
+                    "служить",
                     "честь",
-                    "знать"
+                    "доверять",
+                    "уважать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «rechtschaffen»?",
                 "choices": [
-                    "доверять",
-                    "праведный",
                     "честь",
-                    "уважать"
+                    "праведный",
+                    "долг",
+                    "служить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Pflicht»?",
                 "choices": [
-                    "знать",
-                    "долг",
-                    "честь",
-                    "уважать"
+                    "праведный",
+                    "служить",
+                    "уважать",
+                    "долг"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «achten»?",
                 "choices": [
-                    "доверять",
-                    "уважать",
+                    "праведный",
+                    "граф",
                     "долг",
-                    "граф"
+                    "уважать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2711,82 +2637,82 @@
             {
                 "question": "Что означает немецкое слово «der Brief»?",
                 "choices": [
+                    "письмо",
                     "обман",
                     "обманывать",
-                    "верить",
-                    "письмо"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «glauben»?",
-                "choices": [
-                    "обманывать",
-                    "верить",
-                    "обман",
-                    "письмо"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "обман",
-                    "обманывать",
-                    "подозревать",
-                    "ловушка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Betrug»?",
-                "choices": [
-                    "верить",
-                    "ловушка",
-                    "обман",
-                    "простодушный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «arglos»?",
-                "choices": [
-                    "обман",
-                    "простодушный",
-                    "обманывать",
-                    "ловушка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verdächtigen»?",
-                "choices": [
-                    "подозревать",
-                    "обманывать",
-                    "обман",
-                    "ловушка"
+                    "верить"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «leichtgläubig»?",
+                "question": "Что означает немецкое слово «glauben»?",
                 "choices": [
+                    "обман",
+                    "письмо",
                     "верить",
+                    "обманывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "легковерный",
+                    "письмо",
+                    "обманывать",
+                    "обман"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Betrug»?",
+                "choices": [
                     "простодушный",
                     "обманывать",
-                    "легковерный"
+                    "ловушка",
+                    "обман"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Falle»?",
+                "question": "Что означает немецкое слово «arglos»?",
+                "choices": [
+                    "простодушный",
+                    "подозревать",
+                    "легковерный",
+                    "верить"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «verdächtigen»?",
                 "choices": [
                     "легковерный",
-                    "верить",
-                    "обманывать",
-                    "ловушка"
+                    "подозревать",
+                    "простодушный",
+                    "письмо"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «leichtgläubig»?",
+                "choices": [
+                    "обманывать",
+                    "легковерный",
+                    "простодушный",
+                    "подозревать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «die Falle»?",
+                "choices": [
+                    "обман",
+                    "обманывать",
+                    "ловушка",
+                    "простодушный"
+                ],
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -3453,49 +3379,49 @@
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
-                    "изгонять",
-                    "сожалеть",
+                    "заблуждение",
                     "проклинать",
-                    "заблуждение"
+                    "сожалеть",
+                    "изгонять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "слепой",
+                    "несправедливость",
                     "изгонять",
-                    "сожалеть",
-                    "несправедливость"
+                    "слепой",
+                    "сожалеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Irrtum»?",
                 "choices": [
-                    "заблуждение",
                     "проклинать",
-                    "слепой",
-                    "гнать"
+                    "гнать",
+                    "несправедливость",
+                    "заблуждение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «blind»?",
                 "choices": [
-                    "заблуждение",
-                    "несправедливость",
                     "слепой",
-                    "сожалеть"
+                    "заблуждение",
+                    "изгонять",
+                    "гнать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «jagen»?",
                 "choices": [
                     "слепой",
                     "гнать",
-                    "заблуждение",
+                    "сожалеть",
                     "несправедливость"
                 ],
                 "correctIndex": 1
@@ -3503,12 +3429,12 @@
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "изгонять",
+                    "слепой",
+                    "проклинать",
                     "заблуждение",
-                    "несправедливость",
-                    "сожалеть"
+                    "несправедливость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4205,82 +4131,82 @@
             {
                 "question": "Что означает немецкое слово «helfen»?",
                 "choices": [
+                    "опасность",
+                    "помогать",
                     "рисковать",
-                    "опасность",
-                    "помогать",
                     "сострадание"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Mitleid»?",
-                "choices": [
-                    "опасность",
-                    "сострадание",
-                    "помогать",
-                    "рисковать"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «riskieren»?",
+                "question": "Что означает немецкое слово «das Mitleid»?",
                 "choices": [
                     "рисковать",
-                    "сострадание",
+                    "опасность",
                     "помогать",
-                    "защищать"
+                    "сострадание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «riskieren»?",
+                "choices": [
+                    "измена",
+                    "сострадание",
+                    "рисковать",
+                    "осмеливаться"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Gefahr»?",
                 "choices": [
-                    "опасность",
                     "тайно",
-                    "защищать",
-                    "сострадание"
+                    "измена",
+                    "опасность",
+                    "помогать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «heimlich»?",
                 "choices": [
-                    "помогать",
-                    "опасность",
+                    "измена",
+                    "сострадание",
                     "тайно",
-                    "измена"
+                    "осмеливаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «schützen»?",
                 "choices": [
-                    "измена",
                     "тайно",
+                    "опасность",
                     "защищать",
-                    "осмеливаться"
+                    "измена"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
+                    "сострадание",
                     "измена",
                     "рисковать",
-                    "помогать",
-                    "опасность"
+                    "помогать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wagen»?",
                 "choices": [
-                    "помогать",
                     "осмеливаться",
-                    "опасность",
-                    "сострадание"
+                    "тайно",
+                    "сострадание",
+                    "помогать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4926,59 +4852,59 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "пытка",
                     "ослеплять",
+                    "пытка",
                     "боль",
                     "темнота"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
                     "боль",
                     "пытка",
-                    "темнота",
-                    "ослеплять"
+                    "ослеплять",
+                    "темнота"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Schmerz»?",
                 "choices": [
-                    "боль",
                     "месть",
                     "темнота",
-                    "пытка"
+                    "ослеплять",
+                    "боль"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Dunkelheit»?",
                 "choices": [
+                    "месть",
                     "темнота",
-                    "пытка",
-                    "боль",
-                    "слепнуть"
+                    "слепнуть",
+                    "пытка"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «schreien»?",
                 "choices": [
+                    "слепнуть",
                     "ослеплять",
-                    "боль",
-                    "кричать",
-                    "месть"
+                    "пытка",
+                    "кричать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «erblinden»?",
                 "choices": [
-                    "кричать",
-                    "темнота",
                     "боль",
+                    "пытка",
+                    "кричать",
                     "слепнуть"
                 ],
                 "correctIndex": 3
@@ -4987,11 +4913,11 @@
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "слепнуть",
-                    "ослеплять",
-                    "темнота",
-                    "месть"
+                    "кричать",
+                    "месть",
+                    "ослеплять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5713,38 +5639,38 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "обман",
-                    "пропасть",
-                    "отчаяние",
-                    "прыгать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «springen»?",
-                "choices": [
-                    "отчаяние",
                     "пропасть",
                     "обман",
-                    "прыгать"
+                    "прыгать",
+                    "отчаяние"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «springen»?",
+                "choices": [
+                    "пропасть",
+                    "обман",
+                    "прыгать",
+                    "отчаяние"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Täuschung»?",
                 "choices": [
-                    "падать",
-                    "обман",
                     "избавлять",
-                    "безнадёжность"
+                    "прыгать",
+                    "отчаяние",
+                    "обман"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abgrund»?",
                 "choices": [
-                    "избавлять",
-                    "прыгать",
+                    "падать",
+                    "сдаваться",
                     "обман",
                     "пропасть"
                 ],
@@ -5753,42 +5679,42 @@
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "избавлять",
-                    "прыгать",
-                    "обман",
-                    "сдаваться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
-                "choices": [
+                    "сдаваться",
+                    "отчаяние",
                     "безнадёжность",
-                    "пропасть",
-                    "падать",
-                    "прыгать"
+                    "избавлять"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Hoffnungslosigkeit»?",
+                "choices": [
+                    "пропасть",
+                    "безнадёжность",
+                    "обман",
+                    "сдаваться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «stürzen»?",
                 "choices": [
-                    "отчаяние",
-                    "пропасть",
                     "падать",
-                    "обман"
+                    "пропасть",
+                    "отчаяние",
+                    "безнадёжность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erlösen»?",
                 "choices": [
-                    "обман",
                     "прыгать",
-                    "избавлять",
-                    "падать"
+                    "безнадёжность",
+                    "сдаваться",
+                    "избавлять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6499,12 +6425,12 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
-                    "узнавать",
-                    "умирать",
+                    "осознание",
                     "прощать",
-                    "осознание"
+                    "узнавать",
+                    "умирать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
@@ -6519,20 +6445,20 @@
             {
                 "question": "Что означает немецкое слово «sterben»?",
                 "choices": [
-                    "узнавать",
                     "умирать",
-                    "прощать",
+                    "осознание",
+                    "примирение",
                     "обнимать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "сердце",
-                    "примирение",
+                    "раскаяние",
+                    "обнимать",
                     "осознание",
-                    "раскаяние"
+                    "сердце"
                 ],
                 "correctIndex": 2
             },
@@ -6540,8 +6466,8 @@
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
                     "раскаяние",
-                    "примирение",
                     "умирать",
+                    "примирение",
                     "осознание"
                 ],
                 "correctIndex": 0
@@ -6549,32 +6475,32 @@
             {
                 "question": "Что означает немецкое слово «umarmen»?",
                 "choices": [
+                    "обнимать",
+                    "примирение",
                     "сердце",
-                    "осознание",
-                    "узнавать",
-                    "обнимать"
+                    "умирать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Versöhnung»?",
                 "choices": [
-                    "обнимать",
-                    "умирать",
+                    "прощать",
                     "примирение",
-                    "сердце"
+                    "осознание",
+                    "узнавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
-                    "примирение",
+                    "осознание",
+                    "прощать",
                     "сердце",
-                    "раскаяние",
-                    "прощать"
+                    "узнавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -6715,6 +6641,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7607,6 +7563,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7682,71 +7835,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7754,7 +7852,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/goneril.html
+++ b/output/journeys/goneril.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-die" data-word="Lüge" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Lüge</div>
-            </div>
-            <div class="vocab-translation">ложь</div>
-            <div class="vocab-transcription">[ди ЛЮ-ге]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="schwören">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">schwören</div>
-            </div>
-            <div class="vocab-translation">клясться</div>
-            <div class="vocab-transcription">[ШВЁ-рен]</div>
-        </div>
-
-        <div class="vocab-card is-das" data-word="Erbe" data-article="das">
-            <div class="vocab-header">
-                <span class="article-chip das"><span class="article-icon">⚪</span><span>das</span></span>
-                <div class="vocab-word">Erbe</div>
-            </div>
-            <div class="vocab-translation">наследство</div>
-            <div class="vocab-transcription">[дас ЕР-бе]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="heucheln">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">heucheln</div>
-            </div>
-            <div class="vocab-translation">лицемерить</div>
-            <div class="vocab-transcription">[ХОЙ-хельн]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Gier" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Gier</div>
-            </div>
-            <div class="vocab-translation">жадность</div>
-            <div class="vocab-transcription">[ди ГИР]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="täuschen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">täuschen</div>
-            </div>
-            <div class="vocab-translation">обманывать</div>
-            <div class="vocab-transcription">[ТОЙ-шен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="schmeicheln">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">schmeicheln</div>
-            </div>
-            <div class="vocab-translation">льстить</div>
-            <div class="vocab-transcription">[ШМАЙ-хельн]</div>
-        </div>
-
-        <div class="vocab-card is-das" data-word="Vermögen" data-article="das">
-            <div class="vocab-header">
-                <span class="article-chip das"><span class="article-icon">⚪</span><span>das</span></span>
-                <div class="vocab-word">Vermögen</div>
-            </div>
-            <div class="vocab-translation">состояние</div>
-            <div class="vocab-transcription">[дас фер-МЁ-ген]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1965,82 +1891,82 @@
             {
                 "question": "Что означает немецкое слово «die Lüge»?",
                 "choices": [
-                    "клясться",
-                    "лицемерить",
-                    "ложь",
-                    "наследство"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «schwören»?",
-                "choices": [
-                    "ложь",
                     "наследство",
-                    "лицемерить",
-                    "клясться"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «das Erbe»?",
-                "choices": [
-                    "лицемерить",
+                    "ложь",
                     "клясться",
-                    "наследство",
-                    "ложь"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «heucheln»?",
-                "choices": [
-                    "лицемерить",
-                    "обманывать",
-                    "льстить",
-                    "состояние"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «die Gier»?",
-                "choices": [
-                    "жадность",
-                    "обманывать",
-                    "состояние",
                     "лицемерить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «täuschen»?",
-                "choices": [
-                    "лицемерить",
-                    "обманывать",
-                    "льстить",
-                    "ложь"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «schmeicheln»?",
+                "question": "Что означает немецкое слово «schwören»?",
                 "choices": [
+                    "лицемерить",
+                    "наследство",
                     "клясться",
-                    "ложь",
-                    "льстить",
-                    "лицемерить"
+                    "ложь"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «das Vermögen»?",
+                "question": "Что означает немецкое слово «das Erbe»?",
                 "choices": [
+                    "состояние",
                     "наследство",
-                    "льстить",
-                    "ложь",
-                    "состояние"
+                    "жадность",
+                    "обманывать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «heucheln»?",
+                "choices": [
+                    "состояние",
+                    "жадность",
+                    "обманывать",
+                    "лицемерить"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «die Gier»?",
+                "choices": [
+                    "льстить",
+                    "состояние",
+                    "наследство",
+                    "жадность"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «täuschen»?",
+                "choices": [
+                    "ложь",
+                    "наследство",
+                    "клясться",
+                    "обманывать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «schmeicheln»?",
+                "choices": [
+                    "льстить",
+                    "жадность",
+                    "состояние",
+                    "клясться"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Vermögen»?",
+                "choices": [
+                    "состояние",
+                    "ложь",
+                    "лицемерить",
+                    "клясться"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2814,82 +2740,82 @@
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "править",
-                    "приказывать",
                     "трон",
-                    "власть"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «herrschen»?",
-                "choices": [
-                    "власть",
                     "приказывать",
-                    "править",
-                    "трон"
+                    "власть",
+                    "править"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «herrschen»?",
+                "choices": [
+                    "править",
+                    "приказывать",
+                    "власть",
+                    "трон"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «befehlen»?",
                 "choices": [
-                    "господство",
+                    "править",
                     "приказывать",
-                    "управлять",
-                    "завоёвывать"
+                    "власть",
+                    "трон"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "подчинять",
-                    "власть",
-                    "управлять",
-                    "трон"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «erobern»?",
-                "choices": [
                     "власть",
                     "трон",
-                    "управлять",
-                    "завоёвывать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Herrschaft»?",
-                "choices": [
-                    "завоёвывать",
-                    "власть",
-                    "господство",
-                    "управлять"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «regieren»?",
-                "choices": [
-                    "править",
-                    "управлять",
-                    "трон",
-                    "власть"
+                    "приказывать",
+                    "господство"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «unterwerfen»?",
+                "question": "Что означает немецкое слово «erobern»?",
                 "choices": [
-                    "трон",
                     "управлять",
-                    "приказывать",
-                    "подчинять"
+                    "власть",
+                    "завоёвывать",
+                    "приказывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Herrschaft»?",
+                "choices": [
+                    "управлять",
+                    "подчинять",
+                    "править",
+                    "господство"
                 ],
                 "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «regieren»?",
+                "choices": [
+                    "господство",
+                    "приказывать",
+                    "подчинять",
+                    "управлять"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «unterwerfen»?",
+                "choices": [
+                    "приказывать",
+                    "подчинять",
+                    "господство",
+                    "управлять"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3681,82 +3607,82 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "жестокий",
                     "унижать",
+                    "жестокий",
                     "месть",
                     "изгонять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «grausam»?",
                 "choices": [
-                    "изгонять",
+                    "жестокий",
                     "месть",
-                    "унижать",
-                    "жестокий"
+                    "изгонять",
+                    "унижать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Rache»?",
                 "choices": [
                     "месть",
-                    "ограничивать",
                     "отказывать",
-                    "мучить"
+                    "унижать",
+                    "изгонять"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "отказывать",
-                    "месть",
                     "презирать",
-                    "изгонять"
+                    "изгонять",
+                    "месть",
+                    "ограничивать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verachten»?",
                 "choices": [
-                    "презирать",
-                    "мучить",
                     "унижать",
-                    "изгонять"
+                    "презирать",
+                    "отказывать",
+                    "ограничивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verweigern»?",
                 "choices": [
+                    "презирать",
                     "отказывать",
-                    "ограничивать",
-                    "мучить",
-                    "жестокий"
+                    "изгонять",
+                    "мучить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «quälen»?",
                 "choices": [
+                    "унижать",
+                    "изгонять",
                     "мучить",
-                    "жестокий",
-                    "отказывать",
-                    "презирать"
+                    "ограничивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «beschränken»?",
                 "choices": [
-                    "месть",
-                    "жестокий",
-                    "ограничивать",
-                    "изгонять"
+                    "мучить",
+                    "унижать",
+                    "презирать",
+                    "ограничивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4470,29 +4396,29 @@
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
                 "choices": [
-                    "запирать",
-                    "буря",
                     "отвергать",
+                    "буря",
+                    "запирать",
                     "безжалостный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
                     "буря",
                     "безжалостный",
-                    "запирать",
-                    "отвергать"
+                    "отвергать",
+                    "запирать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «gnadenlos»?",
                 "choices": [
-                    "холод",
-                    "безжалостный",
                     "беспощадный",
+                    "безжалостный",
+                    "буря",
                     "ожесточаться"
                 ],
                 "correctIndex": 1
@@ -4500,42 +4426,42 @@
             {
                 "question": "Что означает немецкое слово «verschließen»?",
                 "choices": [
+                    "холод",
                     "запирать",
-                    "буря",
-                    "беспощадный",
-                    "безжалостный"
+                    "безжалостный",
+                    "отвергать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "запирать",
                     "холод",
-                    "беспощадный",
-                    "буря"
+                    "запирать",
+                    "безжалостный",
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
                     "отвергать",
-                    "буря",
-                    "беспощадный",
-                    "холод"
+                    "ожесточаться",
+                    "запирать",
+                    "беспощадный"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verhärten»?",
                 "choices": [
-                    "ожесточаться",
                     "буря",
-                    "отвергать",
-                    "беспощадный"
+                    "холод",
+                    "ожесточаться",
+                    "безжалостный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -5295,82 +5221,82 @@
             {
                 "question": "Что означает немецкое слово «streiten»?",
                 "choices": [
+                    "предавать",
                     "ссориться",
-                    "ненавидеть",
                     "раздор",
-                    "предавать"
+                    "ненавидеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "ненавидеть",
-                    "предавать",
                     "ссориться",
-                    "раздор"
+                    "раздор",
+                    "ненавидеть",
+                    "предавать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zwietracht»?",
                 "choices": [
+                    "презрение",
+                    "ненавидеть",
                     "раздор",
-                    "страсть",
-                    "предавать",
-                    "изменять"
+                    "предавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
-                    "ссориться",
-                    "ненавидеть",
+                    "разрушать",
+                    "предавать",
                     "презрение",
-                    "страсть"
+                    "ненавидеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «betrügen»?",
                 "choices": [
-                    "презрение",
-                    "ненавидеть",
                     "изменять",
-                    "страсть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Verachtung»?",
-                "choices": [
-                    "презрение",
-                    "ненавидеть",
-                    "ссориться",
-                    "предавать"
+                    "страсть",
+                    "раздор",
+                    "ссориться"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «zerstören»?",
+                "question": "Что означает немецкое слово «die Verachtung»?",
                 "choices": [
-                    "изменять",
-                    "страсть",
-                    "разрушать",
-                    "ненавидеть"
+                    "ссориться",
+                    "предавать",
+                    "презрение",
+                    "разрушать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «zerstören»?",
+                "choices": [
+                    "предавать",
+                    "разрушать",
+                    "изменять",
+                    "ссориться"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «die Leidenschaft»?",
                 "choices": [
-                    "разрушать",
-                    "ссориться",
+                    "раздор",
                     "страсть",
-                    "раздор"
+                    "ненавидеть",
+                    "ссориться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -6146,82 +6072,82 @@
             {
                 "question": "Что означает немецкое слово «die Eifersucht»?",
                 "choices": [
-                    "ревность",
                     "желать",
-                    "бороться",
-                    "соперничать"
+                    "соперничать",
+                    "ревность",
+                    "бороться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «rivalisieren»?",
                 "choices": [
+                    "ревность",
                     "желать",
-                    "бороться",
                     "соперничать",
-                    "ревность"
+                    "бороться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "ревность",
-                    "бороться",
-                    "желать",
-                    "соперничать"
+                    "соперничать",
+                    "яд",
+                    "интрига",
+                    "бороться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "интрига",
+                    "ревность",
                     "желать",
-                    "убивать",
-                    "ревность"
+                    "яд",
+                    "устранять"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beseitigen»?",
                 "choices": [
-                    "устранять",
-                    "ревность",
-                    "желать",
-                    "интрига"
+                    "яд",
+                    "бороться",
+                    "соперничать",
+                    "устранять"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Gift»?",
                 "choices": [
+                    "устранять",
                     "интрига",
                     "яд",
-                    "убивать",
-                    "желать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Intrige»?",
-                "choices": [
-                    "убивать",
-                    "соперничать",
-                    "интрига",
-                    "бороться"
+                    "убивать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «die Intrige»?",
+                "choices": [
+                    "интрига",
+                    "устранять",
+                    "ревность",
+                    "убивать"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «morden»?",
                 "choices": [
-                    "бороться",
                     "убивать",
-                    "желать",
-                    "соперничать"
+                    "ревность",
+                    "соперничать",
+                    "интрига"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6989,82 +6915,82 @@
             {
                 "question": "Что означает немецкое слово «vergiften»?",
                 "choices": [
+                    "отравлять",
                     "отчаяние",
                     "вина",
-                    "отравлять",
                     "умирать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Verzweiflung»?",
-                "choices": [
-                    "умирать",
-                    "отчаяние",
-                    "вина",
-                    "отравлять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "умирать",
-                    "погибель",
-                    "отравлять",
-                    "отчаяние"
                 ],
                 "correctIndex": 0
             },
             {
+                "question": "Что означает немецкое слово «die Verzweiflung»?",
+                "choices": [
+                    "отчаяние",
+                    "отравлять",
+                    "умирать",
+                    "вина"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "отчаяние",
+                    "отравлять",
+                    "умирать",
+                    "вина"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «die Schuld»?",
                 "choices": [
-                    "уничтожать",
-                    "вина",
+                    "погибель",
+                    "отчаяние",
                     "сожалеть",
-                    "отчаяние"
+                    "вина"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vernichten»?",
                 "choices": [
-                    "умирать",
                     "уничтожать",
+                    "отчаяние",
+                    "погибель",
+                    "отравлять"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Verderben»?",
+                "choices": [
+                    "отравлять",
+                    "погибель",
+                    "умирать",
+                    "вина"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «bereuen»?",
+                "choices": [
+                    "умирать",
+                    "сожалеть",
                     "погибель",
                     "ад"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «das Verderben»?",
-                "choices": [
-                    "отчаяние",
-                    "отравлять",
-                    "сожалеть",
-                    "погибель"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «bereuen»?",
-                "choices": [
-                    "ад",
-                    "сожалеть",
-                    "отравлять",
-                    "отчаяние"
-                ],
-                "correctIndex": 1
-            },
-            {
                 "question": "Что означает немецкое слово «die Hölle»?",
                 "choices": [
-                    "погибель",
-                    "ад",
                     "уничтожать",
-                    "отчаяние"
+                    "сожалеть",
+                    "ад",
+                    "погибель"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -7221,6 +7147,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -8113,6 +8069,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -8188,71 +8341,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -8260,7 +8358,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/kent.html
+++ b/output/journeys/kent.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-die" data-word="Treue" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Treue</div>
-            </div>
-            <div class="vocab-translation">верность</div>
-            <div class="vocab-transcription">[ди ТРОЙ-е]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Mut" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Mut</div>
-            </div>
-            <div class="vocab-translation">мужество</div>
-            <div class="vocab-transcription">[дер МУТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="widersprechen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">widersprechen</div>
-            </div>
-            <div class="vocab-translation">возражать</div>
-            <div class="vocab-transcription">[ВИ-дер-шпре-хен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="verteidigen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">verteidigen</div>
-            </div>
-            <div class="vocab-translation">защищать</div>
-            <div class="vocab-transcription">[фер-ТАЙ-ди-ген]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="aufrichtig">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">aufrichtig</div>
-            </div>
-            <div class="vocab-translation">искренний</div>
-            <div class="vocab-transcription">[АУФ-рих-тиг]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Diener" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Diener</div>
-            </div>
-            <div class="vocab-translation">слуга</div>
-            <div class="vocab-transcription">[дер ДИ-нер]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="warnen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">warnen</div>
-            </div>
-            <div class="vocab-translation">предупреждать</div>
-            <div class="vocab-transcription">[ВАР-нен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="gerecht">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">gerecht</div>
-            </div>
-            <div class="vocab-translation">справедливый</div>
-            <div class="vocab-transcription">[ге-РЕХТ]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1900,19 +1826,19 @@
             {
                 "question": "Что означает немецкое слово «die Treue»?",
                 "choices": [
-                    "защищать",
-                    "возражать",
                     "мужество",
-                    "верность"
+                    "верность",
+                    "возражать",
+                    "защищать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Mut»?",
                 "choices": [
-                    "верность",
                     "защищать",
                     "возражать",
+                    "верность",
                     "мужество"
                 ],
                 "correctIndex": 3
@@ -1921,61 +1847,61 @@
                 "question": "Что означает немецкое слово «widersprechen»?",
                 "choices": [
                     "искренний",
-                    "мужество",
+                    "справедливый",
                     "возражать",
-                    "верность"
+                    "предупреждать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verteidigen»?",
                 "choices": [
-                    "искренний",
-                    "верность",
-                    "мужество",
-                    "защищать"
+                    "справедливый",
+                    "слуга",
+                    "защищать",
+                    "предупреждать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «aufrichtig»?",
                 "choices": [
-                    "слуга",
-                    "верность",
                     "мужество",
-                    "искренний"
+                    "искренний",
+                    "верность",
+                    "защищать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "предупреждать",
-                    "искренний",
+                    "возражать",
+                    "мужество",
                     "слуга",
-                    "защищать"
+                    "предупреждать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «warnen»?",
                 "choices": [
+                    "слуга",
                     "предупреждать",
-                    "верность",
-                    "защищать",
-                    "искренний"
+                    "мужество",
+                    "верность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «gerecht»?",
                 "choices": [
-                    "верность",
                     "справедливый",
                     "искренний",
-                    "слуга"
+                    "предупреждать",
+                    "защищать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -2637,72 +2563,72 @@
             {
                 "question": "Что означает немецкое слово «die Verbannung»?",
                 "choices": [
-                    "изгнание",
-                    "гнев",
+                    "несправедливость",
                     "изгнанный",
-                    "несправедливость"
+                    "гнев",
+                    "изгнание"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ungerechtigkeit»?",
                 "choices": [
-                    "несправедливость",
-                    "изгнание",
-                    "изгнанный",
-                    "гнев"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «der Zorn»?",
-                "choices": [
-                    "возвращаться",
                     "гнев",
                     "несправедливость",
+                    "изгнанный",
                     "изгнание"
                 ],
                 "correctIndex": 1
             },
             {
+                "question": "Что означает немецкое слово «der Zorn»?",
+                "choices": [
+                    "несправедливость",
+                    "изгнание",
+                    "гнев",
+                    "возвращаться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «verbannt»?",
                 "choices": [
                     "прощание",
-                    "несправедливость",
+                    "гнев",
                     "изгнанный",
-                    "изгнание"
+                    "возвращаться"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "гнев",
                     "возвращаться",
-                    "наказание",
-                    "прощание"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Strafe»?",
-                "choices": [
-                    "изгнание",
-                    "наказание",
-                    "гнев",
+                    "прощание",
+                    "несправедливость",
                     "изгнанный"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «zurückkehren»?",
+                "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
-                    "наказание",
                     "несправедливость",
-                    "возвращаться",
-                    "изгнанный"
+                    "прощание",
+                    "наказание",
+                    "гнев"
                 ],
                 "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «zurückkehren»?",
+                "choices": [
+                    "возвращаться",
+                    "прощание",
+                    "несправедливость",
+                    "гнев"
+                ],
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -3446,78 +3372,78 @@
                 "choices": [
                     "хитрость",
                     "притворяться",
-                    "переодевание",
-                    "неузнанный"
+                    "неузнанный",
+                    "переодевание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
                     "хитрость",
-                    "неузнанный",
+                    "притворяться",
                     "переодевание",
-                    "притворяться"
+                    "неузнанный"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «unerkannt»?",
                 "choices": [
-                    "притворяться",
-                    "переодевание",
                     "неузнанный",
-                    "верный"
+                    "наниматься",
+                    "переодевание",
+                    "хитрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vorgeben»?",
                 "choices": [
-                    "верный",
-                    "неузнанный",
                     "притворяться",
-                    "наниматься"
+                    "неузнанный",
+                    "наниматься",
+                    "хитрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verstellen»?",
                 "choices": [
-                    "борода",
+                    "неузнанный",
                     "притворяться",
                     "изменять",
-                    "наниматься"
+                    "верный"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Bart»?",
                 "choices": [
-                    "борода",
-                    "хитрость",
                     "верный",
-                    "переодевание"
+                    "неузнанный",
+                    "борода",
+                    "притворяться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «anheuern»?",
                 "choices": [
+                    "переодевание",
+                    "неузнанный",
                     "наниматься",
-                    "хитрость",
-                    "изменять",
-                    "неузнанный"
+                    "борода"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «treu»?",
                 "choices": [
-                    "наниматься",
-                    "верный",
                     "изменять",
-                    "борода"
+                    "верный",
+                    "переодевание",
+                    "неузнанный"
                 ],
                 "correctIndex": 1
             }
@@ -4159,72 +4085,72 @@
             {
                 "question": "Что означает немецкое слово «der Dienst»?",
                 "choices": [
-                    "охранять",
-                    "защита",
-                    "опасность",
-                    "служба"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Schutz»?",
-                "choices": [
                     "служба",
-                    "защита",
                     "опасность",
-                    "охранять"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «die Gefahr»?",
-                "choices": [
-                    "опасность",
-                    "сражаться",
                     "защита",
                     "охранять"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «bewachen»?",
+                "question": "Что означает немецкое слово «der Schutz»?",
                 "choices": [
+                    "опасность",
+                    "охранять",
                     "служба",
-                    "сражаться",
-                    "советовать",
-                    "охранять"
+                    "защита"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Gefahr»?",
+                "choices": [
+                    "охранять",
+                    "советовать",
+                    "сражаться",
+                    "опасность"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «bewachen»?",
+                "choices": [
+                    "советовать",
+                    "служба",
+                    "охранять",
+                    "сражаться"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «kämpfen»?",
                 "choices": [
-                    "стража",
                     "сражаться",
-                    "охранять",
-                    "советовать"
+                    "советовать",
+                    "служба",
+                    "стража"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «raten»?",
                 "choices": [
                     "охранять",
-                    "опасность",
-                    "советовать",
-                    "стража"
+                    "служба",
+                    "защита",
+                    "советовать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Wache»?",
                 "choices": [
                     "охранять",
+                    "сражаться",
                     "служба",
-                    "стража",
-                    "опасность"
+                    "стража"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -4938,39 +4864,39 @@
                 "question": "Что означает немецкое слово «die Strafe»?",
                 "choices": [
                     "унижение",
-                    "сковывать",
                     "стойкость",
-                    "наказание"
+                    "наказание",
+                    "сковывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Demütigung»?",
                 "choices": [
                     "стойкость",
-                    "сковывать",
+                    "наказание",
                     "унижение",
-                    "наказание"
+                    "сковывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Standhaftigkeit»?",
                 "choices": [
-                    "унижение",
                     "выдерживать",
                     "стойкость",
+                    "наказание",
                     "терпеть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fesseln»?",
                 "choices": [
-                    "наказание",
+                    "стойкость",
                     "сковывать",
-                    "выдерживать",
-                    "терпеть"
+                    "терпеть",
+                    "унижение"
                 ],
                 "correctIndex": 1
             },
@@ -4978,39 +4904,39 @@
                 "question": "Что означает немецкое слово «erdulden»?",
                 "choices": [
                     "унижение",
-                    "выдерживать",
+                    "стойкость",
                     "терпеть",
-                    "позор"
+                    "выдерживать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Stock»?",
                 "choices": [
+                    "выдерживать",
                     "позор",
-                    "сковывать",
-                    "колодка",
-                    "выдерживать"
+                    "унижение",
+                    "колодка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ausharren»?",
                 "choices": [
-                    "наказание",
-                    "сковывать",
-                    "стойкость",
-                    "выдерживать"
+                    "выдерживать",
+                    "позор",
+                    "терпеть",
+                    "стойкость"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Schande»?",
                 "choices": [
                     "позор",
-                    "сковывать",
-                    "колодка",
-                    "терпеть"
+                    "терпеть",
+                    "стойкость",
+                    "наказание"
                 ],
                 "correctIndex": 0
             }
@@ -5670,72 +5596,72 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
+                    "поддержка",
                     "буря",
                     "утешать",
-                    "поддержка",
                     "сопровождать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Beistand»?",
                 "choices": [
+                    "поддержка",
                     "утешать",
                     "сопровождать",
-                    "буря",
-                    "поддержка"
+                    "буря"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begleiten»?",
                 "choices": [
-                    "сопровождать",
                     "холод",
+                    "сопровождать",
                     "поддержка",
                     "убежище"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «trösten»?",
                 "choices": [
                     "поддержка",
-                    "утешать",
-                    "буря",
-                    "холод"
+                    "холод",
+                    "убежище",
+                    "утешать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Zuflucht»?",
                 "choices": [
-                    "сопровождать",
-                    "холод",
                     "убежище",
-                    "выдерживать"
+                    "буря",
+                    "сопровождать",
+                    "поддержка"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «durchhalten»?",
                 "choices": [
-                    "сопровождать",
-                    "убежище",
+                    "утешать",
+                    "буря",
                     "выдерживать",
-                    "утешать"
+                    "холод"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Kälte»?",
                 "choices": [
-                    "поддержка",
                     "холод",
-                    "выдерживать",
-                    "сопровождать"
+                    "сопровождать",
+                    "поддержка",
+                    "убежище"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6468,80 +6394,80 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "плакать",
                     "прощание",
-                    "смерть",
-                    "вечный"
+                    "вечный",
+                    "плакать",
+                    "смерть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "вечный",
                     "прощание",
+                    "смерть",
                     "плакать",
-                    "смерть"
+                    "вечный"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
                     "скорбь",
-                    "смерть",
                     "вечный",
-                    "плакать"
+                    "следовать",
+                    "сдаваться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «weinen»?",
                 "choices": [
                     "смерть",
-                    "истощение",
-                    "плакать",
-                    "вечный"
+                    "скорбь",
+                    "следовать",
+                    "плакать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Erschöpfung»?",
                 "choices": [
                     "истощение",
-                    "прощание",
-                    "скорбь",
-                    "смерть"
+                    "сдаваться",
+                    "плакать",
+                    "прощание"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «aufgeben»?",
                 "choices": [
-                    "прощание",
-                    "скорбь",
-                    "плакать",
-                    "сдаваться"
+                    "истощение",
+                    "сдаваться",
+                    "вечный",
+                    "прощание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Trauer»?",
                 "choices": [
+                    "плакать",
                     "скорбь",
-                    "смерть",
-                    "сдаваться",
-                    "прощание"
+                    "вечный",
+                    "сдаваться"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «folgen»?",
                 "choices": [
+                    "истощение",
                     "сдаваться",
-                    "скорбь",
                     "следовать",
-                    "плакать"
+                    "смерть"
                 ],
                 "correctIndex": 2
             }
@@ -6684,6 +6610,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7576,6 +7532,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7651,71 +7804,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7723,7 +7821,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/king_lear.html
+++ b/output/journeys/king_lear.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Thron" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Thron</div>
-            </div>
-            <div class="vocab-translation">трон</div>
-            <div class="vocab-transcription">[дер ТРОН]</div>
-        </div>
-
-        <div class="vocab-card is-das" data-word="Königreich" data-article="das">
-            <div class="vocab-header">
-                <span class="article-chip das"><span class="article-icon">⚪</span><span>das</span></span>
-                <div class="vocab-word">Königreich</div>
-            </div>
-            <div class="vocab-translation">королевство</div>
-            <div class="vocab-transcription">[дас КЁ-ниг-райх]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Macht" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Macht</div>
-            </div>
-            <div class="vocab-translation">власть</div>
-            <div class="vocab-transcription">[ди МАХТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="herrschen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">herrschen</div>
-            </div>
-            <div class="vocab-translation">править</div>
-            <div class="vocab-transcription">[ХЕР-шен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="verkünden">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">verkünden</div>
-            </div>
-            <div class="vocab-translation">провозглашать</div>
-            <div class="vocab-transcription">[фер-КЮН-ден]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Krone" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Krone</div>
-            </div>
-            <div class="vocab-translation">корона</div>
-            <div class="vocab-transcription">[ди КРО-не]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Zeremonie" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Zeremonie</div>
-            </div>
-            <div class="vocab-translation">церемония</div>
-            <div class="vocab-transcription">[ди це-ре-мо-НИ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="prächtig">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">prächtig</div>
-            </div>
-            <div class="vocab-translation">великолепный</div>
-            <div class="vocab-transcription">[ПРЕХ-тиг]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -2001,8 +1927,8 @@
             {
                 "question": "Что означает немецкое слово «der Thron»?",
                 "choices": [
-                    "править",
                     "власть",
+                    "править",
                     "трон",
                     "королевство"
                 ],
@@ -2012,71 +1938,71 @@
                 "question": "Что означает немецкое слово «das Königreich»?",
                 "choices": [
                     "трон",
-                    "власть",
                     "править",
-                    "королевство"
+                    "королевство",
+                    "власть"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Macht»?",
                 "choices": [
-                    "власть",
                     "трон",
-                    "корона",
-                    "королевство"
+                    "церемония",
+                    "власть",
+                    "великолепный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «herrschen»?",
                 "choices": [
-                    "церемония",
+                    "провозглашать",
                     "править",
-                    "великолепный",
-                    "провозглашать"
+                    "корона",
+                    "королевство"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verkünden»?",
                 "choices": [
-                    "провозглашать",
-                    "королевство",
                     "власть",
-                    "корона"
+                    "великолепный",
+                    "провозглашать",
+                    "королевство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Krone»?",
                 "choices": [
-                    "править",
                     "церемония",
-                    "великолепный",
-                    "корона"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «die Zeremonie»?",
-                "choices": [
-                    "править",
-                    "церемония",
-                    "королевство",
-                    "великолепный"
+                    "корона",
+                    "власть",
+                    "трон"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «prächtig»?",
+                "question": "Что означает немецкое слово «die Zeremonie»?",
                 "choices": [
-                    "королевство",
+                    "корона",
                     "править",
-                    "великолепный",
+                    "власть",
                     "церемония"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «prächtig»?",
+                "choices": [
+                    "корона",
+                    "великолепный",
+                    "церемония",
+                    "трон"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -2860,82 +2786,82 @@
             {
                 "question": "Что означает немецкое слово «demütigen»?",
                 "choices": [
-                    "унижать",
                     "неблагодарность",
                     "проклинать",
+                    "унижать",
                     "гнев"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Zorn»?",
                 "choices": [
                     "унижать",
-                    "проклинать",
                     "неблагодарность",
-                    "гнев"
+                    "гнев",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Undankbarkeit»?",
                 "choices": [
-                    "неблагодарность",
-                    "унижать",
-                    "изгонять",
-                    "проклинать"
+                    "гнев",
+                    "проклинать",
+                    "проклятие",
+                    "неблагодарность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verfluchen»?",
                 "choices": [
                     "проклинать",
-                    "проклятие",
                     "унижать",
-                    "гнев"
+                    "гнев",
+                    "проклятие"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vertreiben»?",
                 "choices": [
-                    "изгонять",
-                    "гнев",
                     "унижать",
-                    "обида"
+                    "изгонять",
+                    "обида",
+                    "проклинать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Kränkung»?",
                 "choices": [
-                    "гнев",
                     "обида",
                     "унижать",
-                    "неблагодарность"
+                    "изгонять",
+                    "гнев"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «bereuen»?",
                 "choices": [
-                    "проклятие",
-                    "сожалеть",
+                    "проклинать",
                     "изгонять",
-                    "гнев"
+                    "гнев",
+                    "сожалеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «der Fluch»?",
                 "choices": [
-                    "сожалеть",
                     "изгонять",
+                    "проклятие",
                     "унижать",
-                    "проклятие"
+                    "неблагодарность"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3729,12 +3655,12 @@
             {
                 "question": "Что означает немецкое слово «verlassen»?",
                 "choices": [
-                    "жестокость",
-                    "покидать",
+                    "отчаяние",
                     "отвергать",
-                    "отчаяние"
+                    "покидать",
+                    "жестокость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verstoßen»?",
@@ -3749,9 +3675,9 @@
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
+                    "отчаяние",
                     "покидать",
                     "слеза",
-                    "одиночество",
                     "жестокость"
                 ],
                 "correctIndex": 3
@@ -3759,29 +3685,29 @@
             {
                 "question": "Что означает немецкое слово «die Verzweiflung»?",
                 "choices": [
-                    "одиночество",
-                    "просить",
                     "слеза",
-                    "отчаяние"
+                    "отчаяние",
+                    "отвергать",
+                    "просить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "отчаяние",
                     "жестокость",
+                    "нужда",
                     "просить",
-                    "покидать"
+                    "отвергать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Einsamkeit»?",
                 "choices": [
-                    "отвергать",
+                    "слеза",
                     "жестокость",
-                    "покидать",
+                    "просить",
                     "одиночество"
                 ],
                 "correctIndex": 3
@@ -3789,22 +3715,22 @@
             {
                 "question": "Что означает немецкое слово «die Träne»?",
                 "choices": [
-                    "отчаяние",
-                    "одиночество",
                     "слеза",
-                    "нужда"
+                    "покидать",
+                    "отчаяние",
+                    "жестокость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Not»?",
                 "choices": [
-                    "просить",
-                    "слеза",
                     "нужда",
-                    "отчаяние"
+                    "слеза",
+                    "отчаяние",
+                    "одиночество"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4588,80 +4514,80 @@
             {
                 "question": "Что означает немецкое слово «der Sturm»?",
                 "choices": [
-                    "бушевать",
-                    "безумие",
                     "буря",
+                    "безумие",
+                    "бушевать",
                     "гром"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Wahnsinn»?",
-                "choices": [
-                    "буря",
-                    "гром",
-                    "безумие",
-                    "бушевать"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «toben»?",
-                "choices": [
-                    "буря",
-                    "хаос",
-                    "голый",
-                    "бушевать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Donner»?",
-                "choices": [
-                    "бушевать",
-                    "хаос",
-                    "гром",
-                    "буря"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «der Blitz»?",
-                "choices": [
-                    "молния",
-                    "гром",
-                    "голый",
-                    "хаос"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «schreien»?",
+                "question": "Что означает немецкое слово «der Wahnsinn»?",
+                "choices": [
+                    "гром",
+                    "безумие",
+                    "бушевать",
+                    "буря"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «toben»?",
                 "choices": [
                     "голый",
+                    "хаос",
+                    "бушевать",
+                    "кричать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «der Donner»?",
+                "choices": [
+                    "кричать",
+                    "безумие",
+                    "молния",
+                    "гром"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «der Blitz»?",
+                "choices": [
+                    "кричать",
+                    "гром",
+                    "хаос",
+                    "молния"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «schreien»?",
+                "choices": [
+                    "гром",
                     "бушевать",
                     "кричать",
-                    "буря"
+                    "молния"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «nackt»?",
                 "choices": [
-                    "гром",
-                    "голый",
                     "молния",
-                    "бушевать"
+                    "бушевать",
+                    "безумие",
+                    "голый"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «das Chaos»?",
                 "choices": [
                     "буря",
                     "хаос",
-                    "бушевать",
-                    "гром"
+                    "кричать",
+                    "бушевать"
                 ],
                 "correctIndex": 1
             }
@@ -5463,59 +5389,59 @@
             {
                 "question": "Что означает немецкое слово «das Elend»?",
                 "choices": [
-                    "мёрзнуть",
+                    "нищий",
                     "бедный",
                     "нищета",
-                    "нищий"
+                    "мёрзнуть"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «der Bettler»?",
                 "choices": [
-                    "мёрзнуть",
-                    "бедный",
                     "нищий",
-                    "нищета"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «arm»?",
-                "choices": [
-                    "бедный",
                     "нищета",
-                    "шут",
-                    "хижина"
+                    "бедный",
+                    "мёрзнуть"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «frieren»?",
+                "question": "Что означает немецкое слово «arm»?",
                 "choices": [
-                    "шут",
-                    "мёрзнуть",
+                    "нищета",
                     "бедный",
-                    "страдать"
+                    "хижина",
+                    "нищий"
                 ],
                 "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «frieren»?",
+                "choices": [
+                    "страдать",
+                    "нищета",
+                    "нищий",
+                    "мёрзнуть"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Hütte»?",
                 "choices": [
                     "страдать",
-                    "шут",
-                    "мёрзнуть",
-                    "хижина"
+                    "хижина",
+                    "познание",
+                    "нищий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
-                    "мёрзнуть",
-                    "хижина",
+                    "шут",
                     "познание",
+                    "нищий",
                     "страдать"
                 ],
                 "correctIndex": 3
@@ -5523,20 +5449,20 @@
             {
                 "question": "Что означает немецкое слово «der Narr»?",
                 "choices": [
-                    "познание",
                     "шут",
-                    "страдать",
-                    "хижина"
+                    "познание",
+                    "мёрзнуть",
+                    "нищета"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Erkenntnis»?",
                 "choices": [
-                    "страдать",
-                    "нищий",
+                    "хижина",
+                    "бедный",
                     "познание",
-                    "шут"
+                    "мёрзнуть"
                 ],
                 "correctIndex": 2
             }
@@ -6328,29 +6254,29 @@
             {
                 "question": "Что означает немецкое слово «erkennen»?",
                 "choices": [
+                    "правда",
                     "узнавать",
-                    "раскаяние",
                     "понимать",
-                    "правда"
+                    "раскаяние"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «verstehen»?",
                 "choices": [
-                    "понимать",
                     "раскаяние",
-                    "правда",
-                    "узнавать"
+                    "понимать",
+                    "узнавать",
+                    "правда"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Wahrheit»?",
                 "choices": [
-                    "мудрость",
-                    "узнавать",
-                    "прозрение",
+                    "понимать",
+                    "прощать",
+                    "раскаяние",
                     "правда"
                 ],
                 "correctIndex": 3
@@ -6358,52 +6284,52 @@
             {
                 "question": "Что означает немецкое слово «die Reue»?",
                 "choices": [
-                    "узнавать",
+                    "правда",
                     "раскаяние",
-                    "мудрость",
-                    "виновный"
+                    "виновный",
+                    "прозрение"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Weisheit»?",
                 "choices": [
-                    "понимать",
                     "раскаяние",
-                    "мудрость",
-                    "правда"
+                    "прозрение",
+                    "понимать",
+                    "мудрость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «vergeben»?",
                 "choices": [
                     "узнавать",
                     "прощать",
-                    "понимать",
-                    "раскаяние"
+                    "прозрение",
+                    "правда"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Einsicht»?",
                 "choices": [
+                    "мудрость",
+                    "понимать",
                     "виновный",
-                    "прозрение",
-                    "правда",
-                    "узнавать"
+                    "прозрение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schuldig»?",
                 "choices": [
+                    "прозрение",
                     "прощать",
                     "виновный",
-                    "раскаяние",
-                    "понимать"
+                    "мудрость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -7201,82 +7127,82 @@
             {
                 "question": "Что означает немецкое слово «verzeihen»?",
                 "choices": [
-                    "умирать",
-                    "прощать",
                     "конец",
-                    "смерть"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Tod»?",
-                "choices": [
+                    "умирать",
                     "смерть",
-                    "конец",
-                    "умирать",
                     "прощать"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «sterben»?",
-                "choices": [
-                    "конец",
-                    "скорбь",
-                    "умирать",
-                    "смерть"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Ende»?",
-                "choices": [
-                    "прощать",
-                    "сердце",
-                    "конец",
-                    "вечный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «das Herz»?",
-                "choices": [
-                    "смерть",
-                    "прощать",
-                    "конец",
-                    "сердце"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Trauer»?",
+                "question": "Что означает немецкое слово «der Tod»?",
+                "choices": [
+                    "умирать",
+                    "прощать",
+                    "конец",
+                    "смерть"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «sterben»?",
+                "choices": [
+                    "умирать",
+                    "вечный",
+                    "скорбь",
+                    "прощание"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «das Ende»?",
+                "choices": [
+                    "прощание",
+                    "прощать",
+                    "сердце",
+                    "конец"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «das Herz»?",
                 "choices": [
                     "сердце",
-                    "конец",
-                    "скорбь",
-                    "вечный"
+                    "прощание",
+                    "вечный",
+                    "смерть"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Trauer»?",
+                "choices": [
+                    "скорбь",
+                    "вечный",
+                    "смерть",
+                    "сердце"
+                ],
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Abschied»?",
                 "choices": [
-                    "смерть",
-                    "прощание",
+                    "скорбь",
                     "умирать",
-                    "вечный"
+                    "вечный",
+                    "прощание"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «ewig»?",
                 "choices": [
-                    "вечный",
-                    "прощать",
+                    "конец",
                     "прощание",
-                    "конец"
+                    "сердце",
+                    "вечный"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -7433,6 +7359,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -8325,6 +8281,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -8400,71 +8553,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -8472,7 +8570,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/oswald.html
+++ b/output/journeys/oswald.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-der" data-word="Diener" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Diener</div>
-            </div>
-            <div class="vocab-translation">слуга</div>
-            <div class="vocab-transcription">[дер ДИ-нер]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Gehorsam" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Gehorsam</div>
-            </div>
-            <div class="vocab-translation">послушание</div>
-            <div class="vocab-transcription">[дер ге-ХОР-зам]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Ergebenheit" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Ergebenheit</div>
-            </div>
-            <div class="vocab-translation">преданность</div>
-            <div class="vocab-transcription">[ди ер-ГЕ-бен-хайт]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="dienen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">dienen</div>
-            </div>
-            <div class="vocab-translation">служить</div>
-            <div class="vocab-transcription">[ДИ-нен]</div>
-        </div>
-
-        <div class="vocab-card is-der" data-word="Verwalter" data-article="der">
-            <div class="vocab-header">
-                <span class="article-chip der"><span class="article-icon">♂</span><span>der</span></span>
-                <div class="vocab-word">Verwalter</div>
-            </div>
-            <div class="vocab-translation">управляющий</div>
-            <div class="vocab-transcription">[дер фер-ВАЛЬ-тер]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="ergeben">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">ergeben</div>
-            </div>
-            <div class="vocab-translation">покорный</div>
-            <div class="vocab-transcription">[ер-ГЕ-бен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="unterwürfig">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">unterwürfig</div>
-            </div>
-            <div class="vocab-translation">раболепный</div>
-            <div class="vocab-transcription">[УН-тер-вюр-фиг]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="befolgen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">befolgen</div>
-            </div>
-            <div class="vocab-translation">исполнять</div>
-            <div class="vocab-transcription">[бе-ФОЛЬ-ген]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1928,30 +1854,30 @@
             {
                 "question": "Что означает немецкое слово «der Diener»?",
                 "choices": [
-                    "послушание",
-                    "служить",
                     "преданность",
-                    "слуга"
+                    "слуга",
+                    "послушание",
+                    "служить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Gehorsam»?",
                 "choices": [
                     "слуга",
+                    "служить",
                     "преданность",
-                    "послушание",
-                    "служить"
+                    "послушание"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Ergebenheit»?",
                 "choices": [
-                    "послушание",
-                    "покорный",
+                    "раболепный",
+                    "слуга",
                     "преданность",
-                    "исполнять"
+                    "послушание"
                 ],
                 "correctIndex": 2
             },
@@ -1959,51 +1885,51 @@
                 "question": "Что означает немецкое слово «dienen»?",
                 "choices": [
                     "служить",
+                    "исполнять",
                     "покорный",
-                    "управляющий",
-                    "послушание"
+                    "управляющий"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Verwalter»?",
                 "choices": [
-                    "преданность",
                     "управляющий",
-                    "слуга",
-                    "исполнять"
+                    "раболепный",
+                    "покорный",
+                    "служить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «ergeben»?",
                 "choices": [
                     "послушание",
                     "покорный",
-                    "преданность",
-                    "исполнять"
+                    "исполнять",
+                    "служить"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterwürfig»?",
                 "choices": [
-                    "раболепный",
-                    "исполнять",
+                    "слуга",
                     "управляющий",
-                    "слуга"
+                    "раболепный",
+                    "преданность"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «befolgen»?",
                 "choices": [
                     "преданность",
-                    "послушание",
-                    "покорный",
-                    "исполнять"
+                    "управляющий",
+                    "исполнять",
+                    "послушание"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -2647,52 +2573,52 @@
             {
                 "question": "Что означает немецкое слово «der Bote»?",
                 "choices": [
-                    "передавать",
-                    "гонец",
-                    "поручение",
-                    "спешка"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «der Auftrag»?",
-                "choices": [
-                    "поручение",
                     "гонец",
                     "спешка",
+                    "поручение",
                     "передавать"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Eile»?",
+                "question": "Что означает немецкое слово «der Auftrag»?",
                 "choices": [
+                    "спешка",
+                    "гонец",
                     "передавать",
-                    "поручение",
-                    "послание",
-                    "спешка"
+                    "поручение"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Eile»?",
+                "choices": [
+                    "торопиться",
+                    "спешка",
+                    "гонец",
+                    "передавать"
+                ],
+                "correctIndex": 1
+            },
+            {
                 "question": "Что означает немецкое слово «überbringen»?",
                 "choices": [
-                    "гонец",
-                    "торопиться",
-                    "передавать",
-                    "спешить"
+                    "спешка",
+                    "послание",
+                    "спешить",
+                    "передавать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «hasten»?",
                 "choices": [
+                    "послание",
+                    "гонец",
                     "торопиться",
-                    "спешить",
-                    "передавать",
-                    "послание"
+                    "спешить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Botschaft»?",
@@ -2700,19 +2626,19 @@
                     "поручение",
                     "послание",
                     "гонец",
-                    "торопиться"
+                    "передавать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «eilen»?",
                 "choices": [
-                    "торопиться",
-                    "поручение",
                     "передавать",
-                    "спешить"
+                    "торопиться",
+                    "спешить",
+                    "гонец"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3434,39 +3360,39 @@
             {
                 "question": "Что означает немецкое слово «die Beleidigung»?",
                 "choices": [
-                    "оскорблять",
                     "оскорбление",
+                    "оскорблять",
                     "неуважение",
                     "трусость"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Respektlosigkeit»?",
                 "choices": [
-                    "оскорблять",
-                    "оскорбление",
                     "неуважение",
-                    "трусость"
+                    "оскорбление",
+                    "трусость",
+                    "оскорблять"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
                 "choices": [
-                    "высмеивать",
-                    "пренебрегать",
+                    "оскорблять",
+                    "трусость",
                     "дерзкий",
-                    "трусость"
+                    "неуважение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «beleidigen»?",
                 "choices": [
+                    "дерзкий",
                     "трусливый",
                     "пренебрегать",
-                    "неуважение",
                     "оскорблять"
                 ],
                 "correctIndex": 3
@@ -3474,42 +3400,42 @@
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "оскорблять",
+                    "высмеивать",
                     "дерзкий",
-                    "пренебрегать",
-                    "высмеивать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «frech»?",
-                "choices": [
-                    "дерзкий",
-                    "оскорбление",
-                    "трусость",
-                    "трусливый"
+                    "трусливый",
+                    "трусость"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «missachten»?",
+                "question": "Что означает немецкое слово «frech»?",
                 "choices": [
+                    "трусость",
                     "оскорбление",
                     "пренебрегать",
-                    "оскорблять",
-                    "трусость"
+                    "дерзкий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «missachten»?",
+                "choices": [
+                    "высмеивать",
+                    "оскорбление",
+                    "оскорблять",
+                    "пренебрегать"
+                ],
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «feige»?",
                 "choices": [
-                    "трусость",
+                    "пренебрегать",
+                    "оскорблять",
                     "трусливый",
-                    "неуважение",
-                    "оскорбление"
+                    "высмеивать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4157,72 +4083,72 @@
             {
                 "question": "Что означает немецкое слово «der Spion»?",
                 "choices": [
+                    "шпион",
                     "предательство",
                     "скрытность",
-                    "шпионить",
-                    "шпион"
+                    "шпионить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «der Verrat»?",
                 "choices": [
-                    "шпион",
                     "скрытность",
-                    "шпионить",
-                    "предательство"
+                    "шпион",
+                    "предательство",
+                    "шпионить"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Heimlichkeit»?",
                 "choices": [
-                    "скрытность",
+                    "шпионить",
                     "подслушивать",
-                    "выдавать",
-                    "вынюхивать"
+                    "скрытность",
+                    "выдавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «spionieren»?",
                 "choices": [
+                    "шпион",
                     "шпионить",
-                    "вынюхивать",
-                    "скрытность",
-                    "шпион"
+                    "выдавать",
+                    "предательство"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «lauschen»?",
                 "choices": [
                     "подслушивать",
-                    "выдавать",
-                    "шпионить",
-                    "скрытность"
+                    "шпион",
+                    "вынюхивать",
+                    "выдавать"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «verraten»?",
                 "choices": [
-                    "выдавать",
-                    "предательство",
+                    "подслушивать",
+                    "скрытность",
                     "вынюхивать",
-                    "скрытность"
+                    "выдавать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «schnüffeln»?",
                 "choices": [
-                    "выдавать",
-                    "скрытность",
                     "шпион",
-                    "вынюхивать"
+                    "шпионить",
+                    "вынюхивать",
+                    "выдавать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -4954,82 +4880,82 @@
             {
                 "question": "Что означает немецкое слово «die Intrige»?",
                 "choices": [
-                    "план",
-                    "коварство",
-                    "ковать",
-                    "интрига"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «der Plan»?",
-                "choices": [
-                    "план",
-                    "ковать",
                     "интрига",
+                    "ковать",
+                    "план",
                     "коварство"
                 ],
                 "correctIndex": 0
             },
             {
-                "question": "Что означает немецкое слово «die Hinterlist»?",
+                "question": "Что означает немецкое слово «der Plan»?",
                 "choices": [
-                    "ловушка",
-                    "интрига",
                     "ковать",
-                    "коварство"
+                    "коварство",
+                    "интрига",
+                    "план"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «die Hinterlist»?",
+                "choices": [
+                    "план",
+                    "обманывать",
+                    "коварство",
+                    "хитрый"
+                ],
+                "correctIndex": 2
+            },
+            {
                 "question": "Что означает немецкое слово «schmieden»?",
                 "choices": [
-                    "обманывать",
-                    "интрига",
-                    "коварный",
-                    "ковать"
+                    "хитрый",
+                    "ловушка",
+                    "ковать",
+                    "коварство"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «hintergehen»?",
                 "choices": [
                     "ловушка",
+                    "план",
                     "обманывать",
-                    "интрига",
-                    "хитрый"
+                    "ковать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «tückisch»?",
                 "choices": [
-                    "ковать",
-                    "интрига",
+                    "план",
+                    "хитрый",
                     "коварный",
-                    "ловушка"
+                    "обманывать"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verschlagen»?",
                 "choices": [
-                    "ловушка",
+                    "хитрый",
+                    "ковать",
                     "коварство",
-                    "коварный",
-                    "хитрый"
+                    "ловушка"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Falle»?",
                 "choices": [
-                    "коварный",
-                    "ловушка",
-                    "ковать",
-                    "интрига"
+                    "интрига",
+                    "обманывать",
+                    "коварство",
+                    "ловушка"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -5682,71 +5608,71 @@
                 "question": "Что означает немецкое слово «die Verfolgung»?",
                 "choices": [
                     "преследовать",
-                    "охота",
                     "преследование",
+                    "охота",
                     "гнаться"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Jagd»?",
                 "choices": [
                     "гнаться",
+                    "преследование",
                     "охота",
-                    "преследование",
                     "преследовать"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «verfolgen»?",
-                "choices": [
-                    "выслеживать",
-                    "преследование",
-                    "гнаться",
-                    "преследовать"
-                ],
-                "correctIndex": 3
-            },
-            {
-                "question": "Что означает немецкое слово «jagen»?",
-                "choices": [
-                    "добыча",
-                    "травить",
-                    "гнаться",
-                    "выслеживать"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «aufspüren»?",
+                "question": "Что означает немецкое слово «verfolgen»?",
                 "choices": [
                     "гнаться",
                     "преследовать",
                     "преследование",
-                    "выслеживать"
+                    "добыча"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «jagen»?",
+                "choices": [
+                    "преследование",
+                    "охота",
+                    "травить",
+                    "гнаться"
                 ],
                 "correctIndex": 3
             },
             {
+                "question": "Что означает немецкое слово «aufspüren»?",
+                "choices": [
+                    "выслеживать",
+                    "преследование",
+                    "преследовать",
+                    "охота"
+                ],
+                "correctIndex": 0
+            },
+            {
                 "question": "Что означает немецкое слово «hetzen»?",
                 "choices": [
-                    "преследовать",
-                    "травить",
-                    "преследование",
-                    "выслеживать"
+                    "охота",
+                    "гнаться",
+                    "добыча",
+                    "травить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Beute»?",
                 "choices": [
-                    "преследовать",
-                    "добыча",
+                    "охота",
                     "преследование",
-                    "охота"
+                    "выслеживать",
+                    "добыча"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -6472,12 +6398,12 @@
             {
                 "question": "Что означает немецкое слово «der Tod»?",
                 "choices": [
-                    "падать",
                     "смерть",
-                    "поражение",
-                    "трусость"
+                    "падать",
+                    "трусость",
+                    "поражение"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Feigheit»?",
@@ -6492,62 +6418,62 @@
             {
                 "question": "Что означает немецкое слово «die Niederlage»?",
                 "choices": [
-                    "смерть",
-                    "трусость",
-                    "умолять",
-                    "поражение"
+                    "проигрывать",
+                    "поражение",
+                    "жалкий",
+                    "умолять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «fallen»?",
                 "choices": [
-                    "умолять",
-                    "трусость",
                     "поражение",
-                    "падать"
+                    "падать",
+                    "проигрывать",
+                    "жалкий"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «unterliegen»?",
                 "choices": [
-                    "поражение",
-                    "умолять",
+                    "падать",
                     "проигрывать",
-                    "хныкать"
+                    "поражение",
+                    "жалкий"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «wimmern»?",
                 "choices": [
-                    "хныкать",
                     "проигрывать",
-                    "жалкий",
-                    "трусость"
+                    "хныкать",
+                    "падать",
+                    "поражение"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «betteln»?",
                 "choices": [
-                    "жалкий",
                     "умолять",
-                    "хныкать",
-                    "проигрывать"
+                    "поражение",
+                    "смерть",
+                    "жалкий"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erbärmlich»?",
                 "choices": [
+                    "поражение",
                     "проигрывать",
                     "жалкий",
-                    "смерть",
-                    "трусость"
+                    "смерть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -6688,6 +6614,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7580,6 +7536,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7655,71 +7808,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7727,7 +7825,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;

--- a/output/journeys/regan.html
+++ b/output/journeys/regan.html
@@ -620,81 +620,7 @@
     </div>
 
     <!-- Сітка слів -->
-    <div class="vocabulary-grid">
-
-        <div class="vocab-card is-neutral" data-word="vortäuschen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">vortäuschen</div>
-            </div>
-            <div class="vocab-translation">притворяться</div>
-            <div class="vocab-transcription">[ФОР-той-шен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="übertreffen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">übertreffen</div>
-            </div>
-            <div class="vocab-translation">превосходить</div>
-            <div class="vocab-transcription">[ю-бер-ТРЕ-фен]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="wetteifern">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">wetteifern</div>
-            </div>
-            <div class="vocab-translation">состязаться</div>
-            <div class="vocab-transcription">[ВЕТ-ай-ферн]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Falschheit" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Falschheit</div>
-            </div>
-            <div class="vocab-translation">фальшь</div>
-            <div class="vocab-transcription">[ди ФАЛЬШ-хайт]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="vorspielen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">vorspielen</div>
-            </div>
-            <div class="vocab-translation">разыгрывать</div>
-            <div class="vocab-transcription">[ФОР-шпи-лен]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="List" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">List</div>
-            </div>
-            <div class="vocab-translation">хитрость</div>
-            <div class="vocab-transcription">[ди ЛИСТ]</div>
-        </div>
-
-        <div class="vocab-card is-neutral" data-word="erschleichen">
-            <div class="vocab-header">
-                <span class="word-type-chip">лексика без артикля</span>
-                <div class="vocab-word">erschleichen</div>
-            </div>
-            <div class="vocab-translation">выманивать</div>
-            <div class="vocab-transcription">[ер-ШЛАЙ-хен]</div>
-        </div>
-
-        <div class="vocab-card is-die" data-word="Habgier" data-article="die">
-            <div class="vocab-header">
-                <span class="article-chip die"><span class="article-icon">♀</span><span>die</span></span>
-                <div class="vocab-word">Habgier</div>
-            </div>
-            <div class="vocab-translation">алчность</div>
-            <div class="vocab-transcription">[ди ХАБ-гир]</div>
-        </div>
-
-    </div>
+    <div class="vocabulary-grid"></div>
 </section>
 
 
@@ -1941,27 +1867,27 @@
                 "question": "Что означает немецкое слово «übertreffen»?",
                 "choices": [
                     "притворяться",
+                    "фальшь",
                     "состязаться",
-                    "превосходить",
-                    "фальшь"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «wetteifern»?",
-                "choices": [
-                    "притворяться",
-                    "хитрость",
-                    "разыгрывать",
-                    "состязаться"
+                    "превосходить"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Falschheit»?",
+                "question": "Что означает немецкое слово «wetteifern»?",
                 "choices": [
                     "состязаться",
-                    "разыгрывать",
+                    "выманивать",
+                    "фальшь",
+                    "превосходить"
+                ],
+                "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «die Falschheit»?",
+                "choices": [
+                    "притворяться",
+                    "превосходить",
                     "фальшь",
                     "выманивать"
                 ],
@@ -1970,42 +1896,42 @@
             {
                 "question": "Что означает немецкое слово «vorspielen»?",
                 "choices": [
-                    "хитрость",
+                    "состязаться",
                     "превосходить",
                     "разыгрывать",
-                    "алчность"
+                    "фальшь"
                 ],
                 "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die List»?",
                 "choices": [
-                    "фальшь",
                     "хитрость",
-                    "превосходить",
-                    "разыгрывать"
+                    "выманивать",
+                    "разыгрывать",
+                    "алчность"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erschleichen»?",
                 "choices": [
-                    "притворяться",
-                    "превосходить",
-                    "выманивать",
-                    "разыгрывать"
+                    "фальшь",
+                    "состязаться",
+                    "алчность",
+                    "выманивать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Habgier»?",
                 "choices": [
-                    "разыгрывать",
-                    "выманивать",
-                    "алчность",
-                    "превосходить"
+                    "хитрость",
+                    "состязаться",
+                    "превосходить",
+                    "алчность"
                 ],
-                "correctIndex": 2
+                "correctIndex": 3
             }
         ],
         "quizAttempts": {},
@@ -2649,72 +2575,72 @@
             {
                 "question": "Что означает немецкое слово «das Bündnis»?",
                 "choices": [
+                    "заговорить",
                     "союз",
                     "планировать",
-                    "заговорить",
                     "делить"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «teilen»?",
                 "choices": [
+                    "заговорить",
+                    "союз",
                     "делить",
-                    "планировать",
-                    "союз",
-                    "заговорить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «planen»?",
-                "choices": [
-                    "планировать",
-                    "союз",
-                    "заговорить",
-                    "делить"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «verschwören»?",
-                "choices": [
-                    "договариваться",
-                    "союз",
-                    "заговорить",
                     "планировать"
                 ],
                 "correctIndex": 2
             },
             {
+                "question": "Что означает немецкое слово «planen»?",
+                "choices": [
+                    "договариваться",
+                    "стратегия",
+                    "заговорить",
+                    "планировать"
+                ],
+                "correctIndex": 3
+            },
+            {
+                "question": "Что означает немецкое слово «verschwören»?",
+                "choices": [
+                    "сговор",
+                    "стратегия",
+                    "делить",
+                    "заговорить"
+                ],
+                "correctIndex": 3
+            },
+            {
                 "question": "Что означает немецкое слово «die Absprache»?",
                 "choices": [
-                    "заговорить",
                     "сговор",
-                    "делить",
-                    "союз"
+                    "заговорить",
+                    "договариваться",
+                    "делить"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «vereinbaren»?",
                 "choices": [
                     "планировать",
-                    "делить",
                     "договариваться",
-                    "союз"
+                    "союз",
+                    "заговорить"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Strategie»?",
                 "choices": [
                     "планировать",
-                    "сговор",
-                    "договариваться",
-                    "стратегия"
+                    "стратегия",
+                    "делить",
+                    "договариваться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -3482,82 +3408,82 @@
             {
                 "question": "Что означает немецкое слово «foltern»?",
                 "choices": [
-                    "злоба",
                     "пытать",
-                    "насмехаться",
-                    "унижать"
+                    "унижать",
+                    "злоба",
+                    "насмехаться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «erniedrigen»?",
                 "choices": [
-                    "унижать",
                     "насмехаться",
+                    "пытать",
                     "злоба",
-                    "пытать"
+                    "унижать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «verhöhnen»?",
                 "choices": [
-                    "насмехаться",
-                    "отвергать",
+                    "пытать",
                     "жестокость",
-                    "жёсткость"
+                    "насмехаться",
+                    "унижать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «die Bosheit»?",
                 "choices": [
-                    "насмехаться",
-                    "жестоко обращаться",
+                    "унижать",
                     "злоба",
-                    "пытать"
+                    "пытать",
+                    "жёсткость"
                 ],
-                "correctIndex": 2
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «misshandeln»?",
                 "choices": [
-                    "насмехаться",
-                    "отвергать",
                     "жестоко обращаться",
-                    "жестокость"
+                    "жёсткость",
+                    "унижать",
+                    "отвергать"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «die Härte»?",
                 "choices": [
-                    "пытать",
                     "жёсткость",
-                    "отвергать",
-                    "унижать"
+                    "насмехаться",
+                    "злоба",
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «abweisen»?",
                 "choices": [
-                    "пытать",
-                    "отвергать",
-                    "насмехаться",
-                    "злоба"
+                    "жёсткость",
+                    "унижать",
+                    "жестоко обращаться",
+                    "отвергать"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Grausamkeit»?",
                 "choices": [
-                    "жёсткость",
-                    "пытать",
-                    "унижать",
-                    "жестокость"
+                    "жестокость",
+                    "насмехаться",
+                    "отвергать",
+                    "жестоко обращаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -4306,82 +4232,82 @@
             {
                 "question": "Что означает немецкое слово «blenden»?",
                 "choices": [
-                    "выкалывать",
-                    "садизм",
                     "наслаждаться",
-                    "ослеплять"
+                    "ослеплять",
+                    "садизм",
+                    "выкалывать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «der Sadismus»?",
                 "choices": [
-                    "выкалывать",
+                    "садизм",
                     "ослеплять",
-                    "наслаждаться",
-                    "садизм"
+                    "выкалывать",
+                    "наслаждаться"
                 ],
-                "correctIndex": 3
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «genießen»?",
                 "choices": [
-                    "наслаждаться",
                     "беспощадный",
-                    "ослеплять",
-                    "садизм"
+                    "брутальность",
+                    "наслаждаться",
+                    "растаптывать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «ausstechen»?",
                 "choices": [
-                    "наслаждаться",
                     "растаптывать",
-                    "выкалывать",
-                    "беспощадный"
-                ],
-                "correctIndex": 2
-            },
-            {
-                "question": "Что означает немецкое слово «die Folter»?",
-                "choices": [
                     "пытка",
-                    "брутальность",
-                    "выкалывать",
-                    "садизм"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «erbarmungslos»?",
-                "choices": [
-                    "пытка",
-                    "выкалывать",
-                    "брутальность",
-                    "беспощадный"
+                    "беспощадный",
+                    "выкалывать"
                 ],
                 "correctIndex": 3
             },
             {
-                "question": "Что означает немецкое слово «die Brutalität»?",
+                "question": "Что означает немецкое слово «die Folter»?",
                 "choices": [
-                    "растаптывать",
-                    "пытка",
                     "брутальность",
-                    "ослеплять"
+                    "ослеплять",
+                    "пытка",
+                    "садизм"
                 ],
                 "correctIndex": 2
             },
             {
-                "question": "Что означает немецкое слово «zertreten»?",
+                "question": "Что означает немецкое слово «erbarmungslos»?",
                 "choices": [
-                    "растаптывать",
+                    "брутальность",
+                    "ослеплять",
                     "беспощадный",
-                    "наслаждаться",
-                    "садизм"
+                    "выкалывать"
+                ],
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Brutalität»?",
+                "choices": [
+                    "брутальность",
+                    "ослеплять",
+                    "пытка",
+                    "наслаждаться"
                 ],
                 "correctIndex": 0
+            },
+            {
+                "question": "Что означает немецкое слово «zertreten»?",
+                "choices": [
+                    "ослеплять",
+                    "растаптывать",
+                    "выкалывать",
+                    "наслаждаться"
+                ],
+                "correctIndex": 1
             }
         ],
         "quizAttempts": {},
@@ -5036,69 +4962,69 @@
                 "question": "Что означает немецкое слово «die Witwe»?",
                 "choices": [
                     "вдова",
-                    "вожделеть",
                     "вожделение",
-                    "соблазнять"
+                    "соблазнять",
+                    "вожделеть"
                 ],
                 "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «begehren»?",
                 "choices": [
-                    "соблазнять",
                     "вдова",
                     "вожделение",
-                    "вожделеть"
+                    "вожделеть",
+                    "соблазнять"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verführen»?",
                 "choices": [
+                    "вдова",
                     "соблазнять",
-                    "похоть",
                     "добиваться",
-                    "заманивать"
+                    "вожделеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «die Begierde»?",
                 "choices": [
-                    "вожделение",
                     "похоть",
+                    "вожделение",
                     "заманивать",
-                    "вдова"
+                    "вожделеть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «locken»?",
                 "choices": [
-                    "заманивать",
-                    "вожделение",
+                    "вожделеть",
                     "добиваться",
-                    "вдова"
+                    "соблазнять",
+                    "заманивать"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «die Lust»?",
                 "choices": [
-                    "похоть",
                     "соблазнять",
-                    "вдова",
-                    "добиваться"
+                    "вожделение",
+                    "заманивать",
+                    "похоть"
                 ],
-                "correctIndex": 0
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «werben»?",
                 "choices": [
                     "добиваться",
-                    "соблазнять",
                     "похоть",
-                    "вожделение"
+                    "заманивать",
+                    "вожделеть"
                 ],
                 "correctIndex": 0
             }
@@ -5743,72 +5669,72 @@
             {
                 "question": "Что означает немецкое слово «wettkämpfen»?",
                 "choices": [
-                    "ненавидеть",
+                    "угрожать",
                     "соревноваться",
-                    "угрожать",
-                    "соперничество"
-                ],
-                "correctIndex": 1
-            },
-            {
-                "question": "Что означает немецкое слово «hassen»?",
-                "choices": [
-                    "ненавидеть",
-                    "соперничество",
-                    "угрожать",
-                    "соревноваться"
-                ],
-                "correctIndex": 0
-            },
-            {
-                "question": "Что означает немецкое слово «bedrohen»?",
-                "choices": [
-                    "подозревать",
-                    "угрожать",
                     "соперничество",
                     "ненавидеть"
                 ],
                 "correctIndex": 1
             },
             {
-                "question": "Что означает немецкое слово «die Rivalität»?",
+                "question": "Что означает немецкое слово «hassen»?",
                 "choices": [
+                    "соревноваться",
+                    "ненавидеть",
+                    "соперничество",
+                    "угрожать"
+                ],
+                "correctIndex": 1
+            },
+            {
+                "question": "Что означает немецкое слово «bedrohen»?",
+                "choices": [
+                    "бороться",
                     "подозревать",
-                    "не доверять",
                     "угрожать",
                     "соперничество"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
+            },
+            {
+                "question": "Что означает немецкое слово «die Rivalität»?",
+                "choices": [
+                    "соревноваться",
+                    "угрожать",
+                    "соперничество",
+                    "ненавидеть"
+                ],
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «bekämpfen»?",
                 "choices": [
                     "ненавидеть",
-                    "бороться",
-                    "угрожать",
-                    "соперничество"
+                    "соперничество",
+                    "соревноваться",
+                    "бороться"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «misstrauen»?",
                 "choices": [
                     "ненавидеть",
-                    "не доверять",
-                    "угрожать",
-                    "соперничество"
+                    "соревноваться",
+                    "бороться",
+                    "не доверять"
                 ],
-                "correctIndex": 1
+                "correctIndex": 3
             },
             {
                 "question": "Что означает немецкое слово «argwöhnen»?",
                 "choices": [
-                    "не доверять",
                     "подозревать",
-                    "бороться",
-                    "соперничество"
+                    "угрожать",
+                    "соревноваться",
+                    "ненавидеть"
                 ],
-                "correctIndex": 1
+                "correctIndex": 0
             }
         ],
         "quizAttempts": {},
@@ -6536,17 +6462,17 @@
                 "choices": [
                     "мучение",
                     "отравленный",
-                    "издыхать",
-                    "страдать"
+                    "страдать",
+                    "издыхать"
                 ],
                 "correctIndex": 1
             },
             {
                 "question": "Что означает немецкое слово «leiden»?",
                 "choices": [
+                    "отравленный",
                     "мучение",
                     "издыхать",
-                    "отравленный",
                     "страдать"
                 ],
                 "correctIndex": 3
@@ -6554,9 +6480,9 @@
             {
                 "question": "Что означает немецкое слово «verenden»?",
                 "choices": [
-                    "отравленный",
                     "проклятый",
-                    "рок",
+                    "отравленный",
+                    "проклинать",
                     "издыхать"
                 ],
                 "correctIndex": 3
@@ -6564,19 +6490,19 @@
             {
                 "question": "Что означает немецкое слово «die Qual»?",
                 "choices": [
-                    "рок",
                     "отравленный",
-                    "расплачиваться",
-                    "мучение"
+                    "страдать",
+                    "мучение",
+                    "проклинать"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             },
             {
                 "question": "Что означает немецкое слово «verwünschen»?",
                 "choices": [
-                    "отравленный",
                     "расплачиваться",
-                    "мучение",
+                    "рок",
+                    "отравленный",
                     "проклинать"
                 ],
                 "correctIndex": 3
@@ -6584,20 +6510,20 @@
             {
                 "question": "Что означает немецкое слово «das Verhängnis»?",
                 "choices": [
-                    "мучение",
-                    "издыхать",
                     "рок",
-                    "проклинать"
+                    "проклинать",
+                    "страдать",
+                    "проклятый"
                 ],
-                "correctIndex": 2
+                "correctIndex": 0
             },
             {
                 "question": "Что означает немецкое слово «büßen»?",
                 "choices": [
                     "расплачиваться",
-                    "мучение",
-                    "страдать",
-                    "рок"
+                    "проклинать",
+                    "рок",
+                    "проклятый"
                 ],
                 "correctIndex": 0
             },
@@ -6605,11 +6531,11 @@
                 "question": "Что означает немецкое слово «verflucht»?",
                 "choices": [
                     "рок",
-                    "проклинать",
-                    "мучение",
-                    "проклятый"
+                    "расплачиваться",
+                    "проклятый",
+                    "мучение"
                 ],
-                "correctIndex": 3
+                "correctIndex": 2
             }
         ],
         "quizAttempts": {},
@@ -6750,6 +6676,36 @@ const globalOptionPools = {
     german: collectGlobalWordValues('german'),
     russian: collectGlobalWordValues('russian'),
 };
+
+const ARTICLE_META = {
+    der: {
+        icon: '♂',
+        cardClass: 'is-der',
+        chipClass: 'der',
+    },
+    die: {
+        icon: '♀',
+        cardClass: 'is-die',
+        chipClass: 'die',
+    },
+    das: {
+        icon: '⚪',
+        cardClass: 'is-das',
+        chipClass: 'das',
+    },
+};
+
+const NEUTRAL_LABEL_FALLBACK = 'лексика без артикля';
+const NEUTRAL_LABEL_KEYS = [
+    'part_of_speech',
+    'partOfSpeech',
+    'pos',
+    'type',
+    'wordType',
+    'word_type',
+    'category',
+    'wordCategory',
+];
 
 const studyQueueState = {
     queue: [],
@@ -7642,6 +7598,203 @@ function setActiveExerciseSections(phaseKey) {
     refreshActiveExerciseContentHeight();
 }
 
+function extractArticleData(wordValue) {
+    const raw = typeof wordValue === 'string' ? wordValue.trim() : '';
+    if (!raw) {
+        return { baseWord: '', article: null };
+    }
+
+    const match = raw.match(/^(der|die|das)\s+/i);
+    if (!match) {
+        return { baseWord: raw, article: null };
+    }
+
+    const article = match[1].toLowerCase();
+    const baseWord = raw.slice(match[0].length).trim() || raw;
+    return { baseWord, article };
+}
+
+function resolveNeutralLabel(item) {
+    if (!item || typeof item !== 'object') {
+        return NEUTRAL_LABEL_FALLBACK;
+    }
+
+    for (const key of NEUTRAL_LABEL_KEYS) {
+        const value = item[key];
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (trimmed) {
+                return trimmed;
+            }
+        }
+    }
+
+    return NEUTRAL_LABEL_FALLBACK;
+}
+
+function createNeutralChip(label) {
+    const chip = document.createElement('span');
+    chip.className = 'word-type-chip';
+    chip.textContent = label || NEUTRAL_LABEL_FALLBACK;
+    return chip;
+}
+
+function createArticleChip(article) {
+    const chip = document.createElement('span');
+    const meta = article ? ARTICLE_META[article] : null;
+
+    if (!meta) {
+        return createNeutralChip(NEUTRAL_LABEL_FALLBACK);
+    }
+
+    chip.className = `article-chip ${meta.chipClass}`;
+    const icon = document.createElement('span');
+    icon.className = 'article-icon';
+    icon.textContent = meta.icon;
+    const label = document.createElement('span');
+    label.textContent = article;
+    chip.append(icon, label);
+    return chip;
+}
+
+function createStudyButtonForWord(item, phaseKey) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn-study';
+    button.textContent = 'Изучить';
+
+    const safe = value => {
+        if (typeof value === 'string') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    button.dataset.word = safe(item && item.word);
+    button.dataset.translation = safe(item && item.translation);
+    button.dataset.transcription = safe(item && item.transcription);
+    button.dataset.russianHint = safe(item && item.russian_hint);
+    button.dataset.sentence = safe(item && item.sentence);
+    button.dataset.sentenceTranslation = safe(item && item.sentenceTranslation);
+    const resolvedCharacterId = typeof characterId === 'string'
+        ? characterId
+        : (characterId === null || characterId === undefined ? '' : String(characterId));
+    button.dataset.characterId = safe(resolvedCharacterId);
+    button.dataset.phaseKey = safe(phaseKey || '');
+    button.dataset.emoji = safe((item && (item.visual_hint || item.emoji)) || '📝');
+
+    return button;
+}
+
+function setupStudyButtonForCard(studyBtn, item) {
+    if (!studyBtn) {
+        return;
+    }
+
+    studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
+    studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
+    studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
+    studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
+
+    const initialState = isWordInStudyQueue({
+        word: item && item.word,
+        characterId: characterId,
+    });
+    applyStudyButtonState(studyBtn, initialState);
+
+    studyBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const payload = buildStudyPayloadFromButton(this, item);
+        const toggled = toggleStudyWord(payload);
+
+        if (toggled === null) {
+            alert('Не удалось обновить список изучения');
+            applyStudyButtonState(this, isWordInStudyQueue(payload));
+            return;
+        }
+
+        if (navigator.vibrate && isTouchDevice) {
+            navigator.vibrate(20);
+        }
+    });
+}
+
+function buildVocabularyCardElement(item, phaseKey) {
+    if (!item || typeof item !== 'object') {
+        return null;
+    }
+
+    const { baseWord, article } = extractArticleData(item && item.word);
+    const card = document.createElement('div');
+    card.classList.add('vocab-card');
+
+    const meta = article ? ARTICLE_META[article] : null;
+    if (meta) {
+        card.classList.add(meta.cardClass);
+        card.dataset.article = article;
+    } else {
+        card.classList.add('is-neutral');
+    }
+
+    const rawWord = item && typeof item.word === 'string' ? item.word.trim() : '';
+    const cardWord = baseWord || rawWord;
+    if (cardWord) {
+        card.dataset.word = cardWord;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'vocab-header';
+
+    const badge = meta
+        ? createArticleChip(article)
+        : createNeutralChip(resolveNeutralLabel(item));
+    header.appendChild(badge);
+
+    const wordElement = document.createElement('div');
+    wordElement.className = 'vocab-word';
+    wordElement.textContent = cardWord || '';
+    header.appendChild(wordElement);
+    card.appendChild(header);
+
+    const translationElement = document.createElement('div');
+    translationElement.className = 'vocab-translation';
+    translationElement.textContent = item && typeof item.translation === 'string'
+        ? item.translation
+        : '';
+    card.appendChild(translationElement);
+
+    const hintValue = item && typeof item.russian_hint === 'string'
+        ? item.russian_hint.trim()
+        : '';
+    if (hintValue) {
+        const hintElement = document.createElement('div');
+        hintElement.className = 'word-hint';
+        hintElement.textContent = `(${hintValue})`;
+        card.appendChild(hintElement);
+    }
+
+    const transcriptionValue = item && typeof item.transcription === 'string'
+        ? item.transcription.trim()
+        : '';
+    if (transcriptionValue) {
+        const transcriptionElement = document.createElement('div');
+        transcriptionElement.className = 'vocab-transcription';
+        transcriptionElement.textContent = transcriptionValue;
+        card.appendChild(transcriptionElement);
+    }
+
+    const studyBtn = createStudyButtonForWord(item, phaseKey);
+    card.appendChild(studyBtn);
+    setupStudyButtonForCard(studyBtn, item);
+
+    return card;
+}
+
 function displayVocabulary(phaseKey) {
     // Prevent multiple rapid transitions
     if (isTransitioning) return;
@@ -7717,71 +7870,16 @@ function displayVocabulary(phaseKey) {
 
     grid.innerHTML = '';
 
-    phase.words.forEach((item, index) => {
+    const words = Array.isArray(phase.words) ? phase.words : [];
+
+    words.forEach((item, index) => {
         setTimeout(() => {
-            const card = document.createElement('div');
-            card.className = 'word-card';
-            card.style.animationDelay = `${index * 0.1}s`;
-
-            const hintValue = typeof item.russian_hint === 'string' ? item.russian_hint.trim() : '';
-            const hintMarkup = hintValue
-                ? `<div class="word-hint">(${hintValue})</div>`
-                : '';
-
-            // Простая карточка словаря
-            card.innerHTML = `
-                <div class="word-meta">
-                    <div class="word-german">${item.word}</div>
-                    <div class="word-translation">${item.translation}</div>
-                    ${hintMarkup}
-                    <div class="word-transcription">${item.transcription}</div>
-                </div>
-                <button class="btn-study" type="button"
-                    data-word="${item.word || ''}"
-                    data-translation="${item.translation || ''}"
-                    data-transcription="${item.transcription || ''}"
-                    data-russian-hint="${hintValue}"
-                    data-sentence="${item.sentence || ''}"
-                    data-sentence-translation="${item.sentenceTranslation || ''}"
-                    data-character-id="${characterId || ''}"
-                    data-phase-key="${phaseKey || ''}"
-                    data-emoji="${item.visual_hint || '📝'}"
-                >Изучить</button>
-            `;
-
-            // Добавляем обработчик для кнопки
-            const studyBtn = card.querySelector('.btn-study');
-            if (studyBtn) {
-                studyBtn.dataset.defaultLabel = studyBtn.dataset.defaultLabel || 'Изучить';
-                studyBtn.dataset.activeLabel = studyBtn.dataset.activeLabel || 'В списке';
-                studyBtn.dataset.inactiveTitle = studyBtn.dataset.inactiveTitle || 'Добавить слово в список изучения';
-                studyBtn.dataset.activeTitle = studyBtn.dataset.activeTitle || 'Удалить слово из списка изучения';
-
-                const initialState = isWordInStudyQueue({
-                    word: item.word,
-                    characterId: characterId,
-                });
-                applyStudyButtonState(studyBtn, initialState);
-
-                studyBtn.addEventListener('click', function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-
-                    const payload = buildStudyPayloadFromButton(this, item);
-                    const toggled = toggleStudyWord(payload);
-
-                    if (toggled === null) {
-                        alert('Не удалось обновить список изучения');
-                        applyStudyButtonState(this, isWordInStudyQueue(payload));
-                        return;
-                    }
-
-                    if (navigator.vibrate && isTouchDevice) {
-                        navigator.vibrate(20);
-                    }
-                });
+            const card = buildVocabularyCardElement(item, phaseKey);
+            if (!card) {
+                return;
             }
 
+            card.style.animationDelay = `${index * 0.1}s`;
             grid.appendChild(card);
         }, index * 50);
     });
@@ -7789,7 +7887,7 @@ function displayVocabulary(phaseKey) {
     // Ensure UI reflects current queue after rendering
     setTimeout(() => {
         updateAllStudyButtons();
-    }, phase.words.length * 50 + 20);
+    }, words.length * 50 + 20);
 
     // Update progress bar
     const progress = ((currentPhaseIndex + 1) / phaseKeys.length) * 100;


### PR DESCRIPTION
## Summary
- refactor the journey runtime vocabulary renderer to build modern `vocab-card` markup with article chips, neutral badges, and study button wiring
- trim the mnemonic vocabulary generator to output only the section header/legend and an empty vocabulary grid for client-side population
- regenerate the journey pages and bundled runtime script so the static output matches the new client rendering flow

## Testing
- python -m compileall generators/mnemonics_gen.py
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68d92b7f1e908320a5ebc6cbeef831ad