### PR TITLE
Restore phase navigation buttons in vocabulary section

### DIFF
--- a/generators/mnemonics_gen.py
+++ b/generators/mnemonics_gen.py
@@ -549,6 +549,11 @@ class MnemonicsGenerator:
 
     <!-- Сітка слів -->
     <div class="vocabulary-grid"></div>
+
+    <div class="phase-navigation">
+        <button class="change-phase-btn prev-btn" type="button">← Предыдущая фаза</button>
+        <button class="change-phase-btn next-btn" type="button">Следующая фаза →</button>
+    </div>
 </section>
 """
         return html


### PR DESCRIPTION
## Summary
- render the phase navigation buttons beneath the mnemonic vocabulary grid so existing controls work again

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68d938dfb3f88320afed664e167895bf